### PR TITLE
Clean NVMe admin HDL width handling

### DIFF
--- a/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
+++ b/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
@@ -247,7 +247,7 @@ module pcileech_nvme_admin_responder(
                                         cqe[0] <= 32'h0;
                                         cqe[1] <= 32'h0;
                                         cqe[2] <= {cmd_cid, sq_head};
-                                        cqe[3] <= {15'h0, cq_phase};
+                                        cqe[3] <= {31'h0, cq_phase};
                                         cqe_dw_idx <= 2'h0;
                                         state  <= S_POST_CQE;
                                     end
@@ -259,7 +259,7 @@ module pcileech_nvme_admin_responder(
                                 cqe[0] <= 32'h0;
                                 cqe[1] <= 32'h0;
                                 cqe[2] <= {cmd_cid, sq_head};
-                                cqe[3] <= {15'h0, cq_phase};
+                                cqe[3] <= {31'h0, cq_phase};
                                 cqe_dw_idx <= 2'h0;
                                 state  <= S_POST_CQE;
                             end
@@ -283,7 +283,7 @@ module pcileech_nvme_admin_responder(
                                 endcase
                                 cqe[1] <= 32'h0;
                                 cqe[2] <= {cmd_cid, sq_head};
-                                cqe[3] <= {15'h0, cq_phase};
+                                cqe[3] <= {31'h0, cq_phase};
                                 cqe_dw_idx <= 2'h0;
                                 state  <= S_POST_CQE;
                             end
@@ -297,7 +297,7 @@ module pcileech_nvme_admin_responder(
                                 endcase
                                 cqe[1] <= 32'h0;
                                 cqe[2] <= {cmd_cid, sq_head};
-                                cqe[3] <= {15'h0, cq_phase};
+                                cqe[3] <= {31'h0, cq_phase};
                                 cqe_dw_idx <= 2'h0;
                                 state  <= S_POST_CQE;
                             end
@@ -308,7 +308,7 @@ module pcileech_nvme_admin_responder(
                                 if (aer_pending < 4'hF)
                                     aer_pending <= aer_pending + 1'b1;
                                 // move the SQ head along but don't post any CQE
-                                if (sq_head >= asqs)
+                                if (sq_head >= {4'h0, asqs})
                                     sq_head <= 16'h0;
                                 else
                                     sq_head <= sq_head + 1'b1;
@@ -320,7 +320,7 @@ module pcileech_nvme_admin_responder(
                                 cqe[0] <= 32'h0;
                                 cqe[1] <= 32'h0;
                                 cqe[2] <= {cmd_cid, sq_head};
-                                cqe[3] <= {15'h0, cq_phase};
+                                cqe[3] <= {31'h0, cq_phase};
                                 cqe_dw_idx <= 2'h0;
                                 state  <= S_POST_CQE;
                             end
@@ -400,7 +400,7 @@ module pcileech_nvme_admin_responder(
                         cqe[0] <= 32'h0;
                         cqe[1] <= 32'h0;
                         cqe[2] <= {cmd_cid, sq_head};
-                        cqe[3] <= {15'h0, cq_phase};
+                        cqe[3] <= {31'h0, cq_phase};
                         cqe_dw_idx <= 2'h0;
                         state  <= S_POST_CQE;
                     end
@@ -409,8 +409,8 @@ module pcileech_nvme_admin_responder(
                     S_POST_CQE: begin
                         dma_wr_req   <= 1'b1;
                         dma_wr_valid <= 1'b1;
-                        dma_wr_addr  <= acq_base + {48'h0, cq_head} * 16
-                                        + {62'h0, cqe_dw_idx, 2'b00};
+                        dma_wr_addr  <= acq_base + {44'h0, cq_head, 4'h0}
+                                        + {60'h0, cqe_dw_idx, 2'b00};
                         dma_wr_data  <= cqe[cqe_dw_idx];
                         dma_wr_be    <= 4'hF;
 
@@ -435,13 +435,13 @@ module pcileech_nvme_admin_responder(
                         msix_trigger <= 1'b1;
 
                         // wrap SQ head
-                        if (sq_head >= asqs)
+                        if (sq_head >= {4'h0, asqs})
                             sq_head <= 16'h0;
                         else
                             sq_head <= sq_head + 1'b1;
 
                         // wrap CQ head and flip the phase bit
-                        if (cq_head >= acqs) begin
+                        if (cq_head >= {4'h0, acqs}) begin
                             cq_head  <= 16'h0;
                             cq_phase <= ~cq_phase;
                         end else begin

--- a/internal/firmware/svgen/templates/nvme_dma_bridge.sv.tmpl
+++ b/internal/firmware/svgen/templates/nvme_dma_bridge.sv.tmpl
@@ -73,7 +73,7 @@ module pcileech_nvme_dma_bridge(
     // CplD receive buffer: hold up to 4 DWORDs from one 128-bit beat
     reg [31:0] rx_buf [0:3];
     reg [2:0]  rx_buf_cnt;          // how many DWORDs in buffer (0-4)
-    reg [2:0]  rx_buf_idx;          // current emit index
+    reg [1:0]  rx_buf_idx;          // current emit index
 
     always @(posedge clk) begin
         if (rst) begin
@@ -87,7 +87,7 @@ module pcileech_nvme_dma_bridge(
             rd_remaining    <= 10'h0;
             rd_tag          <= 8'h80;
             rx_buf_cnt      <= 3'h0;
-            rx_buf_idx      <= 3'h0;
+            rx_buf_idx      <= 2'h0;
         end else begin
             dma_wr_done   <= 1'b0;
             dma_rd_valid  <= 1'b0;
@@ -216,7 +216,7 @@ module pcileech_nvme_dma_bridge(
                                 // payload starts at [127:96] = 1 DWORD
                                 rx_buf[0]  <= tlp_rx_tdata[127:96];
                                 rx_buf_cnt <= 3'd1;
-                                rx_buf_idx <= 3'd0;
+                                rx_buf_idx <= 2'd0;
                                 bstate     <= B_RD_EMIT;
                             end
                         end
@@ -232,11 +232,11 @@ module pcileech_nvme_dma_bridge(
                     if (rd_remaining <= 10'd1) begin
                         dma_rd_done <= 1'b1;
                         bstate      <= B_IDLE;
-                    end else if (rx_buf_cnt == 3'd0 || rx_buf_idx >= (rx_buf_cnt - 3'd1)) begin
+                    end else if (rx_buf_cnt == 3'd0 || {1'b0, rx_buf_idx} >= (rx_buf_cnt - 3'd1)) begin
                         // buffer emptied (or was never filled), need more data from bus
                         bstate <= B_RD_DRAIN;
                     end else begin
-                        rx_buf_idx <= rx_buf_idx + 3'd1;
+                        rx_buf_idx <= rx_buf_idx + 2'd1;
                     end
                 end
 
@@ -254,7 +254,7 @@ module pcileech_nvme_dma_bridge(
                         else
                             rx_buf_cnt <= rd_remaining[2:0];
 
-                        rx_buf_idx <= 3'd0;
+                        rx_buf_idx <= 2'd0;
                         bstate     <= B_RD_EMIT;
                     end
                 end


### PR DESCRIPTION
## Summary
- Keep the NVMe admin PRP2 behavior from PR #58 intact.
- Clean width-expansion/truncation issues in the generated NVMe responder and DMA bridge so both modules pass Verilator lint.
- Make CQE phase words, queue limit comparisons, completion-queue address arithmetic, and DMA bridge receive-buffer indexing explicit-width.

## Root cause
PR #58 fixed admin response writes to use `PRP2` after crossing the first `PRP1` page. A deeper verification pass showed the generated NVMe HDL still had width warnings in the responder and DMA bridge. These are not PRP2 logic regressions, but they are avoidable synthesis/lint risks in the same admin path.

## Validation
- `go test -race -count=1 ./...`
- `git diff --check --cached`
- `git diff --check`
- `verilator --lint-only -sv internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl`
- `verilator --lint-only -sv internal/firmware/svgen/templates/nvme_dma_bridge.sv.tmpl`