### PR TITLE
Align NVMe admin compatibility data

### DIFF
--- a/internal/firmware/nvme/identify.go
+++ b/internal/firmware/nvme/identify.go
@@ -88,11 +88,11 @@ func buildIdentifyController(ids firmware.DeviceIDs, barData []byte) [4096]byte 
 	binary.LittleEndian.PutUint32(data[0x060:], 0x00000000) // CTRATT
 
 	// Admin Command Set Attributes (0x100)
-	binary.LittleEndian.PutUint16(data[0x100:], 0x0006) // OACS - Format + FW Download
+	binary.LittleEndian.PutUint16(data[0x100:], 0x0002) // OACS - Format NVM
 	data[0x102] = 3                                     // ACL
 	data[0x103] = 7                                     // AERL
 	data[0x104] = 0x14                                  // FRMW
-	data[0x105] = 0x0E                                  // LPA
+	data[0x105] = 0x00                                  // LPA - no optional log-page attributes
 	data[0x106] = 0x3F                                  // ELPE
 	data[0x107] = 0                                     // NPSS (1 power state)
 	data[0x108] = 0x01                                  // AVSCC
@@ -103,7 +103,7 @@ func buildIdentifyController(ids firmware.DeviceIDs, barData []byte) [4096]byte 
 	data[0x201] = 0x44                                  // CQES min=max=16B
 	binary.LittleEndian.PutUint16(data[0x202:], 0x0000) // MAXCMD
 	binary.LittleEndian.PutUint32(data[0x204:], 1)      // NN - 1 namespace
-	binary.LittleEndian.PutUint16(data[0x208:], 0x001F) // ONCS
+	binary.LittleEndian.PutUint16(data[0x208:], 0x000C) // ONCS - Dataset Mgmt + Write Zeroes
 	binary.LittleEndian.PutUint16(data[0x20A:], 0x0000) // FUSES
 	data[0x20C] = 0x00                                  // FNA
 	data[0x20D] = 0x01                                  // VWC present

--- a/internal/firmware/nvme/identify_test.go
+++ b/internal/firmware/nvme/identify_test.go
@@ -95,6 +95,30 @@ func TestIdentifyController_NN(t *testing.T) {
 	}
 }
 
+func TestIdentifyController_AdvertisesOnlyImplementedAdminCommands(t *testing.T) {
+	id := BuildIdentifyData(sampleIDs(), nil)
+	oacs := binary.LittleEndian.Uint16(id.Controller[0x100:])
+	if oacs != 0x0002 {
+		t.Errorf("OACS: got 0x%04X, want only Format NVM support", oacs)
+	}
+}
+
+func TestIdentifyController_AdvertisesImplementedNVMCommands(t *testing.T) {
+	id := BuildIdentifyData(sampleIDs(), nil)
+	oncs := binary.LittleEndian.Uint16(id.Controller[0x208:])
+	if oncs != 0x000C {
+		t.Errorf("ONCS: got 0x%04X, want Dataset Management and Write Zeroes only", oncs)
+	}
+}
+
+func TestIdentifyController_AdvertisesConservativeLogPageAttributes(t *testing.T) {
+	id := BuildIdentifyData(sampleIDs(), nil)
+	lpa := id.Controller[0x105]
+	if lpa != 0x00 {
+		t.Errorf("LPA: got 0x%02X, want no optional log-page attributes", lpa)
+	}
+}
+
 func TestIdentifyController_Version(t *testing.T) {
 	// nil BAR data -> default NVMe 1.4
 	id := BuildIdentifyData(sampleIDs(), nil)

--- a/internal/firmware/svgen/nvme_responder_test.go
+++ b/internal/firmware/svgen/nvme_responder_test.go
@@ -45,3 +45,31 @@ func TestGenerateNVMeResponderSV_HandlesFormattingIOQueuePath(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateNVMeResponderSV_HandlesCompatibilityLogsAndFeatures(t *testing.T) {
+	cfg := testConfig()
+
+	result, err := GenerateNVMeResponderSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateNVMeResponderSV failed: %v", err)
+	}
+
+	for _, want := range []string{
+		"log_page_id",
+		"log_dw_limit",
+		"8'h01: dma_wr_data <= 32'h0;",
+		"8'h03: dma_wr_data <= (data_dw_cnt == 11'h0) ? 32'h00000001 : 32'h0;",
+		"8'h04: dma_wr_data <= 32'h0;",
+		"volatile_write_cache_enabled",
+		"async_event_config",
+		"8'h06:   cqe[0] <= {31'h0, volatile_write_cache_enabled};",
+		"8'h08:   cqe[0] <= interrupt_coalescing;",
+		"8'h09:   cqe[0] <= interrupt_vector_config;",
+		"8'h0B:   cqe[0] <= async_event_config;",
+		"8'h0F:   cqe[0] <= keep_alive_timer;",
+	} {
+		if !strings.Contains(result, want) {
+			t.Fatalf("NVMe responder should contain %q", want)
+		}
+	}
+}

--- a/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
+++ b/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
@@ -142,6 +142,8 @@ module pcileech_nvme_admin_responder(
     // transfer progress
     reg [10:0]  data_dw_cnt;
     reg [10:0]  io_zero_dw_limit;
+    reg [10:0]  log_dw_limit;
+    reg [7:0]   log_page_id;
     reg [12:0]  id_rom_offset;
 
     // edge detect for CC.EN so we can do a clean shutdown
@@ -167,6 +169,12 @@ module pcileech_nvme_admin_responder(
     // Set/Get Features Number of Queues must be consistent - stornvme sets
     // the desired count then reads it back.  We clamp to what CAP.MQES allows.
     reg [31:0]  num_queues_granted;
+    reg         volatile_write_cache_enabled;
+    reg [31:0]  interrupt_coalescing;
+    reg [31:0]  interrupt_vector_config;
+    reg [31:0]  write_atomicity_normal;
+    reg [31:0]  async_event_config;
+    reg [31:0]  keep_alive_timer;
 
     always @(posedge clk) begin
         if (rst) begin
@@ -188,11 +196,19 @@ module pcileech_nvme_admin_responder(
             cqe_dw_idx      <= 2'h0;
             data_dw_cnt     <= 11'h0;
             io_zero_dw_limit <= 11'h0;
+            log_dw_limit    <= 11'd128;
+            log_page_id     <= 8'h02;
             id_rom_offset   <= 13'h0;
             id_rom_addr     <= 13'h0;
             cc_en_prev      <= 1'b0;
             aer_pending     <= 4'h0;
             num_queues_granted <= 32'h00010001;  // default: 1 SQ + 1 CQ
+            volatile_write_cache_enabled <= 1'b1;
+            interrupt_coalescing <= 32'h0;
+            interrupt_vector_config <= 32'h0;
+            write_atomicity_normal <= 32'h0;
+            async_event_config <= 32'h0;
+            keep_alive_timer <= 32'h0;
             iosq_base       <= 64'h0;
             iocq_base       <= 64'h0;
             iosq_size       <= 16'h0;
@@ -324,7 +340,12 @@ module pcileech_nvme_admin_responder(
 
                             // Get Log Page
                             8'h02: begin
+                                log_page_id <= cmd_cdw10[7:0];
                                 data_dw_cnt <= 11'h0;
+                                if (cmd_cdw10[31:16] >= 16'd1023)
+                                    log_dw_limit <= 11'd1024;
+                                else
+                                    log_dw_limit <= {1'b0, cmd_cdw10[25:16]} + 11'd1;
                                 state       <= S_EXEC_LOGPAGE;
                             end
 
@@ -400,15 +421,34 @@ module pcileech_nvme_admin_responder(
                                 case (cmd_cdw10[7:0])
                                     8'h04:   cqe[0] <= 32'h0;            // temp threshold
                                     8'h05:   cqe[0] <= 32'h0;            // error recovery
-                                    8'h06:   cqe[0] <= cmd_cdw11;        // volatile write cache
+                                    8'h06: begin                           // volatile write cache
+                                        volatile_write_cache_enabled <= cmd_cdw11[0];
+                                        cqe[0] <= {31'h0, cmd_cdw11[0]};
+                                    end
                                     8'h07: begin                           // number of queues
                                         num_queues_granted <= cmd_cdw11;
                                         cqe[0] <= cmd_cdw11;
                                     end
-                                    8'h08:   cqe[0] <= 32'h0;            // interrupt vector config
-                                    8'h09:   cqe[0] <= 32'h0;            // write atomicity
-                                    8'h0B:   cqe[0] <= 32'h0;            // interrupt coalescing
-                                    8'h0F:   cqe[0] <= 32'h0;            // keep alive timer
+                                    8'h08: begin                           // interrupt coalescing
+                                        interrupt_coalescing <= cmd_cdw11;
+                                        cqe[0] <= cmd_cdw11;
+                                    end
+                                    8'h09: begin                           // interrupt vector config
+                                        interrupt_vector_config <= cmd_cdw11;
+                                        cqe[0] <= cmd_cdw11;
+                                    end
+                                    8'h0A: begin                           // write atomicity normal
+                                        write_atomicity_normal <= cmd_cdw11;
+                                        cqe[0] <= cmd_cdw11;
+                                    end
+                                    8'h0B: begin                           // async event config
+                                        async_event_config <= cmd_cdw11;
+                                        cqe[0] <= cmd_cdw11;
+                                    end
+                                    8'h0F: begin                           // keep alive timer
+                                        keep_alive_timer <= cmd_cdw11;
+                                        cqe[0] <= cmd_cdw11;
+                                    end
                                     default: cqe[0] <= 32'h0;
                                 endcase
                                 cqe[1] <= 32'h0;
@@ -421,8 +461,15 @@ module pcileech_nvme_admin_responder(
                             // Get Features
                             8'h0A: begin
                                 case (cmd_cdw10[7:0])
+                                    8'h04:   cqe[0] <= 32'h00000135;  // 35C warning threshold
+                                    8'h05:   cqe[0] <= 32'h0;  // no error recovery timeout
+                                    8'h06:   cqe[0] <= {31'h0, volatile_write_cache_enabled};
                                     8'h07:   cqe[0] <= num_queues_granted;  // echo last Set Features value
-                                    8'h0B:   cqe[0] <= 32'h00000000;  // coalescing off
+                                    8'h08:   cqe[0] <= interrupt_coalescing;
+                                    8'h09:   cqe[0] <= interrupt_vector_config;
+                                    8'h0A:   cqe[0] <= write_atomicity_normal;
+                                    8'h0B:   cqe[0] <= async_event_config;
+                                    8'h0F:   cqe[0] <= keep_alive_timer;
                                     default: cqe[0] <= 32'h0;
                                 endcase
                                 cqe[1] <= 32'h0;
@@ -513,22 +560,29 @@ module pcileech_nvme_admin_responder(
                         state <= S_WAIT_DMA_WR;
                     end
 
-                    // ---- SMART health log: "everything is fine" -------------
-                    // 512B of mostly zeros with temperature ~35°C and full spare
+                    // ---- common admin logs: error, SMART, firmware, NS list -
                     S_EXEC_LOGPAGE: begin
                         dma_wr_req   <= 1'b1;
                         dma_wr_valid <= 1'b1;
                         dma_wr_addr  <= cmd_prp_addr({data_dw_cnt, 2'b00});
                         dma_wr_be    <= 4'hF;
 
-                        case (data_dw_cnt)
-                            11'h000: dma_wr_data <= 32'h01340000;  // temp=308K (35°C), no warnings
-                            11'h001: dma_wr_data <= 32'h00640064;  // 100% spare, 100% threshold
-                            11'h002: dma_wr_data <= 32'h00000000;  // 0% used
-                            default: dma_wr_data <= 32'h00000000;
+                        case (log_page_id)
+                            8'h01: dma_wr_data <= 32'h0;
+                            8'h02: begin
+                                case (data_dw_cnt)
+                                    11'h000: dma_wr_data <= 32'h01340000;  // temp=308K (35C), no warnings
+                                    11'h001: dma_wr_data <= 32'h00640064;  // 100% spare, 100% threshold
+                                    11'h002: dma_wr_data <= 32'h00000000;  // 0% used
+                                    default: dma_wr_data <= 32'h00000000;
+                                endcase
+                            end
+                            8'h03: dma_wr_data <= (data_dw_cnt == 11'h0) ? 32'h00000001 : 32'h0;
+                            8'h04: dma_wr_data <= 32'h0;
+                            default: dma_wr_data <= 32'h0;
                         endcase
 
-                        if (data_dw_cnt >= 11'd127) begin
+                        if (data_dw_cnt >= log_dw_limit - 11'd1) begin
                             return_state <= S_WRITE_DATA;
                         end else begin
                             data_dw_cnt  <= data_dw_cnt + 1'b1;


### PR DESCRIPTION
## Summary
- Stop advertising NVMe admin/NVM capabilities that the generated responder does not implement.
- Add stable Get Features/Set Features state for common Windows probes such as volatile write cache, interrupt coalescing/vector config, async events, and keep-alive.
- Make Get Log Page length-aware and return safe minimal data for error, SMART, firmware slot, and changed namespace logs.

## Why
The responder should avoid inviting host behavior it cannot complete, while still answering the low-risk admin probes Windows commonly sends during controller initialization and format setup.

## Validation
- `go test -race -count=1 ./...`
- `git diff --check`
- `verilator --lint-only -sv internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl`
- `go run ./cmd/pcileechgen build --from-json testdata/donors/nvme.json --board CaptainDMA_100T --output /tmp/pcileechgen-nvme-compat-smoke --skip-vivado`