### PR TITLE
Fix board source path overrides

### DIFF
--- a/internal/board/board.go
+++ b/internal/board/board.go
@@ -19,6 +19,7 @@ type Board struct {
 	TopModule    string `json:"top_module"`
 	ProjectDir   string `json:"project_dir"`
 	SubDir       string `json:"sub_dir"`
+	// SourceSubDir is mutually exclusive with SubDir; it only overrides source/IP paths.
 	SourceSubDir string `json:"source_sub_dir"`
 	TCLFile      string `json:"tcl_file"`
 	BuildTCL     string `json:"build_tcl"`

--- a/internal/board/board.go
+++ b/internal/board/board.go
@@ -19,6 +19,7 @@ type Board struct {
 	TopModule    string `json:"top_module"`
 	ProjectDir   string `json:"project_dir"`
 	SubDir       string `json:"sub_dir"`
+	SourceSubDir string `json:"source_sub_dir"`
 	TCLFile      string `json:"tcl_file"`
 	BuildTCL     string `json:"build_tcl"`
 }
@@ -44,20 +45,22 @@ func (b *Board) BRAMSizeOrDefault() int {
 	return DefaultBRAMSize
 }
 
+// SourceBasePath returns the directory that contains source and IP folders.
+func (b *Board) SourceBasePath(libDir string) string {
+	if b.SourceSubDir != "" {
+		return filepath.Join(libDir, b.ProjectDir, b.SourceSubDir)
+	}
+	return b.LibPath(libDir)
+}
+
 // SrcPath returns the path to source files for this board.
 func (b *Board) SrcPath(libDir string) string {
-	if b.SubDir != "" {
-		return filepath.Join(libDir, b.ProjectDir, b.SubDir, "src")
-	}
-	return filepath.Join(libDir, b.ProjectDir, "src")
+	return filepath.Join(b.SourceBasePath(libDir), "src")
 }
 
 // IPPath returns the path to IP cores for this board.
 func (b *Board) IPPath(libDir string) string {
-	if b.SubDir != "" {
-		return filepath.Join(libDir, b.ProjectDir, b.SubDir, "ip")
-	}
-	return filepath.Join(libDir, b.ProjectDir, "ip")
+	return filepath.Join(b.SourceBasePath(libDir), "ip")
 }
 
 // TCLPath returns the full path to the Vivado project generation TCL script.

--- a/internal/board/board_embed_test.go
+++ b/internal/board/board_embed_test.go
@@ -119,6 +119,31 @@ func TestBoard_Paths(t *testing.T) {
 	}
 }
 
+func TestBoard_SourceSubDirPaths(t *testing.T) {
+	b := &Board{
+		ProjectDir:   "ZDMA",
+		SourceSubDir: "100T",
+		TCLFile:      "vivado_generate_project_100t.tcl",
+		BuildTCL:     "vivado_build_100t.tcl",
+	}
+
+	if got := b.SourceBasePath("/fpga"); got != "/fpga/ZDMA/100T" {
+		t.Errorf("SourceBasePath = %q", got)
+	}
+	if got := b.SrcPath("/fpga"); got != "/fpga/ZDMA/100T/src" {
+		t.Errorf("SrcPath = %q", got)
+	}
+	if got := b.IPPath("/fpga"); got != "/fpga/ZDMA/100T/ip" {
+		t.Errorf("IPPath = %q", got)
+	}
+	if got := b.TCLPath("/fpga"); got != "/fpga/ZDMA/vivado_generate_project_100t.tcl" {
+		t.Errorf("TCLPath = %q", got)
+	}
+	if got := b.BuildTCLPath("/fpga"); got != "/fpga/ZDMA/vivado_build_100t.tcl" {
+		t.Errorf("BuildTCLPath = %q", got)
+	}
+}
+
 func TestBoard_PathsNoSubDir(t *testing.T) {
 	b := &Board{
 		ProjectDir: "PCIeSquirrel",

--- a/internal/board/board_test.go
+++ b/internal/board/board_test.go
@@ -70,10 +70,16 @@ func TestBoardPaths(t *testing.T) {
 		t.Errorf("CaptainDMA_100T TCLPath() = %q", cdma.TCLPath(libDir))
 	}
 
-	// Board with custom BuildTCL (ZDMA)
+	// Board with source tree nested below project TCL scripts (ZDMA)
 	zdma, _ := Find("ZDMA")
 	if zdma.BuildTCLPath(libDir) != libDir+"/ZDMA/vivado_build_100t.tcl" {
 		t.Errorf("ZDMA BuildTCLPath() = %q", zdma.BuildTCLPath(libDir))
+	}
+	if zdma.SrcPath(libDir) != libDir+"/ZDMA/100T/src" {
+		t.Errorf("ZDMA SrcPath() = %q", zdma.SrcPath(libDir))
+	}
+	if zdma.IPPath(libDir) != libDir+"/ZDMA/100T/ip" {
+		t.Errorf("ZDMA IPPath() = %q", zdma.IPPath(libDir))
 	}
 }
 

--- a/internal/board/boards.json
+++ b/internal/board/boards.json
@@ -97,7 +97,8 @@
         "top_module": "pcileech_tbx4_100t_top",
         "project_dir": "ZDMA",
         "tcl_file": "vivado_generate_project_100t.tcl",
-        "build_tcl": "vivado_build_100t.tcl"
+        "build_tcl": "vivado_build_100t.tcl",
+        "source_sub_dir": "100T"
     },
     {
         "name": "GBOX",


### PR DESCRIPTION
### Motivation
- Some FPGA board repositories place Vivado TCL scripts at the project root while keeping `src`/`ip` under a nested directory, which prevented correct source/IP lookup for those boards. 
- The ZDMA board in the upstream `pcileech-fpga` layout uses a nested `100T` source tree that needs to be referenced separately from the TCL scripts. 

### Description
- Add an optional `source_sub_dir` board metadata field (`SourceSubDir` in `Board`) and a `SourceBasePath` helper so source/IP paths can be resolved independently of TCL/project paths. 
- Change `SrcPath` and `IPPath` to use `SourceBasePath` and keep `TCLPath`/`BuildTCLPath` behavior unchanged for TCL files. 
- Update `internal/board/boards.json` to set `source_sub_dir` for `ZDMA` so its sources live under `ZDMA/100T`. 
- Add and update tests (`TestBoard_SourceSubDirPaths` and adjustments to existing board path tests) in `internal/board` to cover the split TCL vs source layout. 

### Testing
- Ran `go test ./...` and all tests completed successfully. 
- Added board path tests exercising `SourceBasePath`, `SrcPath`, `IPPath`, and `TCLPath` which passed under the test run.
