### PR TITLE
Expose NVMe diagnostic registers

### DIFF
--- a/cmd/pcileechgen/boards.go
+++ b/cmd/pcileechgen/boards.go
@@ -1,35 +1,88 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 	"text/tabwriter"
 
 	"github.com/sercanarga/pcileechgen/internal/board"
 	"github.com/spf13/cobra"
 )
 
+var boardsJSON bool
+
 var boardsCmd = &cobra.Command{
 	Use:   "boards",
 	Short: "List all supported FPGA boards",
 	Long:  "Displays all supported pcileech-fpga board variants with their FPGA part and PCIe lane configuration.",
-	Run: func(cmd *cobra.Command, args []string) {
-		boards := board.All()
-
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tFPGA PART\tPCIe\tBRAM\tTOP MODULE")
-		fmt.Fprintln(w, "----\t---------\t----\t----\t----------")
-
-		for _, b := range boards {
-			fmt.Fprintf(w, "%s\t%s\tx%d\t%d\t%s\n",
-				b.Name, b.FPGAPart, b.PCIeLanes, b.BRAMSizeOrDefault(), b.TopModule)
-		}
-		w.Flush()
-
-		fmt.Printf("\nTotal: %d boards\n", len(boards))
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runBoards(cmd.OutOrStdout(), boardsJSON)
 	},
 }
 
+type boardInfo struct {
+	Name         string `json:"name"`
+	FPGAPart     string `json:"fpga_part"`
+	PCIeLanes    int    `json:"pcie_lanes"`
+	MaxLinkSpeed uint8  `json:"max_link_speed"`
+	BRAMSize     int    `json:"bram_size"`
+	TopModule    string `json:"top_module"`
+	ProjectDir   string `json:"project_dir"`
+	SubDir       string `json:"sub_dir,omitempty"`
+	SourceSubDir string `json:"source_sub_dir,omitempty"`
+	TCLFile      string `json:"tcl_file"`
+	BuildTCL     string `json:"build_tcl,omitempty"`
+}
+
+func runBoards(out io.Writer, jsonOutput bool) error {
+	boards := board.All()
+	if jsonOutput {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(boardInfos(boards)); err != nil {
+			return fmt.Errorf("render boards JSON: %w", err)
+		}
+		return nil
+	}
+
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tFPGA PART\tPCIe\tBRAM\tTOP MODULE")
+	fmt.Fprintln(w, "----\t---------\t----\t----\t----------")
+
+	for _, b := range boards {
+		fmt.Fprintf(w, "%s\t%s\tx%d\t%d\t%s\n",
+			b.Name, b.FPGAPart, b.PCIeLanes, b.BRAMSizeOrDefault(), b.TopModule)
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("render boards table: %w", err)
+	}
+
+	fmt.Fprintf(out, "\nTotal: %d boards\n", len(boards))
+	return nil
+}
+
+func boardInfos(boards []board.Board) []boardInfo {
+	infos := make([]boardInfo, 0, len(boards))
+	for _, b := range boards {
+		infos = append(infos, boardInfo{
+			Name:         b.Name,
+			FPGAPart:     b.FPGAPart,
+			PCIeLanes:    b.PCIeLanes,
+			MaxLinkSpeed: b.MaxLinkSpeedOrDefault(),
+			BRAMSize:     b.BRAMSizeOrDefault(),
+			TopModule:    b.TopModule,
+			ProjectDir:   b.ProjectDir,
+			SubDir:       b.SubDir,
+			SourceSubDir: b.SourceSubDir,
+			TCLFile:      b.TCLFile,
+			BuildTCL:     b.BuildTCL,
+		})
+	}
+	return infos
+}
+
 func init() {
+	boardsCmd.Flags().BoolVar(&boardsJSON, "json", false, "emit machine-readable board definitions")
 	rootCmd.AddCommand(boardsCmd)
 }

--- a/cmd/pcileechgen/boards_test.go
+++ b/cmd/pcileechgen/boards_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/board"
+)
+
+func TestRunBoardsJSON_EmitsMachineReadableBoards(t *testing.T) {
+	var out bytes.Buffer
+
+	if err := runBoards(&out, true); err != nil {
+		t.Fatalf("runBoards returned error: %v", err)
+	}
+
+	var got []boardInfo
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("boards JSON did not decode: %v", err)
+	}
+	if len(got) != len(board.All()) {
+		t.Fatalf("board count = %d, want %d", len(got), len(board.All()))
+	}
+	if got[0].Name == "" || got[0].FPGAPart == "" || got[0].TopModule == "" || got[0].BRAMSize <= 0 {
+		t.Fatalf("first board missing required fields: %+v", got[0])
+	}
+}

--- a/cmd/pcileechgen/mmio_trace.go
+++ b/cmd/pcileechgen/mmio_trace.go
@@ -26,6 +26,7 @@ type mmioTraceOptions struct {
 	jsonOutput bool
 	outputFile string
 	traceFile  string
+	format     string
 }
 
 var mmioTraceOpts mmioTraceOptions
@@ -38,7 +39,7 @@ var mmioTraceCmd = &cobra.Command{
 Example:
   pcileechgen mmio-trace --bdf 0000:03:00.0 --duration 5s
   pcileechgen mmio-trace --bdf 03:00.0 --bar-size 4096 --class-code 0x010802
-  pcileechgen mmio-trace --trace-file mmiotrace.txt --bar-base 0xf7800000 --bar-index 2 --json`,
+  pcileechgen mmio-trace --trace-file mmiotrace.txt --format mmio2verilog --bar-base 0xf7800000 --bar-index 2 --json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if mmioTraceOpts.traceFile == "" {
 			if _, err := pci.ParseBDF(mmioTraceOpts.bdf); err != nil {
@@ -64,8 +65,12 @@ Example:
 		if err != nil {
 			return err
 		}
+		traceFormat, err := parseTraceFormat(mmioTraceOpts.format)
+		if err != nil {
+			return err
+		}
 
-		trace, err := loadMMIOTrace(mmioTraceOpts, barBase)
+		trace, err := loadMMIOTrace(mmioTraceOpts, barBase, traceFormat)
 		if err != nil {
 			return err
 		}
@@ -105,7 +110,7 @@ Example:
 	},
 }
 
-func loadMMIOTrace(opts mmioTraceOptions, barBase uint64) (*mmio.TraceResult, error) {
+func loadMMIOTrace(opts mmioTraceOptions, barBase uint64, format mmio.TraceFormat) (*mmio.TraceResult, error) {
 	if opts.traceFile != "" {
 		f, err := os.Open(opts.traceFile)
 		if err != nil {
@@ -118,6 +123,7 @@ func loadMMIOTrace(opts mmioTraceOptions, barBase uint64) (*mmio.TraceResult, er
 			BARIndex: opts.barIndex,
 			BARSize:  opts.barSize,
 			BARBase:  barBase,
+			Format:   format,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("parse trace file %q: %w", opts.traceFile, err)
@@ -136,6 +142,18 @@ func loadMMIOTrace(opts mmioTraceOptions, barBase uint64) (*mmio.TraceResult, er
 	trace.Duration = opts.duration
 	trace.StartTime = start
 	return trace, nil
+}
+
+func parseTraceFormat(raw string) (mmio.TraceFormat, error) {
+	if strings.TrimSpace(raw) == "" {
+		return mmio.TraceFormatAuto, nil
+	}
+
+	format := mmio.TraceFormat(strings.ToLower(strings.TrimSpace(raw)))
+	if !format.Valid() {
+		return "", fmt.Errorf("invalid --format %q (expected auto, mmiotrace, or mmio2verilog)", raw)
+	}
+	return format, nil
 }
 
 func parseTraceClassCode(raw string) (uint32, error) {
@@ -210,6 +228,7 @@ func init() {
 	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.classCode, "class-code", "", "PCI class code in hex (e.g. 0x010802)")
 	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.outputFile, "output", "", "save raw trace JSON to file")
 	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.traceFile, "trace-file", "", "analyze an existing mmiotrace text file instead of capturing live")
+	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.format, "format", "auto", "offline trace format: auto, mmiotrace, or mmio2verilog")
 	mmioTraceCmd.Flags().BoolVar(&mmioTraceOpts.jsonOutput, "json", false, "emit machine-readable report")
 	rootCmd.AddCommand(mmioTraceCmd)
 }

--- a/cmd/pcileechgen/mmio_trace_test.go
+++ b/cmd/pcileechgen/mmio_trace_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
 )
 
 func TestParseTraceBARBase(t *testing.T) {
@@ -28,7 +30,7 @@ func TestLoadMMIOTrace_FromTraceFile(t *testing.T) {
 		barIndex:  2,
 		barSize:   4096,
 		traceFile: tracePath,
-	}, 0xf7800000)
+	}, 0xf7800000, mmio.TraceFormatMMIO2Verilog)
 
 	if err != nil {
 		t.Fatalf("loadMMIOTrace returned error: %v", err)

--- a/docs/source-audit.md
+++ b/docs/source-audit.md
@@ -1,0 +1,53 @@
+# External Source Audit
+
+This audit records which ideas from related public projects are suitable for
+PCILeechGen and which are intentionally out of scope. External repositories are
+reference material only; code is not copied without a license review and a local
+test that proves the adapted behavior.
+
+## Safety Boundary
+
+PCILeechGen supports educational and research firmware generation, donor
+profiling, artifact validation, board metadata, and driver-compatibility
+diagnostics. It must not add features whose purpose is anti-cheat bypass,
+unauthorized memory access, activation locks, game cheating, detection evasion,
+or fake activity generation for bypass claims.
+
+## Adapted Sources
+
+| Source | Useful idea | Decision | Local surface |
+| --- | --- | --- | --- |
+| `ret2c/MMIO2Verilog` | Text MMIO traces can seed BAR behavior models. | Adapt trace format support; do not copy generated Verilog. | `internal/donor/mmio`, `pcileechgen mmio-trace --format mmio2verilog` |
+| `Shocka-Zulu/Bar2Verilog` | BAR binary dumps can produce static read maps. | Keep as future importer input; generate through `BARModel`, not raw pasted HDL. | `internal/firmware/barmodel` |
+| `Ap3x/PCIeConfigSpace` and `Simonrak/writemask.it` | Config-space dumps and write masks are useful validation inputs. | Future work: typed importers for sanitized dump formats. | `internal/pci`, `internal/firmware/codegen` |
+| `Moer2831/PCILeechFWGenerator` | Guided workflows, board checks, manifests, and validation improve UX. | Already aligned; adapt only safe UX/validation ideas. | `cmd/pcileechgen`, `internal/firmware/output` |
+| `Shocka-Zulu/DevicePopulation` | Population data can guide donor class/profile prioritization. | Use only aggregate class/profile prioritization, not identity spoofing claims. | `internal/firmware/devclass` |
+| `ufrisk/pcileech` and `ufrisk/pcileech-fpga` | Upstream protocol and FPGA framework behavior. | Treat as primary compatibility reference. | `lib/pcileech-fpga`, generated SV/TCL |
+| `Moer2831/pcileech-nvme`, `16SalomonArs/Pcileech-DMA-NVMe-VMD`, `rick-heig/eNVMe` | NVMe register, queue, identify, and diagnostics behavior. | Adapt spec-faithful NVMe behavior only. Exclude VMD/bypass claims. | `internal/firmware/nvme`, `internal/firmware/svgen` |
+| `ret2c/pcileech-rt5392`, `ekknod/pcileech-wifi`, Wi-Fi forks | Device-class BAR and interrupt examples. | Adapt class-profile patterns only when backed by public driver/spec behavior. | `internal/firmware/devclass`, `internal/firmware/barmodel` |
+| `noy00y/PCILeech-Litefury`, board/TCL forks | Additional board metadata and build scripts. | Add boards only after source path, top module, part, lane count, and BRAM size validate. | `internal/board/boards.json`, `pcileechgen boards --json` |
+
+## Excluded Sources
+
+Repositories or documents framed around anti-cheat bypass, game cheating,
+activation cracking, fake device activity for evasion, or unauthorized memory
+operations are not implementation sources. They may be listed in the audit only
+to explain exclusion and prevent accidental feature creep.
+
+Examples from the supplied list that require exclusion or heavy filtering:
+
+- `Pcileech-Intel-I226-V-FullEmu`
+- `Pcileech-DMA-Unblocker`
+- `VGK-DMA-BYPASS`
+- `DMA-Activator*`
+- `mcp_server_pcileech`
+- anti-cheat detector/bypass repositories
+
+## Acceptance Rule
+
+Every future adaptation from this audit needs:
+
+1. A source entry in this file.
+2. A license/safety decision before implementation.
+3. A Go test or HDL lint fixture proving the local behavior.
+4. Generated output through PCILeechGen templates and models, not copied HDL.

--- a/internal/donor/mmio/import.go
+++ b/internal/donor/mmio/import.go
@@ -14,11 +14,27 @@ type TextTraceOptions struct {
 	BARIndex int
 	BARSize  int
 	BARBase  uint64
+	Format   TraceFormat
 }
+
+type TraceFormat string
+
+const (
+	TraceFormatAuto         TraceFormat = "auto"
+	TraceFormatLive         TraceFormat = "mmiotrace"
+	TraceFormatMMIO2Verilog TraceFormat = "mmio2verilog"
+)
 
 func ParseTextTrace(r io.Reader, opts TextTraceOptions) (*TraceResult, error) {
 	if r == nil {
 		return nil, fmt.Errorf("trace reader is nil")
+	}
+	format := opts.Format
+	if format == "" {
+		format = TraceFormatAuto
+	}
+	if !format.Valid() {
+		return nil, fmt.Errorf("unsupported trace format %q", format)
 	}
 
 	trace := &TraceResult{
@@ -31,7 +47,7 @@ func ParseTextTrace(r io.Reader, opts TextTraceOptions) (*TraceResult, error) {
 	var last time.Duration
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		rec, ok := parseTextTraceLine(scanner.Text(), opts.BARBase)
+		rec, ok := parseTextTraceLine(scanner.Text(), opts.BARBase, format)
 		if !ok {
 			continue
 		}
@@ -54,7 +70,11 @@ func ParseTextTrace(r io.Reader, opts TextTraceOptions) (*TraceResult, error) {
 	return trace, nil
 }
 
-func parseTextTraceLine(line string, barBase uint64) (AccessRecord, bool) {
+func (f TraceFormat) Valid() bool {
+	return f == TraceFormatAuto || f == TraceFormatLive || f == TraceFormatMMIO2Verilog
+}
+
+func parseTextTraceLine(line string, barBase uint64, format TraceFormat) (AccessRecord, bool) {
 	fields := strings.Fields(strings.TrimSpace(line))
 	if len(fields) < 5 {
 		return AccessRecord{}, false
@@ -70,7 +90,7 @@ func parseTextTraceLine(line string, barBase uint64) (AccessRecord, bool) {
 		return AccessRecord{}, false
 	}
 
-	addrField, valueField, ok := traceAddressValueFields(fields)
+	addrField, valueField, ok := traceAddressValueFields(fields, format)
 	if !ok {
 		return AccessRecord{}, false
 	}
@@ -93,11 +113,11 @@ func parseTextTraceLine(line string, barBase uint64) (AccessRecord, bool) {
 	return rec, true
 }
 
-func traceAddressValueFields(fields []string) (string, string, bool) {
-	if strings.HasPrefix(fields[3], "0x") {
+func traceAddressValueFields(fields []string, format TraceFormat) (string, string, bool) {
+	if format != TraceFormatMMIO2Verilog && strings.HasPrefix(fields[3], "0x") {
 		return fields[3], fields[4], true
 	}
-	if len(fields) >= 6 && strings.HasPrefix(fields[4], "0x") {
+	if format != TraceFormatLive && len(fields) >= 6 && strings.HasPrefix(fields[4], "0x") {
 		return fields[4], fields[5], true
 	}
 	return "", "", false

--- a/internal/donor/mmio/import_test.go
+++ b/internal/donor/mmio/import_test.go
@@ -36,6 +36,30 @@ func TestParseTextTrace_Ret2cShapeWithBARBase(t *testing.T) {
 	}
 }
 
+func TestParseTextTrace_RejectsLiveShapeWhenFormatIsMMIO2Verilog(t *testing.T) {
+	input := strings.NewReader("R 4 1234567.890 0xfee00100 0x00000001 extra\n")
+
+	_, err := ParseTextTrace(input, TextTraceOptions{
+		Format: TraceFormatMMIO2Verilog,
+	})
+
+	if err == nil {
+		t.Fatal("expected explicit MMIO2Verilog format to reject live trace shape")
+	}
+}
+
+func TestParseTextTrace_RejectsMMIO2VerilogShapeWhenFormatIsLive(t *testing.T) {
+	input := strings.NewReader("R 4 2456.105919 2 0xf780010c 0x4c02 0x0 0\n")
+
+	_, err := ParseTextTrace(input, TextTraceOptions{
+		Format: TraceFormatLive,
+	})
+
+	if err == nil {
+		t.Fatal("expected explicit live format to reject MMIO2Verilog trace shape")
+	}
+}
+
 func TestParseTextTrace_LiveTracePipeShape(t *testing.T) {
 	input := strings.NewReader("R 4 1234567.890 0xfee00100 0x00000001 extra\n")
 

--- a/internal/donor/mmio/trace_live.go
+++ b/internal/donor/mmio/trace_live.go
@@ -96,5 +96,5 @@ func LiveTrace(bdf string, duration time.Duration) (*TraceResult, error) {
 
 // parseMMIOTraceLine parses one mmiotrace line (R/W <width> <ts> <addr> <val>).
 func parseMMIOTraceLine(line string) (AccessRecord, bool) {
-	return parseTextTraceLine(line, 0)
+	return parseTextTraceLine(line, 0, TraceFormatLive)
 }

--- a/internal/firmware/nvme/identify.go
+++ b/internal/firmware/nvme/identify.go
@@ -88,11 +88,11 @@ func buildIdentifyController(ids firmware.DeviceIDs, barData []byte) [4096]byte 
 	binary.LittleEndian.PutUint32(data[0x060:], 0x00000000) // CTRATT
 
 	// Admin Command Set Attributes (0x100)
-	binary.LittleEndian.PutUint16(data[0x100:], 0x0006) // OACS - Format + FW Download
+	binary.LittleEndian.PutUint16(data[0x100:], 0x0002) // OACS - Format NVM
 	data[0x102] = 3                                     // ACL
 	data[0x103] = 7                                     // AERL
 	data[0x104] = 0x14                                  // FRMW
-	data[0x105] = 0x0E                                  // LPA
+	data[0x105] = 0x00                                  // LPA - no optional log-page attributes
 	data[0x106] = 0x3F                                  // ELPE
 	data[0x107] = 0                                     // NPSS (1 power state)
 	data[0x108] = 0x01                                  // AVSCC
@@ -103,7 +103,7 @@ func buildIdentifyController(ids firmware.DeviceIDs, barData []byte) [4096]byte 
 	data[0x201] = 0x44                                  // CQES min=max=16B
 	binary.LittleEndian.PutUint16(data[0x202:], 0x0000) // MAXCMD
 	binary.LittleEndian.PutUint32(data[0x204:], 1)      // NN - 1 namespace
-	binary.LittleEndian.PutUint16(data[0x208:], 0x001F) // ONCS
+	binary.LittleEndian.PutUint16(data[0x208:], 0x000C) // ONCS - Dataset Mgmt + Write Zeroes
 	binary.LittleEndian.PutUint16(data[0x20A:], 0x0000) // FUSES
 	data[0x20C] = 0x00                                  // FNA
 	data[0x20D] = 0x01                                  // VWC present

--- a/internal/firmware/nvme/identify_test.go
+++ b/internal/firmware/nvme/identify_test.go
@@ -95,6 +95,30 @@ func TestIdentifyController_NN(t *testing.T) {
 	}
 }
 
+func TestIdentifyController_AdvertisesOnlyImplementedAdminCommands(t *testing.T) {
+	id := BuildIdentifyData(sampleIDs(), nil)
+	oacs := binary.LittleEndian.Uint16(id.Controller[0x100:])
+	if oacs != 0x0002 {
+		t.Errorf("OACS: got 0x%04X, want only Format NVM support", oacs)
+	}
+}
+
+func TestIdentifyController_AdvertisesImplementedNVMCommands(t *testing.T) {
+	id := BuildIdentifyData(sampleIDs(), nil)
+	oncs := binary.LittleEndian.Uint16(id.Controller[0x208:])
+	if oncs != 0x000C {
+		t.Errorf("ONCS: got 0x%04X, want Dataset Management and Write Zeroes only", oncs)
+	}
+}
+
+func TestIdentifyController_AdvertisesConservativeLogPageAttributes(t *testing.T) {
+	id := BuildIdentifyData(sampleIDs(), nil)
+	lpa := id.Controller[0x105]
+	if lpa != 0x00 {
+		t.Errorf("LPA: got 0x%02X, want no optional log-page attributes", lpa)
+	}
+}
+
 func TestIdentifyController_Version(t *testing.T) {
 	// nil BAR data -> default NVMe 1.4
 	id := BuildIdentifyData(sampleIDs(), nil)

--- a/internal/firmware/svgen/generator.go
+++ b/internal/firmware/svgen/generator.go
@@ -96,6 +96,28 @@ func (c *SVGeneratorConfig) NVMeCQ1DoorbellOffset() uint32 {
 	return dbBase + 3*stride
 }
 
+func (c *SVGeneratorConfig) NVMeDiagBaseOffset() uint32 {
+	stride := uint32(4) << c.NVMeDoorbellStride
+	dbBase := uint32(board.DefaultBRAMSize)
+	return dbBase + 4*stride
+}
+
+func (c *SVGeneratorConfig) NVMeDiagLastCommandOffset() uint32 {
+	return c.NVMeDiagBaseOffset() + 0x4
+}
+
+func (c *SVGeneratorConfig) NVMeDiagLastNSIDOffset() uint32 {
+	return c.NVMeDiagBaseOffset() + 0x8
+}
+
+func (c *SVGeneratorConfig) NVMeDiagLastCDW10Offset() uint32 {
+	return c.NVMeDiagBaseOffset() + 0xC
+}
+
+func (c *SVGeneratorConfig) NVMeDiagQueueStateOffset() uint32 {
+	return c.NVMeDiagBaseOffset() + 0x10
+}
+
 func renderTemplate(name string, data any) (string, error) {
 	tmplStr := mustReadTemplate(name + ".sv.tmpl")
 	tmpl, err := template.New(name).Funcs(svFuncMap()).Parse(tmplStr)

--- a/internal/firmware/svgen/nvme_controller_test.go
+++ b/internal/firmware/svgen/nvme_controller_test.go
@@ -44,12 +44,14 @@ func TestGenerateBarControllerSV_ExposesNVMeDiagnostics(t *testing.T) {
 
 	for _, want := range []string{
 		"nvme_diag_addr_hit",
+		"nvme_diag_wr_addr_hit",
 		"nvme_diag_data",
 		"32'h00001010",
 		"32'h00001014",
 		"nvme_debug_status",
 		"nvme_debug_last_cmd",
 		"nvme_debug_queue_state",
+		".wr_valid       ( wr_valid && wr_bar[0] && !nvme_diag_wr_addr_hit )",
 		".debug_last_cdw10",
 	} {
 		if !strings.Contains(result, want) {

--- a/internal/firmware/svgen/nvme_controller_test.go
+++ b/internal/firmware/svgen/nvme_controller_test.go
@@ -4,12 +4,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sercanarga/pcileechgen/internal/firmware/barmodel"
 	"github.com/sercanarga/pcileechgen/internal/firmware/nvme"
 )
 
 func TestGenerateBarControllerSV_WiresNVMeQID1Doorbells(t *testing.T) {
 	cfg := testConfig()
 	cfg.NVMeIdentify = &nvme.IdentifyData{}
+	cfg.BARModel = &barmodel.BARModel{Size: 0x4000}
 	cfg.NVMeDoorbellStride = 0
 
 	result, err := GenerateBarControllerSV(cfg)
@@ -25,6 +27,33 @@ func TestGenerateBarControllerSV_WiresNVMeQID1Doorbells(t *testing.T) {
 	} {
 		if !strings.Contains(result, want) {
 			t.Fatalf("NVMe bar controller should contain %q", want)
+		}
+	}
+}
+
+func TestGenerateBarControllerSV_ExposesNVMeDiagnostics(t *testing.T) {
+	cfg := testConfig()
+	cfg.NVMeIdentify = &nvme.IdentifyData{}
+	cfg.BARModel = &barmodel.BARModel{Size: 0x4000}
+	cfg.NVMeDoorbellStride = 0
+
+	result, err := GenerateBarControllerSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarControllerSV failed: %v", err)
+	}
+
+	for _, want := range []string{
+		"nvme_diag_addr_hit",
+		"nvme_diag_data",
+		"32'h00001010",
+		"32'h00001014",
+		"nvme_debug_status",
+		"nvme_debug_last_cmd",
+		"nvme_debug_queue_state",
+		".debug_last_cdw10",
+	} {
+		if !strings.Contains(result, want) {
+			t.Fatalf("NVMe bar controller should contain diagnostic wiring %q", want)
 		}
 	}
 }

--- a/internal/firmware/svgen/nvme_doorbell_test.go
+++ b/internal/firmware/svgen/nvme_doorbell_test.go
@@ -20,3 +20,22 @@ func TestNVMeDoorbellOffsets_QID1(t *testing.T) {
 		t.Errorf("CQ1 doorbell (stride=1) = 0x%X, want 0x1018", got)
 	}
 }
+
+func TestNVMeDiagnosticOffsets_FollowDoorbellStride(t *testing.T) {
+	cfg := &SVGeneratorConfig{NVMeDoorbellStride: 0}
+
+	if got := cfg.NVMeDiagBaseOffset(); got != 0x1010 {
+		t.Errorf("diagnostic base = 0x%X, want 0x1010", got)
+	}
+	if got := cfg.NVMeDiagLastCommandOffset(); got != 0x1014 {
+		t.Errorf("last command diagnostic = 0x%X, want 0x1014", got)
+	}
+
+	cfg.NVMeDoorbellStride = 1
+	if got := cfg.NVMeDiagBaseOffset(); got != 0x1020 {
+		t.Errorf("diagnostic base (stride=1) = 0x%X, want 0x1020", got)
+	}
+	if got := cfg.NVMeDiagLastCommandOffset(); got != 0x1024 {
+		t.Errorf("last command diagnostic (stride=1) = 0x%X, want 0x1024", got)
+	}
+}

--- a/internal/firmware/svgen/nvme_responder_test.go
+++ b/internal/firmware/svgen/nvme_responder_test.go
@@ -73,3 +73,27 @@ func TestGenerateNVMeResponderSV_HandlesCompatibilityLogsAndFeatures(t *testing.
 		}
 	}
 }
+
+func TestGenerateNVMeResponderSV_TracksDebugState(t *testing.T) {
+	cfg := testConfig()
+
+	result, err := GenerateNVMeResponderSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateNVMeResponderSV failed: %v", err)
+	}
+
+	for _, want := range []string{
+		"output reg [31:0]   debug_status",
+		"output reg [31:0]   debug_last_cmd",
+		"output reg [31:0]   debug_last_nsid",
+		"output reg [31:0]   debug_last_cdw10",
+		"output reg [31:0]   debug_queue_state",
+		"debug_last_cmd <= {7'h0, active_io_cmd, cmd_opcode, cmd_cid};",
+		"debug_last_nsid <= cmd_nsid;",
+		"debug_last_cdw10 <= cmd_cdw10;",
+	} {
+		if !strings.Contains(result, want) {
+			t.Fatalf("NVMe responder should contain debug state %q", want)
+		}
+	}
+}

--- a/internal/firmware/svgen/nvme_responder_test.go
+++ b/internal/firmware/svgen/nvme_responder_test.go
@@ -45,3 +45,31 @@ func TestGenerateNVMeResponderSV_HandlesFormattingIOQueuePath(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateNVMeResponderSV_HandlesCompatibilityLogsAndFeatures(t *testing.T) {
+	cfg := testConfig()
+
+	result, err := GenerateNVMeResponderSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateNVMeResponderSV failed: %v", err)
+	}
+
+	for _, want := range []string{
+		"log_page_id",
+		"log_dw_limit",
+		"8'h01: dma_wr_data <= 32'h0;",
+		"8'h03: dma_wr_data <= (data_dw_cnt == 11'h0) ? 32'h00000001 : 32'h0;",
+		"8'h04: dma_wr_data <= 32'h0;",
+		"volatile_write_cache_enabled",
+		"async_event_config",
+		"8'h06:   cqe[0] <= {31'h0, volatile_write_cache_enabled};",
+		"8'h08:   cqe[0] <= interrupt_coalescing;",
+		"8'h09:   cqe[0] <= interrupt_vector_config;",
+		"8'h0B:   cqe[0] <= async_event_config;",
+		"8'h0F:   cqe[0] <= keep_alive_timer;",
+	} {
+		if !strings.Contains(result, want) {
+			t.Fatalf("NVMe responder should contain %q", want)
+		}
+	}
+}

--- a/internal/firmware/svgen/templates/bar_controller.sv.tmpl
+++ b/internal/firmware/svgen/templates/bar_controller.sv.tmpl
@@ -268,9 +268,14 @@ module pcileech_tlps128_bar_controller(
     wire [31:0] nvme_debug_queue_state;
 {{ end }}
 {{ if and (eq .DeviceClass "nvme") .NVMeIdentify .BARModel }}
+    // Diagnostic registers are read-only and sit immediately after all four
+    // admin + IO queue doorbells (SQ0/CQ0/SQ1/CQ1), using the same DSTRD spacing.
     wire        nvme_diag_addr_hit = rd_req_valid && rd_req_bar[0] &&
                                      (rd_req_addr_bar0 >= 32'h{{ printf "%08X" .NVMeDiagBaseOffset }}) &&
                                      (rd_req_addr_bar0 <= 32'h{{ printf "%08X" .NVMeDiagQueueStateOffset }});
+    wire        nvme_diag_wr_addr_hit = wr_valid && wr_bar[0] &&
+                                        (wr_addr_bar0 >= 32'h{{ printf "%08X" .NVMeDiagBaseOffset }}) &&
+                                        (wr_addr_bar0 <= 32'h{{ printf "%08X" .NVMeDiagQueueStateOffset }});
     reg  [87:0] nvme_diag_ctx;
     reg  [31:0] nvme_diag_data;
     reg         nvme_diag_valid;
@@ -369,7 +374,7 @@ module pcileech_tlps128_bar_controller(
         .wr_addr        ( {{ if .BARModel }}wr_addr_bar0{{ else }}wr_addr{{ end }}                       ),
         .wr_be          ( wr_be                         ),
         .wr_data        ( wr_data                       ),
-        .wr_valid       ( wr_valid && wr_bar[0]         ),
+        .wr_valid       ( wr_valid && wr_bar[0]{{ if and (eq .DeviceClass "nvme") .NVMeIdentify .BARModel }} && !nvme_diag_wr_addr_hit{{ end }} ),
         .rd_req_ctx     ( rd_req_ctx                    ),
         .rd_req_addr    ( {{ if .BARModel }}rd_req_addr_bar0{{ else }}rd_req_addr{{ end }}                   ),
         .rd_req_valid   ( rd_req_valid && rd_req_bar[0]{{ if .MSIXConfig }} && !msix_addr_hit{{ end }}{{ if and (eq .DeviceClass "nvme") .NVMeIdentify .BARModel }} && !nvme_diag_addr_hit{{ end }} ),

--- a/internal/firmware/svgen/templates/bar_controller.sv.tmpl
+++ b/internal/firmware/svgen/templates/bar_controller.sv.tmpl
@@ -260,20 +260,71 @@ module pcileech_tlps128_bar_controller(
     wire [31:0] bar_rsp_data[7];
     wire        bar_rsp_valid[7];
 
+{{ if and (eq .DeviceClass "nvme") .NVMeIdentify }}
+    wire [31:0] nvme_debug_status;
+    wire [31:0] nvme_debug_last_cmd;
+    wire [31:0] nvme_debug_last_nsid;
+    wire [31:0] nvme_debug_last_cdw10;
+    wire [31:0] nvme_debug_queue_state;
+{{ end }}
+{{ if and (eq .DeviceClass "nvme") .NVMeIdentify .BARModel }}
+    wire        nvme_diag_addr_hit = rd_req_valid && rd_req_bar[0] &&
+                                     (rd_req_addr_bar0 >= 32'h{{ printf "%08X" .NVMeDiagBaseOffset }}) &&
+                                     (rd_req_addr_bar0 <= 32'h{{ printf "%08X" .NVMeDiagQueueStateOffset }});
+    reg  [87:0] nvme_diag_ctx;
+    reg  [31:0] nvme_diag_data;
+    reg         nvme_diag_valid;
+
+    always @(posedge clk) begin
+        nvme_diag_ctx   <= rd_req_ctx;
+        nvme_diag_valid <= nvme_diag_addr_hit;
+        case (rd_req_addr_bar0)
+            32'h{{ printf "%08X" .NVMeDiagBaseOffset }}: nvme_diag_data <= nvme_debug_status;
+            32'h{{ printf "%08X" .NVMeDiagLastCommandOffset }}: nvme_diag_data <= nvme_debug_last_cmd;
+            32'h{{ printf "%08X" .NVMeDiagLastNSIDOffset }}: nvme_diag_data <= nvme_debug_last_nsid;
+            32'h{{ printf "%08X" .NVMeDiagLastCDW10Offset }}: nvme_diag_data <= nvme_debug_last_cdw10;
+            32'h{{ printf "%08X" .NVMeDiagQueueStateOffset }}: nvme_diag_data <= nvme_debug_queue_state;
+            default: nvme_diag_data <= 32'h0;
+        endcase
+    end
+{{ end }}
+
 {{ if and .LatencyConfig .MSIXConfig }}
     // latency -> MSI-X mux -> bar_rsp[0]
+{{ if and (eq .DeviceClass "nvme") .NVMeIdentify .BARModel }}
+    assign bar_rsp_ctx[0]   = nvme_diag_valid ? nvme_diag_ctx :
+                              msix_rsp_valid ? msix_rsp_ctx   : bar0_base_ctx;
+    assign bar_rsp_data[0]  = nvme_diag_valid ? nvme_diag_data :
+                              msix_rsp_valid ? msix_rsp_data  : bar0_base_data;
+    assign bar_rsp_valid[0] = nvme_diag_valid || msix_rsp_valid || bar0_base_valid;
+{{ else }}
     assign bar_rsp_ctx[0]   = msix_rsp_valid ? msix_rsp_ctx   : bar0_base_ctx;
     assign bar_rsp_data[0]  = msix_rsp_valid ? msix_rsp_data  : bar0_base_data;
     assign bar_rsp_valid[0] = msix_rsp_valid || bar0_base_valid;
+{{ end }}
 {{ else if .LatencyConfig }}
+{{ if and (eq .DeviceClass "nvme") .NVMeIdentify .BARModel }}
+    assign bar_rsp_ctx[0]   = nvme_diag_valid ? nvme_diag_ctx : bar0_emu_ctx;
+    assign bar_rsp_data[0]  = nvme_diag_valid ? nvme_diag_data : bar0_emu_data;
+    assign bar_rsp_valid[0] = nvme_diag_valid || bar0_emu_valid;
+{{ else }}
     assign bar_rsp_ctx[0]   = bar0_emu_ctx;
     assign bar_rsp_data[0]  = bar0_emu_data;
     assign bar_rsp_valid[0] = bar0_emu_valid;
+{{ end }}
 {{ else if .MSIXConfig }}
     // MSI-X mux -> bar_rsp[0]
+{{ if and (eq .DeviceClass "nvme") .NVMeIdentify .BARModel }}
+    assign bar_rsp_ctx[0]   = nvme_diag_valid ? nvme_diag_ctx :
+                              msix_rsp_valid ? msix_rsp_ctx   : bar0_base_ctx;
+    assign bar_rsp_data[0]  = nvme_diag_valid ? nvme_diag_data :
+                              msix_rsp_valid ? msix_rsp_data  : bar0_base_data;
+    assign bar_rsp_valid[0] = nvme_diag_valid || msix_rsp_valid || bar0_base_valid;
+{{ else }}
     assign bar_rsp_ctx[0]   = msix_rsp_valid ? msix_rsp_ctx   : bar0_base_ctx;
     assign bar_rsp_data[0]  = msix_rsp_valid ? msix_rsp_data  : bar0_base_data;
     assign bar_rsp_valid[0] = msix_rsp_valid || bar0_base_valid;
+{{ end }}
 {{ end }}
 
     // response mux
@@ -321,7 +372,7 @@ module pcileech_tlps128_bar_controller(
         .wr_valid       ( wr_valid && wr_bar[0]         ),
         .rd_req_ctx     ( rd_req_ctx                    ),
         .rd_req_addr    ( {{ if .BARModel }}rd_req_addr_bar0{{ else }}rd_req_addr{{ end }}                   ),
-        .rd_req_valid   ( rd_req_valid && rd_req_bar[0]{{ if .MSIXConfig }} && !msix_addr_hit{{ end }} ),
+        .rd_req_valid   ( rd_req_valid && rd_req_bar[0]{{ if .MSIXConfig }} && !msix_addr_hit{{ end }}{{ if and (eq .DeviceClass "nvme") .NVMeIdentify .BARModel }} && !nvme_diag_addr_hit{{ end }} ),
 {{ if .LatencyConfig }}
         .rd_rsp_ctx     ( bar0_raw_ctx                  ),
         .rd_rsp_data    ( bar0_raw_data                 ),
@@ -632,7 +683,12 @@ module pcileech_tlps128_bar_controller(
         .dma_wr_done        ( nvme_dma_wr_done              ),
         .msix_trigger       ( nvme_msix_trigger             ),
         .id_rom_addr        ( nvme_id_rom_addr              ),
-        .id_rom_data        ( nvme_id_rom_data              )
+        .id_rom_data        ( nvme_id_rom_data              ),
+        .debug_status       ( nvme_debug_status             ),
+        .debug_last_cmd     ( nvme_debug_last_cmd           ),
+        .debug_last_nsid    ( nvme_debug_last_nsid          ),
+        .debug_last_cdw10   ( nvme_debug_last_cdw10         ),
+        .debug_queue_state  ( nvme_debug_queue_state        )
     );
 
     // this guy does the real PCIe legwork

--- a/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
+++ b/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
@@ -73,7 +73,13 @@ module pcileech_nvme_admin_responder(
 
     // identify data lives in a BRAM initialized from .hex at synthesis
     output reg [12:0]   id_rom_addr,
-    input [31:0]        id_rom_data
+    input [31:0]        id_rom_data,
+
+    output reg [31:0]   debug_status,
+    output reg [31:0]   debug_last_cmd,
+    output reg [31:0]   debug_last_nsid,
+    output reg [31:0]   debug_last_cdw10,
+    output reg [31:0]   debug_queue_state
 );
 
     // FSM states – 4 bits is plenty, Vivado infers one-hot if it wants to
@@ -200,6 +206,11 @@ module pcileech_nvme_admin_responder(
             log_page_id     <= 8'h02;
             id_rom_offset   <= 13'h0;
             id_rom_addr     <= 13'h0;
+            debug_status    <= 32'h0;
+            debug_last_cmd  <= 32'h0;
+            debug_last_nsid <= 32'h0;
+            debug_last_cdw10 <= 32'h0;
+            debug_queue_state <= 32'h0;
             cc_en_prev      <= 1'b0;
             aer_pending     <= 4'h0;
             num_queues_granted <= 32'h00010001;  // default: 1 SQ + 1 CQ
@@ -221,6 +232,8 @@ module pcileech_nvme_admin_responder(
             dma_wr_req      <= 1'b0;
             dma_wr_valid    <= 1'b0;
             msix_trigger    <= 1'b0;
+            debug_status    <= {22'h0, state, active_io_cmd, iosq_enabled, iocq_enabled, cq_phase, iocq_phase, cc_en};
+            debug_queue_state <= {sq_head[7:0], cq_head[7:0], iosq_head[7:0], iocq_head[7:0]};
 
             cc_en_prev <= cc_en;
 
@@ -280,6 +293,9 @@ module pcileech_nvme_admin_responder(
 
                     // ---- figure out what the driver wants --------------------
                     S_DECODE_CMD: begin
+                        debug_last_cmd <= {7'h0, active_io_cmd, cmd_opcode, cmd_cid};
+                        debug_last_nsid <= cmd_nsid;
+                        debug_last_cdw10 <= cmd_cdw10;
                         if (active_io_cmd) begin
                             case (cmd_opcode)
                                 8'h02: begin

--- a/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
+++ b/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
@@ -142,6 +142,8 @@ module pcileech_nvme_admin_responder(
     // transfer progress
     reg [10:0]  data_dw_cnt;
     reg [10:0]  io_zero_dw_limit;
+    reg [10:0]  log_dw_limit;
+    reg [7:0]   log_page_id;
     reg [12:0]  id_rom_offset;
 
     // edge detect for CC.EN so we can do a clean shutdown
@@ -167,6 +169,12 @@ module pcileech_nvme_admin_responder(
     // Set/Get Features Number of Queues must be consistent - stornvme sets
     // the desired count then reads it back.  We clamp to what CAP.MQES allows.
     reg [31:0]  num_queues_granted;
+    reg         volatile_write_cache_enabled;
+    reg [31:0]  interrupt_coalescing;
+    reg [31:0]  interrupt_vector_config;
+    reg [31:0]  write_atomicity_normal;
+    reg [31:0]  async_event_config;
+    reg [31:0]  keep_alive_timer;
 
     always @(posedge clk) begin
         if (rst) begin
@@ -188,11 +196,19 @@ module pcileech_nvme_admin_responder(
             cqe_dw_idx      <= 2'h0;
             data_dw_cnt     <= 11'h0;
             io_zero_dw_limit <= 11'h0;
+            log_dw_limit    <= 11'd128;
+            log_page_id     <= 8'h02;
             id_rom_offset   <= 13'h0;
             id_rom_addr     <= 13'h0;
             cc_en_prev      <= 1'b0;
             aer_pending     <= 4'h0;
             num_queues_granted <= 32'h00010001;  // default: 1 SQ + 1 CQ
+            volatile_write_cache_enabled <= 1'b1;
+            interrupt_coalescing <= 32'h0;
+            interrupt_vector_config <= 32'h0;
+            write_atomicity_normal <= 32'h0;
+            async_event_config <= 32'h0;
+            keep_alive_timer <= 32'h0;
             iosq_base       <= 64'h0;
             iocq_base       <= 64'h0;
             iosq_size       <= 16'h0;
@@ -324,7 +340,12 @@ module pcileech_nvme_admin_responder(
 
                             // Get Log Page
                             8'h02: begin
+                                log_page_id <= cmd_cdw10[7:0];
                                 data_dw_cnt <= 11'h0;
+                                if (cmd_cdw10[31:16] >= 16'd1023)
+                                    log_dw_limit <= 11'd1024;
+                                else
+                                    log_dw_limit <= {1'b0, cmd_cdw10[25:16]} + 11'd1;
                                 state       <= S_EXEC_LOGPAGE;
                             end
 
@@ -400,15 +421,34 @@ module pcileech_nvme_admin_responder(
                                 case (cmd_cdw10[7:0])
                                     8'h04:   cqe[0] <= 32'h0;            // temp threshold
                                     8'h05:   cqe[0] <= 32'h0;            // error recovery
-                                    8'h06:   cqe[0] <= cmd_cdw11;        // volatile write cache
+                                    8'h06: begin                           // volatile write cache
+                                        volatile_write_cache_enabled <= cmd_cdw11[0];
+                                        cqe[0] <= {31'h0, cmd_cdw11[0]};
+                                    end
                                     8'h07: begin                           // number of queues
                                         num_queues_granted <= cmd_cdw11;
                                         cqe[0] <= cmd_cdw11;
                                     end
-                                    8'h08:   cqe[0] <= 32'h0;            // interrupt vector config
-                                    8'h09:   cqe[0] <= 32'h0;            // write atomicity
-                                    8'h0B:   cqe[0] <= 32'h0;            // interrupt coalescing
-                                    8'h0F:   cqe[0] <= 32'h0;            // keep alive timer
+                                    8'h08: begin                           // interrupt coalescing
+                                        interrupt_coalescing <= cmd_cdw11;
+                                        cqe[0] <= cmd_cdw11;
+                                    end
+                                    8'h09: begin                           // interrupt vector config
+                                        interrupt_vector_config <= cmd_cdw11;
+                                        cqe[0] <= cmd_cdw11;
+                                    end
+                                    8'h0A: begin                           // write atomicity normal
+                                        write_atomicity_normal <= cmd_cdw11;
+                                        cqe[0] <= cmd_cdw11;
+                                    end
+                                    8'h0B: begin                           // async event config
+                                        async_event_config <= cmd_cdw11;
+                                        cqe[0] <= cmd_cdw11;
+                                    end
+                                    8'h0F: begin                           // keep alive timer
+                                        keep_alive_timer <= cmd_cdw11;
+                                        cqe[0] <= cmd_cdw11;
+                                    end
                                     default: cqe[0] <= 32'h0;
                                 endcase
                                 cqe[1] <= 32'h0;
@@ -421,8 +461,15 @@ module pcileech_nvme_admin_responder(
                             // Get Features
                             8'h0A: begin
                                 case (cmd_cdw10[7:0])
+                                    8'h04:   cqe[0] <= 32'h00000135;  // 35C warning threshold
+                                    8'h05:   cqe[0] <= 32'h0;  // no error recovery timeout
+                                    8'h06:   cqe[0] <= {31'h0, volatile_write_cache_enabled};
                                     8'h07:   cqe[0] <= num_queues_granted;  // echo last Set Features value
-                                    8'h0B:   cqe[0] <= 32'h00000000;  // coalescing off
+                                    8'h08:   cqe[0] <= interrupt_coalescing;
+                                    8'h09:   cqe[0] <= interrupt_vector_config;
+                                    8'h0A:   cqe[0] <= write_atomicity_normal;
+                                    8'h0B:   cqe[0] <= async_event_config;
+                                    8'h0F:   cqe[0] <= keep_alive_timer;
                                     default: cqe[0] <= 32'h0;
                                 endcase
                                 cqe[1] <= 32'h0;
@@ -513,22 +560,29 @@ module pcileech_nvme_admin_responder(
                         state <= S_WAIT_DMA_WR;
                     end
 
-                    // ---- SMART health log: "everything is fine" -------------
-                    // 512B of mostly zeros with temperature ~35°C and full spare
+                    // ---- common admin logs: error, SMART, firmware, NS list -
                     S_EXEC_LOGPAGE: begin
                         dma_wr_req   <= 1'b1;
                         dma_wr_valid <= 1'b1;
                         dma_wr_addr  <= cmd_prp_addr({data_dw_cnt, 2'b00});
                         dma_wr_be    <= 4'hF;
 
-                        case (data_dw_cnt)
-                            11'h000: dma_wr_data <= 32'h01340000;  // temp=308K (35°C), no warnings
-                            11'h001: dma_wr_data <= 32'h00640064;  // 100% spare, 100% threshold
-                            11'h002: dma_wr_data <= 32'h00000000;  // 0% used
-                            default: dma_wr_data <= 32'h00000000;
+                        case (log_page_id)
+                            8'h01: dma_wr_data <= 32'h0;
+                            8'h02: begin
+                                case (data_dw_cnt)
+                                    11'h000: dma_wr_data <= 32'h01340000;  // temp=308K (35C), no warnings
+                                    11'h001: dma_wr_data <= 32'h00640064;  // 100% spare, 100% threshold
+                                    11'h002: dma_wr_data <= 32'h00000000;  // 0% used
+                                    default: dma_wr_data <= 32'h00000000;
+                                endcase
+                            end
+                            8'h03: dma_wr_data <= (data_dw_cnt == 11'h0) ? 32'h00000001 : 32'h0;
+                            8'h04: dma_wr_data <= 32'h0;
+                            default: dma_wr_data <= 32'h0;
                         endcase
 
-                        if (data_dw_cnt >= 11'd127) begin
+                        if (data_dw_cnt >= log_dw_limit - 11'd1) begin
                             return_state <= S_WRITE_DATA;
                         end else begin
                             data_dw_cnt  <= data_dw_cnt + 1'b1;


### PR DESCRIPTION
## Summary
- Add read-only NVMe diagnostic BAR registers after the QID0/QID1 doorbell range.
- Expose last command, NSID, CDW10, queue heads, phase bits, and responder status from the admin responder.
- Keep diagnostics passive: reads do not change NVMe command execution or queue behavior.

## Additional CLI/source-audit changes
- Add explicit offline MMIO trace format selection: `auto`, `mmiotrace`, and `mmio2verilog`.
- Add `pcileechgen boards --json` with effective board defaults for downstream tooling.
- Add `docs/source-audit.md` to record safe external-source adaptation boundaries and excluded bypass/evasion scopes.

## Dependency
This PR is stacked after #61. Until #61 merges, the GitHub diff against `main` will include the compatibility-data commit as well as this diagnostic-register commit.

## Diagnostic offsets
- status: DSTRD-adjusted diagnostic base
- last command: base + 0x04
- last NSID: base + 0x08
- last CDW10: base + 0x0C
- queue state: base + 0x10

## Validation
- `make check`
- `go test -race -count=1 ./...`
- `git diff --check`
- `verilator --lint-only -sv internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl`
- `go run ./cmd/pcileechgen build --from-json testdata/donors/nvme.json --board CaptainDMA_100T --output /tmp/pcileechgen-nvme-diag-smoke --skip-vivado`
- `verilator --lint-only -Wno-fatal --top-module pcileech_bar_impl_device +incdir+/tmp/pcileechgen-nvme-diag-smoke/src <generated svgen files> testdata/stubs/blackbox.sv`
- manual CLI smoke checks for `boards --json` and `mmio-trace --format mmio2verilog`