### PR TITLE
Handle NVMe admin PRP2 page crossings

### DIFF
--- a/internal/firmware/svgen/nvme_responder_test.go
+++ b/internal/firmware/svgen/nvme_responder_test.go
@@ -1,0 +1,25 @@
+package svgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateNVMeResponderSV_UsesPRP2ForPageCrossingAdminData(t *testing.T) {
+	cfg := testConfig()
+
+	result, err := GenerateNVMeResponderSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateNVMeResponderSV failed: %v", err)
+	}
+
+	if !strings.Contains(result, "function [63:0] cmd_prp_addr") {
+		t.Fatal("NVMe responder should compute admin data addresses through a PRP helper")
+	}
+	if !strings.Contains(result, "{cmd_prp2[63:12], 12'h000}") {
+		t.Fatal("NVMe responder should use PRP2 for admin data crossing the first PRP page")
+	}
+	if strings.Contains(result, "dma_wr_addr  <= cmd_prp1 +") {
+		t.Fatal("NVMe responder should not write all admin data relative to PRP1 only")
+	}
+}

--- a/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
+++ b/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
@@ -111,6 +111,18 @@ module pcileech_nvme_admin_responder(
     wire [31:0] cmd_cdw11    = sqe[11];
     wire [7:0]  identify_cns = cmd_cdw10[7:0];
 
+    function [63:0] cmd_prp_addr;
+        input [12:0] data_byte_offset;
+        reg [12:0] prp_byte_offset;
+        begin
+            prp_byte_offset = {1'b0, cmd_prp1[11:0]} + data_byte_offset;
+            if (prp_byte_offset[12])
+                cmd_prp_addr = {cmd_prp2[63:12], 12'h000} + {52'h0, prp_byte_offset[11:0]};
+            else
+                cmd_prp_addr = cmd_prp1 + {51'h0, data_byte_offset};
+        end
+    endfunction
+
     // CQE we're building – 4 DWORDs, written to host one at a time
     reg [31:0]  cqe [0:3];
     reg [1:0]   cqe_dw_idx;
@@ -327,7 +339,7 @@ module pcileech_nvme_admin_responder(
                         end else begin
                             dma_wr_req   <= 1'b1;
                             dma_wr_valid <= 1'b1;
-                            dma_wr_addr  <= cmd_prp1 + {53'h0, data_dw_cnt - 11'h1, 2'b00};
+                            dma_wr_addr  <= cmd_prp_addr({data_dw_cnt - 11'h1, 2'b00});
                             dma_wr_data  <= id_rom_data;
                             dma_wr_be    <= 4'hF;
 
@@ -346,7 +358,7 @@ module pcileech_nvme_admin_responder(
                     S_EXEC_NSLIST: begin
                         dma_wr_req   <= 1'b1;
                         dma_wr_valid <= 1'b1;
-                        dma_wr_addr  <= cmd_prp1 + {53'h0, data_dw_cnt, 2'b00};
+                        dma_wr_addr  <= cmd_prp_addr({data_dw_cnt, 2'b00});
                         dma_wr_data  <= (data_dw_cnt == 11'h0) ? 32'h00000001 : 32'h0;
                         dma_wr_be    <= 4'hF;
 
@@ -364,7 +376,7 @@ module pcileech_nvme_admin_responder(
                     S_EXEC_LOGPAGE: begin
                         dma_wr_req   <= 1'b1;
                         dma_wr_valid <= 1'b1;
-                        dma_wr_addr  <= cmd_prp1 + {53'h0, data_dw_cnt, 2'b00};
+                        dma_wr_addr  <= cmd_prp_addr({data_dw_cnt, 2'b00});
                         dma_wr_be    <= 4'hF;
 
                         case (data_dw_cnt)


### PR DESCRIPTION
## Summary
- Route NVMe admin Identify, namespace-list, and SMART/log-page DMA writes through a PRP address helper.
- Use `PRP2` after the response buffer crosses the first `PRP1` page instead of writing all data relative to `PRP1`.
- Clean width-expansion/truncation issues in the generated NVMe responder and DMA bridge so both modules pass Verilator lint.
- Add generator coverage so the responder keeps using `PRP2` for page-crossing admin data.

## Root cause
The generated NVMe admin responder decoded `cmd_prp2`, but response data writes were always calculated from `cmd_prp1`. If Windows supplies an admin response buffer that starts late in a page, a 4 KiB Identify response crosses into the next page and the responder writes the tail to the wrong physical address. That can corrupt the admin response path during stornvme initialization.

## Validation
- `go test -race -count=1 ./...`
- `git diff --check`
- `verilator --lint-only -sv internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl`
- `verilator --lint-only -sv internal/firmware/svgen/templates/nvme_dma_bridge.sv.tmpl`

## Notes
This PR is intentionally scoped to the NVMe admin path. It does not change config-space writemask behavior or the cfgspace COE mismatch validation path.