### PR TITLE
feat: add trace-backed donor modeling foundation

### DIFF
--- a/cmd/pcileechgen/build.go
+++ b/cmd/pcileechgen/build.go
@@ -3,9 +3,13 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/sercanarga/pcileechgen/internal/board"
 	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
 	"github.com/sercanarga/pcileechgen/internal/firmware"
 	"github.com/sercanarga/pcileechgen/internal/pci"
 	"github.com/sercanarga/pcileechgen/internal/vivado"
@@ -25,6 +29,7 @@ type buildFlags struct {
 	fromJSON   string
 	stockBar   bool
 	force      bool
+	traces     []string
 }
 
 var buildOpts buildFlags
@@ -55,6 +60,10 @@ func runBuild(cmd *cobra.Command, args []string) error {
 
 	ctx, err := loadDonorContext()
 	if err != nil {
+		return err
+	}
+
+	if err := applyBuildTraceSpecs(ctx, buildOpts.traces); err != nil {
 		return err
 	}
 
@@ -119,6 +128,75 @@ func loadDonorContext() (*donor.DeviceContext, error) {
 	return ctx, nil
 }
 
+func parseBuildTraceSpec(spec string) (int, string, error) {
+	barText, path, ok := strings.Cut(spec, "=")
+	if !ok || barText == "" || path == "" {
+		return 0, "", fmt.Errorf("invalid trace spec %q (want BAR=path, e.g. 2=trace.log)", spec)
+	}
+	bar, err := strconv.Atoi(barText)
+	if err != nil || bar < 0 || bar > 5 {
+		return 0, "", fmt.Errorf("invalid trace BAR %q in %q", barText, spec)
+	}
+	return bar, path, nil
+}
+
+func applyBuildTraceSpecs(ctx *donor.DeviceContext, specs []string) error {
+	if len(specs) == 0 {
+		return nil
+	}
+	if ctx.MMIOTraces == nil {
+		ctx.MMIOTraces = make(map[int]*mmio.TraceResult)
+	}
+	for _, spec := range specs {
+		bar, path, err := parseBuildTraceSpec(spec)
+		if err != nil {
+			return err
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("open BAR%d trace %q: %w", bar, path, err)
+		}
+		barSize := buildTraceBARSize(ctx, bar)
+		barBase := buildTraceBARBase(ctx, bar)
+		trace, parseErr := mmio.ParseTraceReader(f, mmio.TraceImportOptions{
+			BDF:      ctx.Device.BDF.String(),
+			BARIndex: bar,
+			BARSize:  barSize,
+			BARBase:  barBase,
+		})
+		closeErr := f.Close()
+		if parseErr != nil {
+			return fmt.Errorf("parse BAR%d trace %q: %w", bar, path, parseErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close BAR%d trace %q: %w", bar, path, closeErr)
+		}
+		ctx.MMIOTraces[bar] = trace
+	}
+	return nil
+}
+
+func buildTraceBARSize(ctx *donor.DeviceContext, barIndex int) int {
+	for _, bar := range ctx.BARs {
+		if bar.Index == barIndex && bar.Size > 0 {
+			return int(bar.Size)
+		}
+	}
+	if data := ctx.BARContents[barIndex]; len(data) > 0 {
+		return len(data)
+	}
+	return 4096
+}
+
+func buildTraceBARBase(ctx *donor.DeviceContext, barIndex int) uint64 {
+	for _, bar := range ctx.BARs {
+		if bar.Index == barIndex {
+			return bar.Address
+		}
+	}
+	return 0
+}
+
 func printBuildSummary(ctx *donor.DeviceContext, b *board.Board) {
 	slog.Info("build target",
 		"board", b.Name,
@@ -157,6 +235,7 @@ func init() {
 	buildCmd.Flags().StringVar(&buildOpts.libDir, "lib-dir", "lib/pcileech-fpga", "path to pcileech-fpga library")
 	buildCmd.Flags().BoolVar(&buildOpts.stockBar, "stock-bar", false, "use stock bar controller (diagnostic: skip custom SV modules)")
 	buildCmd.Flags().BoolVar(&buildOpts.force, "force", false, "ignore donor BAR > board BRAM check")
+	buildCmd.Flags().StringArrayVar(&buildOpts.traces, "trace", nil, "import MMIO trace into build context as BAR=path (repeatable, e.g. --trace 2=trace.log)")
 
 	_ = buildCmd.MarkFlagRequired("board")
 

--- a/cmd/pcileechgen/build_trace_test.go
+++ b/cmd/pcileechgen/build_trace_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func TestParseBuildTraceSpec(t *testing.T) {
+	bar, path, err := parseBuildTraceSpec("2=/tmp/trace.log")
+	if err != nil {
+		t.Fatalf("parseBuildTraceSpec failed: %v", err)
+	}
+	if bar != 2 || path != "/tmp/trace.log" {
+		t.Fatalf("parseBuildTraceSpec = (%d, %q), want (2, /tmp/trace.log)", bar, path)
+	}
+}
+
+func TestApplyBuildTraceSpecs_AddsTraceToContext(t *testing.T) {
+	tmpDir := t.TempDir()
+	tracePath := filepath.Join(tmpDir, "bar2.trace")
+	if err := os.WriteFile(tracePath, []byte("R 4 0.001 0xfebf001c 0x00000000\nW 4 0.002 0xfebf0024 0x001f001f\n"), 0644); err != nil {
+		t.Fatalf("write trace fixture: %v", err)
+	}
+	ctx := &donor.DeviceContext{
+		Device: pci.PCIDevice{BDF: pci.BDF{Domain: 0, Bus: 3, Device: 0, Function: 0}},
+		BARs:   []pci.BAR{{Index: 2, Type: pci.BARTypeMem32, Address: 0xfebf0000, Size: 8192}},
+	}
+
+	if err := applyBuildTraceSpecs(ctx, []string{"2=" + tracePath}); err != nil {
+		t.Fatalf("applyBuildTraceSpecs failed: %v", err)
+	}
+
+	trace := ctx.MMIOTraces[2]
+	if trace == nil {
+		t.Fatal("BAR2 trace missing from context")
+	}
+	if trace.BDF != "0000:03:00.0" || trace.BARIndex != 2 || trace.BARSize != 8192 {
+		t.Fatalf("trace metadata mismatch: %#v", trace)
+	}
+	if len(trace.Records) != 2 || trace.Records[0].Offset != 0x1C || trace.Records[1].Offset != 0x24 {
+		t.Fatalf("trace records mismatch: %#v", trace.Records)
+	}
+}
+
+func TestApplyBuildTraceSpecs_UsesBARBase(t *testing.T) {
+	tmpDir := t.TempDir()
+	tracePath := filepath.Join(tmpDir, "bar2.trace")
+	if err := os.WriteFile(tracePath, []byte("W 4 0.001 0xfebf1008 0x00000007\n"), 0644); err != nil {
+		t.Fatalf("write trace fixture: %v", err)
+	}
+	ctx := &donor.DeviceContext{
+		Device: pci.PCIDevice{BDF: pci.BDF{Domain: 0, Bus: 3, Device: 0, Function: 0}},
+		BARs:   []pci.BAR{{Index: 2, Type: pci.BARTypeMem32, Address: 0xfebf0000, Size: 8192}},
+	}
+
+	if err := applyBuildTraceSpecs(ctx, []string{"2=" + tracePath}); err != nil {
+		t.Fatalf("applyBuildTraceSpecs failed: %v", err)
+	}
+	if got := ctx.MMIOTraces[2].Records[0].Offset; got != 0x1008 {
+		t.Fatalf("trace offset = 0x%X, want 0x1008", got)
+	}
+}

--- a/cmd/pcileechgen/trace.go
+++ b/cmd/pcileechgen/trace.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+	"github.com/spf13/cobra"
+)
+
+var traceImportOpts struct {
+	input   string
+	output  string
+	bdf     string
+	bar     int
+	barSize int
+	barBase uint64
+}
+
+var traceCmd = &cobra.Command{
+	Use:   "trace",
+	Short: "Import and summarize MMIO traces",
+}
+
+var traceImportCmd = &cobra.Command{
+	Use:   "import",
+	Short: "Import an mmiotrace log and write bar_model_report.json",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runTraceImport(traceImportOpts.input, traceImportOpts.output, traceImportOpts.bdf, traceImportOpts.bar, traceImportOpts.barSize, traceImportOpts.barBase)
+	},
+}
+
+type traceImportReport struct {
+	Reports []*mmio.TraceReport `json:"reports"`
+}
+
+func runTraceImport(inputPath, outputPath, bdf string, barIndex, barSize int, barBase uint64) error {
+	f, err := os.Open(inputPath)
+	if err != nil {
+		return fmt.Errorf("open trace input: %w", err)
+	}
+	defer f.Close()
+
+	trace, err := mmio.ParseTraceReader(f, mmio.TraceImportOptions{
+		BDF:      bdf,
+		BARIndex: barIndex,
+		BARSize:  barSize,
+		BARBase:  barBase,
+	})
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(traceImportReport{Reports: []*mmio.TraceReport{mmio.BuildReport(trace)}}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal trace report: %w", err)
+	}
+
+	if dir := filepath.Dir(outputPath); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("create output directory: %w", err)
+		}
+	}
+	if err := os.WriteFile(outputPath, append(data, '\n'), 0644); err != nil {
+		return fmt.Errorf("write trace report: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	traceImportCmd.Flags().StringVar(&traceImportOpts.input, "input", "", "mmiotrace log path")
+	traceImportCmd.Flags().StringVar(&traceImportOpts.output, "output", "bar_model_report.json", "output report path")
+	traceImportCmd.Flags().StringVar(&traceImportOpts.bdf, "bdf", "", "donor device BDF for report metadata")
+	traceImportCmd.Flags().IntVar(&traceImportOpts.bar, "bar", 0, "BAR index for report metadata")
+	traceImportCmd.Flags().IntVar(&traceImportOpts.barSize, "bar-size", 4096, "BAR size for report metadata")
+	traceImportCmd.Flags().Uint64Var(&traceImportOpts.barBase, "bar-base", 0, "BAR physical base address for offset calculation")
+	_ = traceImportCmd.MarkFlagRequired("input")
+
+	traceCmd.AddCommand(traceImportCmd)
+	rootCmd.AddCommand(traceCmd)
+}

--- a/cmd/pcileechgen/trace_test.go
+++ b/cmd/pcileechgen/trace_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunTraceImport_WritesBarModelReport(t *testing.T) {
+	tmpDir := t.TempDir()
+	input := filepath.Join(tmpDir, "trace.log")
+	output := filepath.Join(tmpDir, "bar_model_report.json")
+	if err := os.WriteFile(input, []byte("R 4 0.001 0xfebf001c 0x00000000\nR 4 0.002 0xfebf001c 0x00000001\nR 4 0.003 0xfebf001c 0x00000001\n"), 0644); err != nil {
+		t.Fatalf("write trace fixture: %v", err)
+	}
+
+	if err := runTraceImport(input, output, "0000:03:00.0", 0, 4096, 0); err != nil {
+		t.Fatalf("runTraceImport failed: %v", err)
+	}
+
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	var got struct {
+		Reports []struct {
+			BDF       string `json:"bdf"`
+			BARIndex  int    `json:"bar_index"`
+			Registers []struct {
+				Offset         uint32 `json:"offset"`
+				Classification string `json:"classification"`
+			} `json:"registers"`
+		} `json:"reports"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("output JSON did not parse: %v", err)
+	}
+	if len(got.Reports) != 1 || got.Reports[0].BDF != "0000:03:00.0" || got.Reports[0].BARIndex != 0 {
+		t.Fatalf("unexpected report identity: %#v", got.Reports)
+	}
+	if len(got.Reports[0].Registers) != 1 || got.Reports[0].Registers[0].Classification != "polled" {
+		t.Fatalf("unexpected register classification: %#v", got.Reports[0].Registers)
+	}
+}

--- a/docs/superpowers/plans/2026-06-24-full-donor-emulation-foundation.md
+++ b/docs/superpowers/plans/2026-06-24-full-donor-emulation-foundation.md
@@ -1,0 +1,59 @@
+# Full Donor Emulation Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add multi-BAR artifacts, explicit register semantics, and deterministic trace reports as the foundation for class-functional donor emulation.
+
+**Architecture:** Keep existing BAR0-compatible firmware generation intact. Add per-BAR COE artifacts and evidence/reporting APIs that later class engines can consume without claiming unsupported behavior.
+
+**Tech Stack:** Go 1.26+, standard library only, existing `go test` package tests.
+
+---
+
+### Task 1: Multi-BAR COE generation
+
+**Files:**
+- Modify: `internal/firmware/codegen/codegen.go`
+- Modify: `internal/firmware/codegen/codegen_test.go`
+- Modify: `internal/firmware/output/writer.go`
+- Modify: `internal/firmware/output/writer_test.go`
+
+- [ ] Write failing tests for `GenerateSingleBarContentCOE` and `writeBARContentArtifacts`.
+- [ ] Run targeted tests and confirm missing-symbol failures.
+- [ ] Implement `GenerateSingleBarContentCOE(barIndex int, data []byte, size int) string`.
+- [ ] Keep `GenerateBarContentCOE(map[int][]byte, size int)` as compatibility wrapper.
+- [ ] Implement output writer helper that emits `pcileech_bar<N>.coe` for each captured BAR plus `pcileech_bar_zero4k.coe`.
+- [ ] Run targeted codegen/output tests.
+
+### Task 2: Register access semantics
+
+**Files:**
+- Modify: `internal/firmware/barmodel/model.go`
+- Modify: `internal/firmware/barmodel/model_test.go`
+
+- [ ] Write failing test for `BARRegister.AccessKind()`.
+- [ ] Run test and confirm missing-symbol failure.
+- [ ] Add `RegisterAccessKind` constants and JSON tags on `BARRegister`/`BARModel`.
+- [ ] Implement access-kind derivation from existing `RWMask`, `IsRW1C`, and `IsFSMDriven` fields.
+- [ ] Run barmodel tests.
+
+### Task 3: MMIO trace reports
+
+**Files:**
+- Modify: `internal/donor/mmio/tracer.go`
+- Modify: `internal/donor/mmio/tracer_test.go`
+
+- [ ] Write failing test for `BuildReport(sampleTrace())` classification.
+- [ ] Run test and confirm missing-symbol failure.
+- [ ] Add `TraceReport`, `RegisterSummary`, and `RegisterClassification` types.
+- [ ] Implement deterministic sorted register summaries using existing `Analyze` output.
+- [ ] Run mmio tests.
+
+### Task 4: Verification
+
+**Files:**
+- No new files.
+
+- [ ] Run `go test ./internal/firmware/codegen ./internal/firmware/output ./internal/firmware/barmodel ./internal/donor/mmio`.
+- [ ] Run `go test ./...`.
+- [ ] Review generated docs/spec for contradictions with implementation.

--- a/docs/superpowers/specs/2026-06-24-full-donor-emulation-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-24-full-donor-emulation-foundation-design.md
@@ -1,0 +1,57 @@
+# Full Donor Emulation Foundation Design
+
+## Goal
+Build the shared substrate needed for class-functional donor emulation across NVMe, xHCI, HDA/audio, Ethernet, SATA, Wi-Fi, Thunderbolt, and limited GPU facades.
+
+## Scope for this slice
+This slice does not claim full class behavior. It adds the reusable foundation every class engine needs:
+
+1. Multi-BAR artifact support: emit per-BAR COE files for captured donor BAR contents while keeping the legacy BAR0-compatible filename.
+2. Register model metadata: expose register access semantics as explicit model data instead of implicit flags.
+3. Trace report data model: turn MMIO traces into deterministic per-register classifications suitable for later BAR model synthesis.
+
+## Non-goals
+- No anti-cheat bypass, stealth/evasion feature, arbitrary DMA service, firmware activation, or spoofing claims.
+- No claim that a generated bitstream fully emulates an unsupported class.
+- No broad class engines in this slice; NVMe/xHCI/HDA/NIC/SATA/Wi-Fi engines come after this foundation.
+
+## Architecture
+
+### Multi-BAR artifacts
+`internal/firmware/output` writes all captured `DeviceContext.BARContents` entries as `pcileech_bar<N>.coe`. Existing `pcileech_bar_zero4k.coe` remains as a compatibility alias using the current largest-BAR behavior, so current templates and users do not break.
+
+### Register model metadata
+`internal/firmware/barmodel.BARRegister` gains JSON tags and an `AccessKind()` method derived from current flags:
+
+- `read_only`: `RWMask == 0`
+- `read_write`: writable normal register
+- `rw1c`: write-one-to-clear
+- `fsm`: driven by a dedicated device FSM
+
+This keeps current template behavior unchanged while making model output machine-readable.
+
+### Trace reports
+`internal/donor/mmio` gains `BuildReport(trace)` with sorted register summaries. `internal/firmware/output` writes `bar_model_report.json` when a donor context contains MMIO traces. `pcileechgen trace import` converts a local mmiotrace log into the same report format, and `pcileechgen build --trace BAR=trace.log` carries trace evidence into `DeviceContext.MMIOTraces` so normal builds emit the report. Trace import can use a BAR physical base to preserve offsets beyond 4KB, which is required for NVMe doorbells. Classification is deliberately conservative:
+
+- `static_read`: reads only, one observed value
+- `volatile_read`: reads only, multiple values
+- `polled`: repeated reads detected
+- `write_only`: writes only
+- `read_write`: both reads and writes
+
+Trace-observed registers are merged into BAR models only when the class/profile model does not already cover that offset. Existing class semantics win; trace registers get reset values from the last observed value, read-only masks for read classifications, and full write masks only when writes were observed.
+
+### NVMe trace evidence
+`internal/firmware/nvme` derives small, explicit evidence from traces: Admin Queue register writes (`AQA`, `ASQ`, `ACQ`) and observed SQ0/CQ0 doorbell spacing. When BAR data does not provide CAP.DSTRD, `output.buildSVConfig` uses trace-derived doorbell stride so generated NVMe doorbell hit logic can match real donor traces. This does not add new NVMe command behavior; it only preserves observed initialization geometry.
+
+## Testing
+- Codegen test proves single-BAR COE generation uses the requested BAR data instead of the largest BAR.
+- Output test proves multiple captured BARs produce multiple deterministic artifact names.
+- BAR model test proves access-kind derivation.
+- MMIO test proves trace report classification is deterministic.
+- Output test proves `bar_model_report.json` is deterministic and parseable when traces are present.
+- CLI test proves `trace import` writes a parseable report from a local mmiotrace fixture.
+- Build CLI test proves `--trace BAR=path` loads trace records into the donor context with BAR metadata.
+- BAR model/output tests prove trace-only registers become conservative SV model registers without overriding existing class registers.
+- MMIO/build tests prove BAR base-aware trace parsing preserves offsets beyond 4KB.
+- NVMe/output tests prove trace evidence extracts Admin Queue writes and doorbell stride, then wires stride into SV config.

--- a/internal/donor/context.go
+++ b/internal/donor/context.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
 	"github.com/sercanarga/pcileechgen/internal/pci"
 )
 
@@ -28,30 +29,32 @@ type DeviceContext struct {
 	ToolVersion string    `json:"tool_version"`
 	Hostname    string    `json:"hostname"`
 
-	Device          pci.PCIDevice       `json:"device"`
-	ConfigSpace     *pci.ConfigSpace    `json:"config_space"`
-	BARs            []pci.BAR           `json:"bars"`
-	BARContents     map[int][]byte      `json:"-"` // BAR memory contents, keyed by BAR index
-	BARProfiles     map[int]*BARProfile `json:"-"` // probing results, keyed by BAR index
-	Capabilities    []pci.Capability    `json:"capabilities"`
-	ExtCapabilities []pci.ExtCapability `json:"ext_capabilities,omitempty"`
-	MSIXData        *MSIXData           `json:"msix_data,omitempty"`
+	Device          pci.PCIDevice             `json:"device"`
+	ConfigSpace     *pci.ConfigSpace          `json:"config_space"`
+	BARs            []pci.BAR                 `json:"bars"`
+	BARContents     map[int][]byte            `json:"-"` // BAR memory contents, keyed by BAR index
+	BARProfiles     map[int]*BARProfile       `json:"-"` // probing results, keyed by BAR index
+	MMIOTraces      map[int]*mmio.TraceResult `json:"-"` // optional MMIO traces, keyed by BAR index
+	Capabilities    []pci.Capability          `json:"capabilities"`
+	ExtCapabilities []pci.ExtCapability       `json:"ext_capabilities,omitempty"`
+	MSIXData        *MSIXData                 `json:"msix_data,omitempty"`
 }
 
 // JSON wire format - config space as hex words, BARs as base64.
 type deviceContextJSON struct {
-	CollectedAt     time.Time              `json:"collected_at"`
-	ToolVersion     string                 `json:"tool_version"`
-	Hostname        string                 `json:"hostname"`
-	Device          pci.PCIDevice          `json:"device"`
-	ConfigSpaceHex  []string               `json:"config_space_hex"`
-	ConfigSpaceSize int                    `json:"config_space_size"`
-	BARs            []pci.BAR              `json:"bars"`
-	BARContents     map[string]string      `json:"bar_contents,omitempty"` // key: BAR index, value: base64
-	BARProfiles     map[string]*BARProfile `json:"bar_profiles,omitempty"`
-	Capabilities    []pci.Capability       `json:"capabilities"`
-	ExtCapabilities []pci.ExtCapability    `json:"ext_capabilities,omitempty"`
-	MSIXData        *MSIXData              `json:"msix_data,omitempty"`
+	CollectedAt     time.Time                    `json:"collected_at"`
+	ToolVersion     string                       `json:"tool_version"`
+	Hostname        string                       `json:"hostname"`
+	Device          pci.PCIDevice                `json:"device"`
+	ConfigSpaceHex  []string                     `json:"config_space_hex"`
+	ConfigSpaceSize int                          `json:"config_space_size"`
+	BARs            []pci.BAR                    `json:"bars"`
+	BARContents     map[string]string            `json:"bar_contents,omitempty"` // key: BAR index, value: base64
+	BARProfiles     map[string]*BARProfile       `json:"bar_profiles,omitempty"`
+	MMIOTraces      map[string]*mmio.TraceResult `json:"mmio_traces,omitempty"`
+	Capabilities    []pci.Capability             `json:"capabilities"`
+	ExtCapabilities []pci.ExtCapability          `json:"ext_capabilities,omitempty"`
+	MSIXData        *MSIXData                    `json:"msix_data,omitempty"`
 }
 
 func (dc *DeviceContext) MarshalJSON() ([]byte, error) {
@@ -85,6 +88,13 @@ func (dc *DeviceContext) MarshalJSON() ([]byte, error) {
 		j.BARProfiles = make(map[string]*BARProfile)
 		for idx, profile := range dc.BARProfiles {
 			j.BARProfiles[strconv.Itoa(idx)] = profile
+		}
+	}
+
+	if len(dc.MMIOTraces) > 0 {
+		j.MMIOTraces = make(map[string]*mmio.TraceResult)
+		for idx, trace := range dc.MMIOTraces {
+			j.MMIOTraces[strconv.Itoa(idx)] = trace
 		}
 	}
 
@@ -150,6 +160,18 @@ func (dc *DeviceContext) UnmarshalJSON(data []byte) error {
 				return fmt.Errorf("invalid BAR profile index %q: %w", idxStr, err)
 			}
 			dc.BARProfiles[idx] = profile
+		}
+	}
+
+	// Reconstruct MMIO traces
+	if len(j.MMIOTraces) > 0 {
+		dc.MMIOTraces = make(map[int]*mmio.TraceResult)
+		for idxStr, trace := range j.MMIOTraces {
+			idx, err := strconv.Atoi(idxStr)
+			if err != nil {
+				return fmt.Errorf("invalid MMIO trace BAR index %q: %w", idxStr, err)
+			}
+			dc.MMIOTraces[idx] = trace
 		}
 	}
 

--- a/internal/donor/context_test.go
+++ b/internal/donor/context_test.go
@@ -1,0 +1,47 @@
+package donor
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func TestDeviceContextJSON_RoundTripsMMIOTraces(t *testing.T) {
+	cs := pci.NewConfigSpace()
+	cs.Size = pci.ConfigSpaceSize
+	ctx := &DeviceContext{
+		ConfigSpace: cs,
+		MMIOTraces: map[int]*mmio.TraceResult{
+			2: {
+				BDF:      "0000:03:00.0",
+				BARIndex: 2,
+				BARSize:  4096,
+				Duration: 5 * time.Millisecond,
+				Records:  []mmio.AccessRecord{{Offset: 0x1C, Type: mmio.AccessRead, Value: 1}},
+			},
+		},
+	}
+
+	data, err := ctx.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON failed: %v", err)
+	}
+	if !strings.Contains(string(data), "mmio_traces") {
+		t.Fatalf("serialized context missing mmio_traces: %s", data)
+	}
+
+	loaded, err := FromJSON(data)
+	if err != nil {
+		t.Fatalf("FromJSON failed: %v", err)
+	}
+	trace := loaded.MMIOTraces[2]
+	if trace == nil {
+		t.Fatal("BAR2 trace missing after round trip")
+	}
+	if trace.BARIndex != 2 || len(trace.Records) != 1 || trace.Records[0].Offset != 0x1C {
+		t.Fatalf("trace did not round-trip: %#v", trace)
+	}
+}

--- a/internal/donor/mmio/trace_live.go
+++ b/internal/donor/mmio/trace_live.go
@@ -6,6 +6,7 @@ package mmio
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strconv"
@@ -19,6 +20,36 @@ const (
 	tracePipe     = tracingDir + "/trace_pipe"
 	tracingOnPath = tracingDir + "/tracing_on"
 )
+
+type TraceImportOptions struct {
+	BDF      string
+	BARIndex int
+	BARSize  int
+	BARBase  uint64
+}
+
+func ParseTraceReader(r io.Reader, opts TraceImportOptions) (*TraceResult, error) {
+	trace := &TraceResult{
+		BDF:      opts.BDF,
+		BARIndex: opts.BARIndex,
+		BARSize:  opts.BARSize,
+	}
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		rec, ok := parseMMIOTraceLine(scanner.Text(), opts)
+		if !ok {
+			continue
+		}
+		trace.Records = append(trace.Records, rec)
+		if rec.Timestamp > trace.Duration {
+			trace.Duration = rec.Timestamp
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read trace: %w", err)
+	}
+	return trace, nil
+}
 
 // LiveTrace enables mmiotrace, records BAR accesses for `duration`, then stops.
 func LiveTrace(bdf string, duration time.Duration) (*TraceResult, error) {
@@ -76,7 +107,7 @@ func LiveTrace(bdf string, duration time.Duration) (*TraceResult, error) {
 				break
 			}
 			line := scanner.Text()
-			rec, ok := parseMMIOTraceLine(line)
+			rec, ok := parseMMIOTraceLine(line, TraceImportOptions{})
 			if ok {
 				result.Records = append(result.Records, rec)
 			}
@@ -97,7 +128,7 @@ func LiveTrace(bdf string, duration time.Duration) (*TraceResult, error) {
 }
 
 // parseMMIOTraceLine parses one mmiotrace line (R/W <width> <ts> <addr> <val>).
-func parseMMIOTraceLine(line string) (AccessRecord, bool) {
+func parseMMIOTraceLine(line string, opts TraceImportOptions) (AccessRecord, bool) {
 	line = strings.TrimSpace(line)
 	// mmiotrace lines typically look like:
 	// R 4 1234567.890 0xfee00000 0x00000001 ...
@@ -118,12 +149,15 @@ func parseMMIOTraceLine(line string) (AccessRecord, bool) {
 		return AccessRecord{}, false
 	}
 
-	// lower 12 bits = offset within 4K BAR page
 	addr, err := strconv.ParseUint(strings.TrimPrefix(fields[3], "0x"), 16, 64)
 	if err != nil {
 		return AccessRecord{}, false
 	}
-	rec.Offset = uint32(addr & 0xFFF) // BAR offset within 4K page
+	offset, ok := traceOffset(addr, opts)
+	if !ok {
+		return AccessRecord{}, false
+	}
+	rec.Offset = offset
 
 	// Parse value
 	val, err := strconv.ParseUint(strings.TrimPrefix(fields[4], "0x"), 16, 32)
@@ -138,4 +172,18 @@ func parseMMIOTraceLine(line string) (AccessRecord, bool) {
 	}
 
 	return rec, true
+}
+
+func traceOffset(addr uint64, opts TraceImportOptions) (uint32, bool) {
+	if opts.BARBase == 0 {
+		return uint32(addr & 0xFFF), true
+	}
+	if addr < opts.BARBase {
+		return 0, false
+	}
+	offset := addr - opts.BARBase
+	if opts.BARSize > 0 && offset >= uint64(opts.BARSize) {
+		return 0, false
+	}
+	return uint32(offset), true
 }

--- a/internal/donor/mmio/tracer.go
+++ b/internal/donor/mmio/tracer.go
@@ -68,6 +68,94 @@ type PollingLoop struct {
 	Interval time.Duration // avg interval between reads
 }
 
+type RegisterClassification string
+
+const (
+	RegisterStaticRead   RegisterClassification = "static_read"
+	RegisterVolatileRead RegisterClassification = "volatile_read"
+	RegisterPolled       RegisterClassification = "polled"
+	RegisterWriteOnly    RegisterClassification = "write_only"
+	RegisterReadWrite    RegisterClassification = "read_write"
+)
+
+// RegisterSummary is the stable report form for one observed BAR register.
+type RegisterSummary struct {
+	Offset         uint32                 `json:"offset"`
+	ReadCount      int                    `json:"read_count"`
+	WriteCount     int                    `json:"write_count"`
+	TotalCount     int                    `json:"total_count"`
+	LastValue      uint32                 `json:"last_value"`
+	Values         []uint32               `json:"values"`
+	Classification RegisterClassification `json:"classification"`
+}
+
+// TraceReport is a deterministic, JSON-friendly summary of one MMIO trace.
+type TraceReport struct {
+	BDF           string            `json:"bdf"`
+	BARIndex      int               `json:"bar_index"`
+	BARSize       int               `json:"bar_size"`
+	DurationMS    int64             `json:"duration_ms"`
+	TotalAccesses int               `json:"total_accesses"`
+	TotalReads    int               `json:"total_reads"`
+	TotalWrites   int               `json:"total_writes"`
+	Registers     []RegisterSummary `json:"registers"`
+	PollingLoops  []PollingLoop     `json:"polling_loops"`
+	InitSequence  []AccessRecord    `json:"init_sequence"`
+}
+
+func BuildReport(trace *TraceResult) *TraceReport {
+	pattern := Analyze(trace)
+	report := &TraceReport{
+		TotalAccesses: pattern.TotalAccesses,
+		TotalReads:    pattern.TotalReads,
+		TotalWrites:   pattern.TotalWrites,
+		PollingLoops:  append([]PollingLoop(nil), pattern.PollingLoops...),
+		InitSequence:  append([]AccessRecord(nil), pattern.InitSequence...),
+	}
+	if trace != nil {
+		report.BDF = trace.BDF
+		report.BARIndex = trace.BARIndex
+		report.BARSize = trace.BARSize
+		report.DurationMS = trace.Duration.Milliseconds()
+	}
+
+	polled := make(map[uint32]bool, len(pattern.PollingLoops))
+	for _, loop := range pattern.PollingLoops {
+		polled[loop.Offset] = true
+	}
+	for _, hot := range pattern.HotRegisters {
+		report.Registers = append(report.Registers, RegisterSummary{
+			Offset:         hot.Offset,
+			ReadCount:      hot.ReadCount,
+			WriteCount:     hot.WriteCount,
+			TotalCount:     hot.TotalCount,
+			LastValue:      hot.LastValue,
+			Values:         append([]uint32(nil), hot.Values...),
+			Classification: classifyRegister(hot, polled[hot.Offset]),
+		})
+	}
+	sort.Slice(report.Registers, func(i, j int) bool {
+		return report.Registers[i].Offset < report.Registers[j].Offset
+	})
+	return report
+}
+
+func classifyRegister(reg HotRegister, polled bool) RegisterClassification {
+	if reg.ReadCount > 0 && reg.WriteCount > 0 {
+		return RegisterReadWrite
+	}
+	if polled {
+		return RegisterPolled
+	}
+	if reg.WriteCount > 0 {
+		return RegisterWriteOnly
+	}
+	if len(reg.Values) > 1 {
+		return RegisterVolatileRead
+	}
+	return RegisterStaticRead
+}
+
 // --- analysis ---
 
 // Analyze crunches raw records into hot-register stats, polling loops, and init sequence.

--- a/internal/donor/mmio/tracer_test.go
+++ b/internal/donor/mmio/tracer_test.go
@@ -28,6 +28,52 @@ func sampleTrace() *TraceResult {
 	}
 }
 
+func TestParseTraceReader_ParsesMMIOTraceLines(t *testing.T) {
+	input := strings.NewReader(`
+ignored line
+R 4 0.001 0xfebf001c 0x00000000
+W 4 0.002 0xfebf0024 0x001f001f
+`)
+
+	trace, err := ParseTraceReader(input, TraceImportOptions{
+		BDF:      "0000:03:00.0",
+		BARIndex: 2,
+		BARSize:  4096,
+	})
+	if err != nil {
+		t.Fatalf("ParseTraceReader failed: %v", err)
+	}
+	if trace.BDF != "0000:03:00.0" || trace.BARIndex != 2 || trace.BARSize != 4096 {
+		t.Fatalf("trace identity mismatch: %#v", trace)
+	}
+	if len(trace.Records) != 2 {
+		t.Fatalf("records = %d, want 2", len(trace.Records))
+	}
+	if trace.Records[0].Offset != 0x1C || trace.Records[0].Type != AccessRead {
+		t.Fatalf("first record mismatch: %#v", trace.Records[0])
+	}
+	if trace.Records[1].Offset != 0x24 || trace.Records[1].Type != AccessWrite {
+		t.Fatalf("second record mismatch: %#v", trace.Records[1])
+	}
+}
+
+func TestParseTraceReader_UsesBARBaseForLargeBAROffsets(t *testing.T) {
+	input := strings.NewReader("W 4 0.001 0xfebf1008 0x00000007\n")
+
+	trace, err := ParseTraceReader(input, TraceImportOptions{
+		BDF:      "0000:03:00.0",
+		BARIndex: 0,
+		BARSize:  8192,
+		BARBase:  0xfebf0000,
+	})
+	if err != nil {
+		t.Fatalf("ParseTraceReader failed: %v", err)
+	}
+	if len(trace.Records) != 1 || trace.Records[0].Offset != 0x1008 {
+		t.Fatalf("trace offset mismatch: %#v", trace.Records)
+	}
+}
+
 func TestAnalyze_Basic(t *testing.T) {
 	p := Analyze(sampleTrace())
 	if p.TotalAccesses != 8 {
@@ -82,6 +128,30 @@ func TestAnalyze_InitSequence(t *testing.T) {
 	// First write should be CC at 0x14
 	if p.InitSequence[0].Offset != 0x14 {
 		t.Errorf("first init write: got 0x%X, want 0x14", p.InitSequence[0].Offset)
+	}
+}
+
+func TestBuildReport_ClassifiesRegisters(t *testing.T) {
+	report := BuildReport(sampleTrace())
+	if report.BDF != "0000:03:00.0" || report.BARIndex != 0 {
+		t.Fatalf("report identity mismatch: %#v", report)
+	}
+	if report.TotalReads != 5 || report.TotalWrites != 3 {
+		t.Fatalf("report totals = R:%d W:%d, want R:5 W:3", report.TotalReads, report.TotalWrites)
+	}
+
+	byOffset := make(map[uint32]RegisterSummary)
+	for _, reg := range report.Registers {
+		byOffset[reg.Offset] = reg
+	}
+	if got := byOffset[0x1C].Classification; got != RegisterPolled {
+		t.Fatalf("CSTS classification = %s, want %s", got, RegisterPolled)
+	}
+	if got := byOffset[0x14].Classification; got != RegisterWriteOnly {
+		t.Fatalf("CC classification = %s, want %s", got, RegisterWriteOnly)
+	}
+	if got := byOffset[0x00].Classification; got != RegisterStaticRead {
+		t.Fatalf("CAP classification = %s, want %s", got, RegisterStaticRead)
 	}
 }
 

--- a/internal/firmware/barmodel/model.go
+++ b/internal/firmware/barmodel/model.go
@@ -4,27 +4,51 @@ package barmodel
 import (
 	"fmt"
 	"log/slog"
+	"sort"
 
 	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
 	"github.com/sercanarga/pcileechgen/internal/firmware/devclass"
 	"github.com/sercanarga/pcileechgen/internal/util"
 )
 
+type RegisterAccessKind string
+
+const (
+	RegisterReadOnly  RegisterAccessKind = "read_only"
+	RegisterReadWrite RegisterAccessKind = "read_write"
+	RegisterRW1C      RegisterAccessKind = "rw1c"
+	RegisterFSMDriven RegisterAccessKind = "fsm"
+)
+
 // BARRegister describes a single register inside a BAR.
 type BARRegister struct {
-	Offset      uint32 // byte offset in BAR
-	Width       int    // 1, 2, or 4 bytes
-	Reset       uint32 // reset/initial value (from donor snapshot or spec default)
-	RWMask      uint32 // writable bits (1 = host can write, 0 = read-only)
-	Name        string // human-readable register name
-	IsRW1C      bool   // true if this register uses write-1-to-clear semantics
-	IsFSMDriven bool   // true if driven by a dedicated FSM always block (excluded from generic reset/write)
+	Offset      uint32 `json:"offset"`  // byte offset in BAR
+	Width       int    `json:"width"`   // 1, 2, or 4 bytes
+	Reset       uint32 `json:"reset"`   // reset/initial value (from donor snapshot or spec default)
+	RWMask      uint32 `json:"rw_mask"` // writable bits (1 = host can write, 0 = read-only)
+	Name        string `json:"name"`    // human-readable register name
+	IsRW1C      bool   `json:"is_rw1c"` // true if this register uses write-1-to-clear semantics
+	IsFSMDriven bool   `json:"is_fsm"`  // true if driven by a dedicated FSM always block (excluded from generic reset/write)
+}
+
+func (r BARRegister) AccessKind() RegisterAccessKind {
+	if r.IsFSMDriven {
+		return RegisterFSMDriven
+	}
+	if r.IsRW1C {
+		return RegisterRW1C
+	}
+	if r.RWMask == 0 {
+		return RegisterReadOnly
+	}
+	return RegisterReadWrite
 }
 
 // BARModel is the complete register map that ends up in the SV template.
 type BARModel struct {
-	Size      int
-	Registers []BARRegister // ordered by Offset
+	Size      int           `json:"size"`
+	Registers []BARRegister `json:"registers"` // ordered by Offset
 }
 
 // BuildBARModel returns a register map from probe data or spec tables.
@@ -65,6 +89,52 @@ func BuildBARModel(barData []byte, classCode uint32, profile *donor.BARProfile) 
 		validateModel(model)
 	}
 	return model
+}
+
+// ApplyTraceReport adds trace-observed registers that the class/profile model does not already cover.
+// Existing class registers win; traces are evidence, not a replacement for protocol semantics.
+func ApplyTraceReport(model *BARModel, report *mmio.TraceReport) *BARModel {
+	if report == nil || len(report.Registers) == 0 {
+		return model
+	}
+	if model == nil {
+		model = &BARModel{Size: report.BARSize}
+	}
+	if model.Size < report.BARSize {
+		model.Size = report.BARSize
+	}
+
+	seen := make(map[uint32]bool, len(model.Registers))
+	for _, reg := range model.Registers {
+		seen[reg.Offset] = true
+	}
+	for _, summary := range report.Registers {
+		if seen[summary.Offset] {
+			continue
+		}
+		model.Registers = append(model.Registers, BARRegister{
+			Offset: summary.Offset,
+			Width:  4,
+			Reset:  summary.LastValue,
+			RWMask: traceRWMask(summary.Classification),
+			Name:   fmt.Sprintf("TRACE_0x%03X", summary.Offset),
+		})
+		seen[summary.Offset] = true
+	}
+	sort.Slice(model.Registers, func(i, j int) bool {
+		return model.Registers[i].Offset < model.Registers[j].Offset
+	})
+	validateModel(model)
+	return model
+}
+
+func traceRWMask(class mmio.RegisterClassification) uint32 {
+	switch class {
+	case mmio.RegisterWriteOnly, mmio.RegisterReadWrite:
+		return 0xFFFFFFFF
+	default:
+		return 0
+	}
 }
 
 // validateModel checks for misaligned or duplicate offsets.

--- a/internal/firmware/barmodel/model_test.go
+++ b/internal/firmware/barmodel/model_test.go
@@ -4,7 +4,53 @@ import (
 	"testing"
 
 	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
 )
+
+func TestBARRegisterAccessKind(t *testing.T) {
+	tests := []struct {
+		name string
+		reg  BARRegister
+		want RegisterAccessKind
+	}{
+		{name: "read-only", reg: BARRegister{RWMask: 0}, want: RegisterReadOnly},
+		{name: "read-write", reg: BARRegister{RWMask: 0xFFFFFFFF}, want: RegisterReadWrite},
+		{name: "rw1c", reg: BARRegister{RWMask: 0x0000000F, IsRW1C: true}, want: RegisterRW1C},
+		{name: "fsm", reg: BARRegister{RWMask: 0xFFFFFFFF, IsFSMDriven: true}, want: RegisterFSMDriven},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reg.AccessKind(); got != tt.want {
+				t.Fatalf("AccessKind() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyTraceReport_AddsObservedRegisters(t *testing.T) {
+	model := &BARModel{Size: 4096}
+	report := &mmio.TraceReport{
+		BARSize: 4096,
+		Registers: []mmio.RegisterSummary{
+			{Offset: 0x80, LastValue: 0xA5A50001, ReadCount: 3, Classification: mmio.RegisterStaticRead},
+			{Offset: 0x84, LastValue: 0x00000002, WriteCount: 1, Classification: mmio.RegisterWriteOnly},
+		},
+	}
+
+	model = ApplyTraceReport(model, report)
+
+	regs := map[uint32]BARRegister{}
+	for _, reg := range model.Registers {
+		regs[reg.Offset] = reg
+	}
+	if regs[0x80].Reset != 0xA5A50001 || regs[0x80].RWMask != 0 {
+		t.Fatalf("static trace register mismatch: %#v", regs[0x80])
+	}
+	if regs[0x84].Reset != 0x00000002 || regs[0x84].RWMask != 0xFFFFFFFF {
+		t.Fatalf("write trace register mismatch: %#v", regs[0x84])
+	}
+}
 
 func TestBuildBARModel_NVMe(t *testing.T) {
 	barData := make([]byte, 4096)

--- a/internal/firmware/codegen/codegen.go
+++ b/internal/firmware/codegen/codegen.go
@@ -71,10 +71,10 @@ func GenerateWritemaskCOE(cs *pci.ConfigSpace) string {
 	// scrubber already neutralized all writable extended cap fields.
 
 	// header type 0 registers (DWORD index = byte offset / 4)
-	masks[0] = 0x00000000  // 0x00: VID:DID (read-only identity)
-	masks[1] = 0xFFFFFFFF  // 0x04: Command:Status (OS needs full control)
-	masks[2] = 0x00000000  // 0x08: RevisionID:ClassCode (read-only identity)
-	masks[3] = 0xFF00FFFF  // 0x0C: CLS+LT writable, HeaderType RO, BIST writable
+	masks[0] = 0x00000000 // 0x00: VID:DID (read-only identity)
+	masks[1] = 0xFFFFFFFF // 0x04: Command:Status (OS needs full control)
+	masks[2] = 0x00000000 // 0x08: RevisionID:ClassCode (read-only identity)
+	masks[3] = 0xFF00FFFF // 0x0C: CLS+LT writable, HeaderType RO, BIST writable
 
 	// BAR registers 0x10-0x24 (DWORD 4-9): size-matching masks
 	for i := 0; i < 6; i++ {
@@ -111,23 +111,36 @@ func GenerateWritemaskCOE(cs *pci.ConfigSpace) string {
 	)
 }
 
-// GenerateBarContentCOE outputs BAR shadow COE from the lowest BAR.
-// Note: actual BAR aperture (Bar0Size) may be variable (>4KB on large boards); this seeds 4KB shadow.
+// GenerateBarContentCOE outputs the legacy BAR shadow COE from the largest BAR.
+// Kept for compatibility with existing templates that expect pcileech_bar_zero4k.coe.
 func GenerateBarContentCOE(barContents map[int][]byte, size int) string {
-	n := 1024
-	if size > 0 {
-		n = (size + 3) / 4
+	data := firmware.LargestBar(barContents)
+	return GenerateSingleBarContentCOE(-1, data, size)
+}
+
+// GenerateSingleBarContentCOE outputs one BAR shadow COE from a specific donor BAR.
+func GenerateSingleBarContentCOE(barIndex int, data []byte, size int) string {
+	if size <= 0 {
+		if len(data) > 0 {
+			size = len(data)
+		} else {
+			size = 4096
+		}
 	}
+	n := (size + 3) / 4
 	words := make([]uint32, n)
 
-	data := firmware.LargestBar(barContents)
 	if data != nil {
 		for i := 0; i+4 <= len(data) && i/4 < len(words); i += 4 {
 			words[i/4] = util.ReadLE32(data, i)
 		}
 	}
 
-	header := "; PCILeechGen - BAR Content (4KB shadow)\n"
+	header := "; PCILeechGen - BAR Content"
+	if barIndex >= 0 {
+		header += fmt.Sprintf(" (BAR%d)", barIndex)
+	}
+	header += "\n"
 	if data != nil {
 		header += "; Populated from donor device BAR memory\n"
 	} else {
@@ -168,4 +181,3 @@ func GenerateMSIXTableHex(entries []pci.MSIXEntry) string {
 
 	return sb.String()
 }
-

--- a/internal/firmware/codegen/codegen_test.go
+++ b/internal/firmware/codegen/codegen_test.go
@@ -125,6 +125,24 @@ func TestGenerateBarContentCOE_WithData(t *testing.T) {
 	}
 }
 
+func TestGenerateSingleBarContentCOE_UsesRequestedBAR(t *testing.T) {
+	bar0 := []byte{0x11, 0x11, 0x11, 0x11}
+	bar2 := []byte{0xDD, 0xCC, 0xBB, 0xAA}
+
+	coe := GenerateSingleBarContentCOE(2, bar2, 4096)
+
+	if !strings.Contains(coe, "BAR2") {
+		t.Error("COE header should identify the source BAR")
+	}
+	if !strings.Contains(coe, "aabbccdd") {
+		t.Error("COE should contain BAR2 data")
+	}
+	if strings.Contains(coe, "11111111") {
+		t.Errorf("COE used BAR0 data instead of requested BAR2: %s", coe[:200])
+	}
+	_ = bar0 // documents the regression: largest/lowest BAR data must not leak in
+}
+
 func TestGenerateConfigSpaceHex(t *testing.T) {
 	cs := pci.NewConfigSpace()
 	cs.Size = pci.ConfigSpaceSize
@@ -188,7 +206,7 @@ func TestGenerateMSIXTableHex_Empty(t *testing.T) {
 func TestWritemask_ScrubbedBAR0FromZero(t *testing.T) {
 	cs := pci.NewConfigSpace()
 	cs.Size = pci.ConfigSpaceSize
-	cs.WriteU16(0x00, 0x1102)     // Creative Labs
+	cs.WriteU16(0x00, 0x1102) // Creative Labs
 	cs.WriteU16(0x02, 0x0012)
 	cs.WriteU32(0x10, 0xFFFFF000) // BAR0 = 4KB mem (from scrubber)
 
@@ -255,11 +273,11 @@ func TestWritemask_IOBAROverwrittenToMemory(t *testing.T) {
 func TestWritemask_IdentityRegistersReadOnly(t *testing.T) {
 	cs := pci.NewConfigSpace()
 	cs.Size = pci.ConfigSpaceSize
-	cs.WriteU16(0x00, 0x1102) // VID
-	cs.WriteU16(0x02, 0x0012) // DID
+	cs.WriteU16(0x00, 0x1102)     // VID
+	cs.WriteU16(0x02, 0x0012)     // DID
 	cs.WriteU32(0x08, 0x04030000) // ClassCode + RevID
-	cs.WriteU16(0x2C, 0x1102) // SubsysVID
-	cs.WriteU16(0x2E, 0x0012) // SubsysDID
+	cs.WriteU16(0x2C, 0x1102)     // SubsysVID
+	cs.WriteU16(0x2E, 0x0012)     // SubsysDID
 	cs.WriteU32(0x10, 0xFFFFF000) // BAR0
 
 	wm := GenerateWritemaskCOE(cs)
@@ -337,8 +355,8 @@ func TestWritemask_MultipleBARs(t *testing.T) {
 func TestConfigSpaceCOE_ScrubbedDeviceIdentity(t *testing.T) {
 	cs := pci.NewConfigSpace()
 	cs.Size = pci.ConfigSpaceSize
-	cs.WriteU16(0x00, 0x1102) // VID
-	cs.WriteU16(0x02, 0x0012) // DID
+	cs.WriteU16(0x00, 0x1102)     // VID
+	cs.WriteU16(0x02, 0x0012)     // DID
 	cs.WriteU32(0x08, 0x04030000) // ClassCode 04:03:00
 
 	coe := GenerateConfigSpaceCOE(cs)
@@ -385,4 +403,3 @@ func parseCOEDwords(t *testing.T, coe string) []string {
 	}
 	return dwords
 }
-

--- a/internal/firmware/nvme/trace.go
+++ b/internal/firmware/nvme/trace.go
@@ -1,0 +1,80 @@
+package nvme
+
+import "github.com/sercanarga/pcileechgen/internal/donor/mmio"
+
+type TraceEvidence struct {
+	HasAdminQueues    bool   `json:"has_admin_queues"`
+	AQA               uint32 `json:"aqa"`
+	ASQ               uint64 `json:"asq"`
+	ACQ               uint64 `json:"acq"`
+	HasDoorbellStride bool   `json:"has_doorbell_stride"`
+	DoorbellStride    uint32 `json:"doorbell_stride"`
+	SQ0DoorbellOffset uint32 `json:"sq0_doorbell_offset"`
+	CQ0DoorbellOffset uint32 `json:"cq0_doorbell_offset"`
+}
+
+func BuildTraceEvidence(trace *mmio.TraceResult) *TraceEvidence {
+	if trace == nil || len(trace.Records) == 0 {
+		return nil
+	}
+
+	var ev TraceEvidence
+	var hasAQA, hasASQLo, hasASQHi, hasACQLo, hasACQHi bool
+	var asqLo, asqHi, acqLo, acqHi uint32
+	var sawSQ0 bool
+	var cq0Offset uint32
+
+	for _, rec := range trace.Records {
+		if rec.Type != mmio.AccessWrite {
+			continue
+		}
+		switch rec.Offset {
+		case 0x24:
+			ev.AQA, hasAQA = rec.Value, true
+		case 0x28:
+			asqLo, hasASQLo = rec.Value, true
+		case 0x2C:
+			asqHi, hasASQHi = rec.Value, true
+		case 0x30:
+			acqLo, hasACQLo = rec.Value, true
+		case 0x34:
+			acqHi, hasACQHi = rec.Value, true
+		case 0x1000:
+			sawSQ0 = true
+		default:
+			if rec.Offset > 0x1000 && (cq0Offset == 0 || rec.Offset < cq0Offset) {
+				cq0Offset = rec.Offset
+			}
+		}
+	}
+
+	if hasAQA && hasASQLo && hasASQHi && hasACQLo && hasACQHi {
+		ev.HasAdminQueues = true
+		ev.ASQ = uint64(asqHi)<<32 | uint64(asqLo)
+		ev.ACQ = uint64(acqHi)<<32 | uint64(acqLo)
+	}
+	if sawSQ0 && cq0Offset > 0x1000 {
+		if stride, ok := doorbellStrideFromDelta(cq0Offset - 0x1000); ok {
+			ev.HasDoorbellStride = true
+			ev.DoorbellStride = stride
+			ev.SQ0DoorbellOffset = 0x1000
+			ev.CQ0DoorbellOffset = cq0Offset
+		}
+	}
+	if ev.HasAdminQueues || ev.HasDoorbellStride {
+		return &ev
+	}
+	return nil
+}
+
+func doorbellStrideFromDelta(delta uint32) (uint32, bool) {
+	if delta < 4 || delta&(delta-1) != 0 {
+		return 0, false
+	}
+	for stride := uint32(0); stride < 16; stride++ {
+		if uint32(4)<<stride == delta {
+			return stride, true
+		}
+	}
+	return 0, false
+}

--- a/internal/firmware/nvme/trace_test.go
+++ b/internal/firmware/nvme/trace_test.go
@@ -1,0 +1,42 @@
+package nvme
+
+import (
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+)
+
+func TestBuildTraceEvidence_InfersDoorbellStride(t *testing.T) {
+	evidence := BuildTraceEvidence(&mmio.TraceResult{
+		BARSize: 8192,
+		Records: []mmio.AccessRecord{
+			{Offset: 0x1000, Type: mmio.AccessWrite, Value: 1},
+			{Offset: 0x1008, Type: mmio.AccessWrite, Value: 1},
+		},
+	})
+	if evidence == nil || !evidence.HasDoorbellStride {
+		t.Fatalf("expected doorbell stride evidence, got %#v", evidence)
+	}
+	if evidence.DoorbellStride != 1 || evidence.SQ0DoorbellOffset != 0x1000 || evidence.CQ0DoorbellOffset != 0x1008 {
+		t.Fatalf("unexpected doorbell evidence: %#v", evidence)
+	}
+}
+
+func TestBuildTraceEvidence_ExtractsAdminQueueWrites(t *testing.T) {
+	evidence := BuildTraceEvidence(&mmio.TraceResult{
+		BARSize: 8192,
+		Records: []mmio.AccessRecord{
+			{Offset: 0x24, Type: mmio.AccessWrite, Value: 0x001f001f},
+			{Offset: 0x28, Type: mmio.AccessWrite, Value: 0x12345000},
+			{Offset: 0x2c, Type: mmio.AccessWrite, Value: 0x00000001},
+			{Offset: 0x30, Type: mmio.AccessWrite, Value: 0x45678000},
+			{Offset: 0x34, Type: mmio.AccessWrite, Value: 0x00000002},
+		},
+	})
+	if evidence == nil || !evidence.HasAdminQueues {
+		t.Fatalf("expected admin queue evidence, got %#v", evidence)
+	}
+	if evidence.AQA != 0x001f001f || evidence.ASQ != 0x0000000112345000 || evidence.ACQ != 0x0000000245678000 {
+		t.Fatalf("unexpected queue evidence: %#v", evidence)
+	}
+}

--- a/internal/firmware/output/coverage_test.go
+++ b/internal/firmware/output/coverage_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sercanarga/pcileechgen/internal/board"
 	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
 	"github.com/sercanarga/pcileechgen/internal/firmware"
 	"github.com/sercanarga/pcileechgen/internal/pci"
 )
@@ -89,7 +90,10 @@ func TestBuildSVConfig(t *testing.T) {
 			ow := NewOutputWriter(t.TempDir(), "", 0, 0)
 			ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, ctx.ExtCapabilities)
 
-			cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0xDEAD, &board.Board{}); if err != nil { t.Fatal(err) }
+			cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0xDEAD, &board.Board{})
+			if err != nil {
+				t.Fatal(err)
+			}
 			if cfg == nil {
 				t.Fatal("config should not be nil")
 			}
@@ -108,9 +112,38 @@ func TestBuildSVConfig_NVMeHasIdentify(t *testing.T) {
 	ow := NewOutputWriter(t.TempDir(), "", 0, 0)
 	ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, ctx.ExtCapabilities)
 
-	cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0xBEEF, &board.Board{}); if err != nil { t.Fatal(err) }
+	cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0xBEEF, &board.Board{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if cfg.NVMeIdentify == nil {
 		t.Error("NVMe class should have Identify data")
+	}
+}
+
+func TestBuildSVConfig_NVMeTraceInfersDoorbellStride(t *testing.T) {
+	ctx := makeDonorContext(0x144D, 0xA808, 0x010802)
+	ctx.BARContents = nil
+	ctx.BARs = []pci.BAR{{Index: 0, Type: pci.BARTypeMem32, Size: 8192}}
+	ctx.MMIOTraces = map[int]*mmio.TraceResult{
+		0: {
+			BARIndex: 0,
+			BARSize:  8192,
+			Records: []mmio.AccessRecord{
+				{Offset: 0x1000, Type: mmio.AccessWrite, Value: 1},
+				{Offset: 0x1008, Type: mmio.AccessWrite, Value: 1},
+			},
+		},
+	}
+	ow := NewOutputWriter(t.TempDir(), "", 0, 0)
+	ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, ctx.ExtCapabilities)
+
+	cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0xBEEF, &board.Board{BRAMSize: 8192})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.NVMeTraceEvidence == nil || cfg.NVMeDoorbellStride != 1 || cfg.NVMeCQ0DoorbellOffset() != 0x1008 {
+		t.Fatalf("trace doorbell evidence not wired into config: %#v", cfg.NVMeTraceEvidence)
 	}
 }
 
@@ -139,7 +172,10 @@ func TestWriteCoreSVArtifacts(t *testing.T) {
 	ow := NewOutputWriter(dir, "", 0, 0)
 	ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, ctx.ExtCapabilities)
 
-	cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0x42, &board.Board{}); if err != nil { t.Fatal(err) }
+	cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0x42, &board.Board{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	scrubbed := ctx.ConfigSpace.Clone()
 
 	if err := ow.writeCoreSVArtifacts(cfg, scrubbed); err != nil {
@@ -172,7 +208,10 @@ func TestWriteConditionalArtifacts_NVMe(t *testing.T) {
 	ow := NewOutputWriter(dir, "", 0, 0)
 	ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, ctx.ExtCapabilities)
 
-	cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0x42, &board.Board{}); if err != nil { t.Fatal(err) }
+	cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0x42, &board.Board{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if err := ow.writeConditionalArtifacts(cfg, ctx); err != nil {
 		t.Fatalf("writeConditionalArtifacts failed: %v", err)
@@ -201,7 +240,10 @@ func TestWriteConditionalArtifacts_MSIXDonor(t *testing.T) {
 	ow := NewOutputWriter(dir, "", 0, 0)
 	ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, ctx.ExtCapabilities)
 
-	cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0x42, &board.Board{BRAMSize: 32768}); if err != nil { t.Fatal(err) }
+	cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0x42, &board.Board{BRAMSize: 32768})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if err := ow.writeConditionalArtifacts(cfg, ctx); err != nil {
 		t.Fatalf("writeConditionalArtifacts failed: %v", err)
@@ -222,7 +264,10 @@ func TestLogSVSummary(t *testing.T) {
 	ow := NewOutputWriter(t.TempDir(), "", 0, 0)
 	ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, ctx.ExtCapabilities)
 
-	cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0x42, &board.Board{}); if err != nil { t.Fatal(err) }
+	cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0x42, &board.Board{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	// should not panic
 	ow.logSVSummary(cfg)
 }

--- a/internal/firmware/output/writer.go
+++ b/internal/firmware/output/writer.go
@@ -2,14 +2,17 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/sercanarga/pcileechgen/internal/board"
 	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
 	"github.com/sercanarga/pcileechgen/internal/firmware"
 	"github.com/sercanarga/pcileechgen/internal/firmware/barmodel"
 	"github.com/sercanarga/pcileechgen/internal/firmware/codegen"
@@ -64,6 +67,10 @@ func (ow *OutputWriter) WriteAll(ctx *donor.DeviceContext, b *board.Board) error
 	scrubbedCS, entropy, overlayMap := ow.scrubAndVary(ctx, b, ids)
 
 	if err := ow.writeConfigSpaceArtifacts(ctx, scrubbedCS, b); err != nil {
+		return err
+	}
+
+	if err := ow.writeTraceReportArtifact(ctx); err != nil {
 		return err
 	}
 
@@ -144,9 +151,71 @@ func (ow *OutputWriter) writeConfigSpaceArtifacts(ctx *donor.DeviceContext, scru
 	bar0Size := firmware.CappedBAR0Size(ctx, b, msixTableSize)
 
 	scrub.ScrubBarContent(ctx.BARContents, ctx.Device.ClassCode, ctx.Device.VendorID, bar0Size)
+	if err := ow.writeBARContentArtifacts(ctx, bar0Size); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ow *OutputWriter) writeBARContentArtifacts(ctx *donor.DeviceContext, fallbackSize int) error {
+	if ctx != nil && len(ctx.BARContents) > 0 {
+		indices := make([]int, 0, len(ctx.BARContents))
+		for idx := range ctx.BARContents {
+			indices = append(indices, idx)
+		}
+		sort.Ints(indices)
+
+		for _, idx := range indices {
+			data := ctx.BARContents[idx]
+			size := len(data)
+			if size == 0 {
+				size = fallbackSize
+			}
+			name := fmt.Sprintf("pcileech_bar%d.coe", idx)
+			if err := ow.writeFile(name, codegen.GenerateSingleBarContentCOE(idx, data, size)); err != nil {
+				return fmt.Errorf("failed to write BAR%d COE: %w", idx, err)
+			}
+		}
+	}
+
+	var barContents map[int][]byte
+	if ctx != nil {
+		barContents = ctx.BARContents
+	}
 	if err := ow.writeFile("pcileech_bar_zero4k.coe",
-		codegen.GenerateBarContentCOE(ctx.BARContents, firmware.CappedBAR0Size(ctx, b, msixTableSize))); err != nil {
-		return fmt.Errorf("failed to write bar zero COE: %w", err)
+		codegen.GenerateBarContentCOE(barContents, fallbackSize)); err != nil {
+		return fmt.Errorf("failed to write legacy BAR COE: %w", err)
+	}
+	return nil
+}
+
+type traceReportArtifact struct {
+	Reports []*mmio.TraceReport `json:"reports"`
+}
+
+func (ow *OutputWriter) writeTraceReportArtifact(ctx *donor.DeviceContext) error {
+	if ctx == nil || len(ctx.MMIOTraces) == 0 {
+		return nil
+	}
+	indices := make([]int, 0, len(ctx.MMIOTraces))
+	for idx := range ctx.MMIOTraces {
+		indices = append(indices, idx)
+	}
+	sort.Ints(indices)
+
+	artifact := traceReportArtifact{
+		Reports: make([]*mmio.TraceReport, 0, len(indices)),
+	}
+	for _, idx := range indices {
+		artifact.Reports = append(artifact.Reports, mmio.BuildReport(ctx.MMIOTraces[idx]))
+	}
+
+	data, err := json.MarshalIndent(artifact, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal BAR model report: %w", err)
+	}
+	if err := ow.writeFile("bar_model_report.json", string(data)+"\n"); err != nil {
+		return fmt.Errorf("failed to write BAR model report: %w", err)
 	}
 	return nil
 }
@@ -329,6 +398,8 @@ func ListOutputFiles() []string {
 		"pcileech_cfgspace.coe",
 		"pcileech_cfgspace_writemask.coe",
 		"pcileech_bar_zero4k.coe",
+		"pcileech_bar<N>.coe",
+		"bar_model_report.json",
 		"vivado_generate_project.tcl",
 		"vivado_build.tcl",
 		"src/",
@@ -435,6 +506,7 @@ func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.
 			barProfile = p
 		}
 	}
+	trace := ctx.MMIOTraces[barIdx]
 	slog.Info("BAR selection for SV codegen",
 		"bar_index", barIdx,
 		"bar_size", len(barData),
@@ -442,9 +514,17 @@ func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.
 		"class_code", fmt.Sprintf("0x%06X", ctx.Device.ClassCode),
 	)
 	bm := barmodel.BuildBARModel(barData, ctx.Device.ClassCode, barProfile)
+	if trace != nil {
+		bm = barmodel.ApplyTraceReport(bm, mmio.BuildReport(trace))
+	}
 	slog.Info("BAR model built",
 		"model_nil", bm == nil,
-		"reg_count", func() int { if bm != nil { return len(bm.Registers) }; return 0 }(),
+		"reg_count", func() int {
+			if bm != nil {
+				return len(bm.Registers)
+			}
+			return 0
+		}(),
 	)
 
 	strategy := devclass.StrategyForClassAndVendor(ctx.Device.ClassCode, ids.VendorID)
@@ -481,9 +561,12 @@ func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.
 
 	if devClass == devclass.ClassNVMe {
 		cfg.NVMeIdentify = nvme.BuildIdentifyData(ids, barData)
+		cfg.NVMeTraceEvidence = nvme.BuildTraceEvidence(trace)
 		if len(barData) >= 0x08 {
 			capHI := util.ReadLE32(barData, 0x04)
 			cfg.NVMeDoorbellStride = capHI & 0x0F
+		} else if cfg.NVMeTraceEvidence != nil && cfg.NVMeTraceEvidence.HasDoorbellStride {
+			cfg.NVMeDoorbellStride = cfg.NVMeTraceEvidence.DoorbellStride
 		}
 	}
 
@@ -516,11 +599,15 @@ func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.
 	// Validate *donor demand* (may exceed) against board BRAM; error unless --force.
 	// (bar0Size is the Capped value actually used for artifacts/scrub/SV.)
 	if issues := ValidateBARSize(donorBar, bram, 0); len(issues) > 0 {
-		if !ow.Force { return nil, fmt.Errorf("%s", issues[0]) }
+		if !ow.Force {
+			return nil, fmt.Errorf("%s", issues[0])
+		}
 	}
 	if cfg.MSIXConfig != nil {
 		if issues := ValidateBARSize(donorBar, bram, cfg.MSIXConfig.TableOffset); len(issues) > 0 {
-			if !ow.Force { return nil, fmt.Errorf("%s", issues[0]) }
+			if !ow.Force {
+				return nil, fmt.Errorf("%s", issues[0])
+			}
 		}
 	}
 

--- a/internal/firmware/output/writer_test.go
+++ b/internal/firmware/output/writer_test.go
@@ -1,10 +1,17 @@
 package output
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/board"
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+	"github.com/sercanarga/pcileechgen/internal/firmware"
+	"github.com/sercanarga/pcileechgen/internal/pci"
 )
 
 func TestNewOutputWriter_Defaults(t *testing.T) {
@@ -45,6 +52,114 @@ func TestWriteFile(t *testing.T) {
 	}
 }
 
+func TestWriteBARContentArtifacts_WritesCapturedBARsAndLegacyAlias(t *testing.T) {
+	tmpDir := t.TempDir()
+	ow := NewOutputWriter(tmpDir, "lib/pcileech-fpga", 4, 3600)
+	ctx := &donor.DeviceContext{
+		BARContents: map[int][]byte{
+			0: {0x17, 0xFF, 0x40, 0x00},
+			2: {0xDD, 0xCC, 0xBB, 0xAA},
+		},
+	}
+
+	if err := ow.writeBARContentArtifacts(ctx, 4096); err != nil {
+		t.Fatalf("writeBARContentArtifacts failed: %v", err)
+	}
+
+	for _, name := range []string{"pcileech_bar0.coe", "pcileech_bar2.coe", "pcileech_bar_zero4k.coe"} {
+		if _, err := os.Stat(filepath.Join(tmpDir, name)); err != nil {
+			t.Fatalf("expected %s to be written: %v", name, err)
+		}
+	}
+
+	bar2, err := os.ReadFile(filepath.Join(tmpDir, "pcileech_bar2.coe"))
+	if err != nil {
+		t.Fatalf("read BAR2 COE: %v", err)
+	}
+	if !strings.Contains(string(bar2), "aabbccdd") {
+		t.Fatalf("BAR2 COE missing BAR2 data: %s", string(bar2[:min(len(bar2), 200)]))
+	}
+}
+
+func TestWriteTraceReportArtifact_WritesBarModelReport(t *testing.T) {
+	tmpDir := t.TempDir()
+	ow := NewOutputWriter(tmpDir, "lib/pcileech-fpga", 4, 3600)
+	ctx := &donor.DeviceContext{
+		MMIOTraces: map[int]*mmio.TraceResult{
+			0: {
+				BDF:      "0000:03:00.0",
+				BARIndex: 0,
+				BARSize:  4096,
+				Records: []mmio.AccessRecord{
+					{Offset: 0x1C, Type: mmio.AccessRead, Value: 0},
+					{Offset: 0x1C, Type: mmio.AccessRead, Value: 0},
+					{Offset: 0x1C, Type: mmio.AccessRead, Value: 1},
+				},
+			},
+		},
+	}
+
+	if err := ow.writeTraceReportArtifact(ctx); err != nil {
+		t.Fatalf("writeTraceReportArtifact failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "bar_model_report.json"))
+	if err != nil {
+		t.Fatalf("read bar_model_report.json: %v", err)
+	}
+	var got struct {
+		Reports []struct {
+			BARIndex  int `json:"bar_index"`
+			Registers []struct {
+				Offset         uint32 `json:"offset"`
+				Classification string `json:"classification"`
+			} `json:"registers"`
+		} `json:"reports"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("report JSON did not parse: %v", err)
+	}
+	if len(got.Reports) != 1 || got.Reports[0].BARIndex != 0 {
+		t.Fatalf("unexpected reports: %#v", got.Reports)
+	}
+	if len(got.Reports[0].Registers) != 1 || got.Reports[0].Registers[0].Classification != "polled" {
+		t.Fatalf("unexpected register classification: %#v", got.Reports[0].Registers)
+	}
+}
+
+func TestBuildSVConfig_UsesTraceReportForBARModel(t *testing.T) {
+	ow := NewOutputWriter(t.TempDir(), "lib/pcileech-fpga", 4, 3600)
+	ctx := &donor.DeviceContext{
+		Device: pci.PCIDevice{
+			BDF:       pci.BDF{Bus: 3},
+			ClassCode: 0xFF0000,
+		},
+		BARs: []pci.BAR{{Index: 0, Type: pci.BARTypeMem32, Size: 4096}},
+		MMIOTraces: map[int]*mmio.TraceResult{
+			0: {
+				BDF:      "0000:03:00.0",
+				BARIndex: 0,
+				BARSize:  4096,
+				Records: []mmio.AccessRecord{
+					{Offset: 0x80, Type: mmio.AccessRead, Value: 0xA5A50001},
+					{Offset: 0x80, Type: mmio.AccessRead, Value: 0xA5A50001},
+				},
+			},
+		},
+	}
+
+	cfg, err := ow.buildSVConfig(ctx, pci.NewConfigSpace(), firmware.DeviceIDs{VendorID: 0x1234, DeviceID: 0x5678, ClassCode: 0xFF0000}, 1, &board.Board{BRAMSize: 4096})
+	if err != nil {
+		t.Fatalf("buildSVConfig failed: %v", err)
+	}
+	if cfg.BARModel == nil || len(cfg.BARModel.Registers) != 1 {
+		t.Fatalf("trace-derived BARModel missing: %#v", cfg.BARModel)
+	}
+	if reg := cfg.BARModel.Registers[0]; reg.Offset != 0x80 || reg.Reset != 0xA5A50001 || reg.RWMask != 0 {
+		t.Fatalf("trace-derived register mismatch: %#v", reg)
+	}
+}
+
 func TestListOutputFiles(t *testing.T) {
 	files := ListOutputFiles()
 	if len(files) == 0 {
@@ -56,9 +171,11 @@ func TestListOutputFiles(t *testing.T) {
 		"pcileech_cfgspace.coe",
 		"pcileech_cfgspace_writemask.coe",
 		"pcileech_bar_zero4k.coe",
+		"pcileech_bar<N>.coe",
 		"vivado_generate_project.tcl",
 		"vivado_build.tcl",
 		"device_context.json",
+		"bar_model_report.json",
 	}
 	for _, name := range expected {
 		found := false

--- a/internal/firmware/svgen/generator.go
+++ b/internal/firmware/svgen/generator.go
@@ -24,15 +24,16 @@ type SVGeneratorConfig struct {
 	DeviceIDs          firmware.DeviceIDs
 	BARModel           *barmodel.BARModel // nil = generic fallback (uses BRAM-based zerowrite4k)
 	ClassCode          uint32
-	LatencyConfig      *LatencyConfig     // TLP response timing (nil = no latency emulator)
-	HasMSIX            bool               // generate MSI-X interrupt controller logic
-	BuildEntropy       uint32             // seed for PRNG uniqueness per build
-	PRNGSeeds          [4]uint32          // computed PRNG seeds for latency emulator
-	DeviceClass        string             // "nvme", "xhci", "audio", "ethernet", or ""
-	MSIXConfig         *MSIXConfig        // MSI-X table replication (nil = no MSI-X table)
-	MSIConfig          *MSIConfig         // MSI capability info (nil = no MSI cap or disabled)
-	NVMeIdentify       *nvme.IdentifyData // NVMe Identify Controller/Namespace data (nil = no responder)
-	NVMeDoorbellStride uint32             // CAP.DSTRD - doorbell stride (0 = 4B, default)
+	LatencyConfig      *LatencyConfig      // TLP response timing (nil = no latency emulator)
+	HasMSIX            bool                // generate MSI-X interrupt controller logic
+	BuildEntropy       uint32              // seed for PRNG uniqueness per build
+	PRNGSeeds          [4]uint32           // computed PRNG seeds for latency emulator
+	DeviceClass        string              // "nvme", "xhci", "audio", "ethernet", or ""
+	MSIXConfig         *MSIXConfig         // MSI-X table replication (nil = no MSI-X table)
+	MSIConfig          *MSIConfig          // MSI capability info (nil = no MSI cap or disabled)
+	NVMeIdentify       *nvme.IdentifyData  // NVMe Identify Controller/Namespace data (nil = no responder)
+	NVMeDoorbellStride uint32              // CAP.DSTRD - doorbell stride (0 = 4B, default)
+	NVMeTraceEvidence  *nvme.TraceEvidence // observed queue/doorbell writes from MMIO traces (nil = none)
 	Bar0Size           int
 }
 

--- a/tools/hdlcheck/main.go
+++ b/tools/hdlcheck/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type fileSet struct {
+	HDL []string
+	TCL []string
+}
+
+type commandPlan struct {
+	Label string
+	Args  []string
+}
+
+type plan struct {
+	Commands []commandPlan
+	Skipped  []string
+}
+
+type lookPathFunc func(string) (string, error)
+
+func main() {
+	dir := flag.String("dir", "pcileech_datastore", "directory containing generated SV/V/TCL artifacts")
+	dryRun := flag.Bool("dry-run", false, "print checks without running external tools")
+	flag.Parse()
+
+	files, err := discoverFiles(*dir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	p := buildPlan(files, exec.LookPath)
+	for _, skipped := range p.Skipped {
+		fmt.Println("SKIP", skipped)
+	}
+	if len(p.Commands) == 0 {
+		fmt.Println("No HDL/TCL checker available; install verilator or vivado for syntax checks.")
+		return
+	}
+	for _, cmd := range p.Commands {
+		fmt.Println(strings.Join(cmd.Args, " "))
+		if *dryRun {
+			continue
+		}
+		proc := exec.Command(cmd.Args[0], cmd.Args[1:]...)
+		proc.Stdout = os.Stdout
+		proc.Stderr = os.Stderr
+		if err := proc.Run(); err != nil {
+			fmt.Fprintln(os.Stderr, cmd.Label, "failed:", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func discoverFiles(root string) (fileSet, error) {
+	var files fileSet
+	if root == "" {
+		return files, errors.New("--dir must not be empty")
+	}
+	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		switch strings.ToLower(filepath.Ext(path)) {
+		case ".sv", ".v":
+			files.HDL = append(files.HDL, path)
+		case ".tcl":
+			files.TCL = append(files.TCL, path)
+		}
+		return nil
+	}); err != nil {
+		return files, fmt.Errorf("scan %s: %w", root, err)
+	}
+	sort.Strings(files.HDL)
+	sort.Strings(files.TCL)
+	return files, nil
+}
+
+func buildPlan(files fileSet, lookPath lookPathFunc) plan {
+	var p plan
+	if len(files.HDL) > 0 {
+		if bin, err := lookPath("verilator"); err == nil {
+			args := append([]string{bin, "--lint-only"}, files.HDL...)
+			p.Commands = append(p.Commands, commandPlan{Label: "verilator", Args: args})
+		} else {
+			p.Skipped = append(p.Skipped, "verilator not found for HDL lint")
+		}
+	}
+	if len(files.TCL) > 0 {
+		p.Skipped = append(p.Skipped, "TCL files found; Vivado parse/build scripts are not run automatically")
+	}
+	return p
+}

--- a/tools/hdlcheck/main_test.go
+++ b/tools/hdlcheck/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "a.sv"))
+	writeTestFile(t, filepath.Join(dir, "b.v"))
+	writeTestFile(t, filepath.Join(dir, "c.tcl"))
+	writeTestFile(t, filepath.Join(dir, "ignore.txt"))
+
+	files, err := discoverFiles(dir)
+	if err != nil {
+		t.Fatalf("discoverFiles failed: %v", err)
+	}
+	if len(files.HDL) != 2 || len(files.TCL) != 1 {
+		t.Fatalf("discoverFiles = %#v, want 2 HDL and 1 TCL", files)
+	}
+}
+
+func TestBuildPlanSkipsMissingTools(t *testing.T) {
+	files := fileSet{HDL: []string{"a.sv"}, TCL: []string{"build.tcl"}}
+	plan := buildPlan(files, func(string) (string, error) { return "", errors.New("missing") })
+
+	if len(plan.Commands) != 0 {
+		t.Fatalf("commands = %#v, want none", plan.Commands)
+	}
+	if len(plan.Skipped) != 2 {
+		t.Fatalf("skipped = %#v, want verilator and vivado skips", plan.Skipped)
+	}
+}
+
+func TestBuildPlanUsesAvailableVerilator(t *testing.T) {
+	files := fileSet{HDL: []string{"a.sv", "b.v"}}
+	plan := buildPlan(files, func(name string) (string, error) {
+		if name == "verilator" {
+			return "/usr/bin/verilator", nil
+		}
+		return "", errors.New("missing")
+	})
+
+	if len(plan.Commands) != 1 {
+		t.Fatalf("commands = %#v, want one", plan.Commands)
+	}
+	cmd := plan.Commands[0]
+	if cmd.Args[0] != "/usr/bin/verilator" || cmd.Args[1] != "--lint-only" {
+		t.Fatalf("unexpected command: %#v", cmd.Args)
+	}
+}
+
+func writeTestFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("module dummy; endmodule\n"), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add multi-BAR donor artifacts while preserving legacy BAR0 output
- persist MMIO traces in donor context JSON and emit `bar_model_report.json`
- merge trace-only offsets into BAR models conservatively
- infer NVMe queue/doorbell evidence from traces for SV generation
- add standalone `tools/hdlcheck` generated-HDL preflight helper

## Verification
- `go run ./tools/hdlcheck --dir tools --dry-run`
- `go test ./tools/hdlcheck`
- `go test ./...` (23 packages ok, 1 no tests)

## Notes
- This branch may overlap with existing upstream PR #44 because both touch donor/MMIO/firmware output paths.
