### PR TITLE
[codex] preserve Vivado license env

### DIFF
--- a/cmd/pcileechgen/build.go
+++ b/cmd/pcileechgen/build.go
@@ -14,17 +14,18 @@ import (
 
 // buildFlags groups all build command flags.
 type buildFlags struct {
-	bdf        string
-	board      string
-	vivadoPath string
-	output     string
-	skipVivado bool
-	jobs       int
-	timeout    int
-	libDir     string
-	fromJSON   string
-	stockBar   bool
-	force      bool
+	bdf         string
+	board       string
+	vivadoPath  string
+	licenseFile string
+	output      string
+	skipVivado  bool
+	jobs        int
+	timeout     int
+	libDir      string
+	fromJSON    string
+	stockBar    bool
+	force       bool
 }
 
 var buildOpts buildFlags
@@ -79,14 +80,15 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	}
 
 	builder := vivado.NewBuilder(b, vivado.BuildOptions{
-		VivadoPath: buildOpts.vivadoPath,
-		OutputDir:  buildOpts.output,
-		LibDir:     buildOpts.libDir,
-		Jobs:       buildOpts.jobs,
-		Timeout:    buildOpts.timeout,
-		SkipVivado: buildOpts.skipVivado,
-		StockBar:   buildOpts.stockBar,
-		Force:      buildOpts.force,
+		VivadoPath:        buildOpts.vivadoPath,
+		VivadoLicenseFile: buildOpts.licenseFile,
+		OutputDir:         buildOpts.output,
+		LibDir:            buildOpts.libDir,
+		Jobs:              buildOpts.jobs,
+		Timeout:           buildOpts.timeout,
+		SkipVivado:        buildOpts.skipVivado,
+		StockBar:          buildOpts.stockBar,
+		Force:             buildOpts.force,
 	})
 
 	return builder.Build(ctx)
@@ -150,6 +152,7 @@ func init() {
 	buildCmd.Flags().StringVar(&buildOpts.board, "board", "", "target FPGA board name (required, e.g. PCIeSquirrel)")
 	buildCmd.Flags().StringVar(&buildOpts.fromJSON, "from-json", "", "load donor device data from JSON file (offline build)")
 	buildCmd.Flags().StringVar(&buildOpts.vivadoPath, "vivado-path", "", "path to Vivado installation")
+	buildCmd.Flags().StringVar(&buildOpts.licenseFile, "vivado-license-file", "", "path or server for Vivado license")
 	buildCmd.Flags().StringVar(&buildOpts.output, "output", "pcileech_datastore", "output directory")
 	buildCmd.Flags().BoolVar(&buildOpts.skipVivado, "skip-vivado", false, "skip Vivado synthesis (only generate artifacts)")
 	buildCmd.Flags().IntVar(&buildOpts.jobs, "jobs", 4, "number of parallel Vivado jobs")

--- a/internal/vivado/builder.go
+++ b/internal/vivado/builder.go
@@ -14,14 +14,15 @@ import (
 
 // BuildOptions holds build configuration.
 type BuildOptions struct {
-	VivadoPath string
-	OutputDir  string
-	LibDir     string
-	Jobs       int
-	Timeout    int
-	SkipVivado bool
-	StockBar   bool
-	Force      bool
+	VivadoPath        string
+	VivadoLicenseFile string
+	OutputDir         string
+	LibDir            string
+	Jobs              int
+	Timeout           int
+	SkipVivado        bool
+	StockBar          bool
+	Force             bool
 }
 
 // WithDefaults returns a copy of opts with zero values replaced by sensible defaults.
@@ -81,6 +82,7 @@ func (b *Builder) Build(ctx *donor.DeviceContext) error {
 	if err != nil {
 		return fmt.Errorf("Vivado not found: %w", err)
 	}
+	vivado.LicenseFile = b.opts.VivadoLicenseFile
 	slog.Info("Vivado found", "version", vivado.Version, "path", vivado.Path)
 
 	timeout := time.Duration(b.opts.Timeout) * time.Second

--- a/internal/vivado/vivado.go
+++ b/internal/vivado/vivado.go
@@ -24,8 +24,9 @@ var DefaultPaths = []string{
 
 // Vivado represents a Vivado installation.
 type Vivado struct {
-	Path    string // path to Vivado installation (e.g., /tools/Xilinx/Vivado/2023.2)
-	Version string // Vivado version string
+	Path        string // path to Vivado installation (e.g., /tools/Xilinx/Vivado/2023.2)
+	Version     string // Vivado version string
+	LicenseFile string
 }
 
 // Find searches for a Vivado installation.
@@ -79,6 +80,9 @@ func Find(customPath string) (*Vivado, error) {
 
 // validateVivado checks if a path contains a valid Vivado installation.
 func validateVivado(path string) (*Vivado, error) {
+	if filepath.Base(path) == "vivado" && filepath.Base(filepath.Dir(path)) == "bin" {
+		path = filepath.Dir(filepath.Dir(path))
+	}
 	binary := filepath.Join(path, "bin", "vivado")
 	if _, err := os.Stat(binary); os.IsNotExist(err) {
 		return nil, fmt.Errorf("Vivado binary not found at %s", binary)
@@ -109,9 +113,7 @@ func (v *Vivado) RunTCL(tclScript string, workDir string, timeout time.Duration)
 	cmd.Stderr = io.MultiWriter(os.Stderr, &output)
 
 	// Set up environment
-	env := os.Environ()
-	env = append(env, fmt.Sprintf("XILINX_VIVADO=%s", v.Path))
-	cmd.Env = env
+	cmd.Env = v.env()
 
 	slog.Info("running Vivado", "cmd", strings.Join(cmd.Args, " "), "dir", workDir, "timeout", timeout)
 
@@ -127,6 +129,18 @@ func (v *Vivado) RunTCL(tclScript string, workDir string, timeout time.Duration)
 	}
 
 	return nil
+}
+
+func (v *Vivado) env() []string {
+	env := os.Environ()
+	env = append(env, fmt.Sprintf("XILINX_VIVADO=%s", v.Path))
+	if v.LicenseFile != "" {
+		env = append(env,
+			fmt.Sprintf("XILINXD_LICENSE_FILE=%s", v.LicenseFile),
+			fmt.Sprintf("LM_LICENSE_FILE=%s", v.LicenseFile),
+		)
+	}
+	return env
 }
 
 func vivadoStartupFailure(output string) (string, bool) {

--- a/internal/vivado/vivado_test.go
+++ b/internal/vivado/vivado_test.go
@@ -41,6 +41,46 @@ func TestVivadoBinaryPath(t *testing.T) {
 	}
 }
 
+func TestValidateVivadoAcceptsBinaryPath(t *testing.T) {
+	installDir := t.TempDir()
+	binDir := filepath.Join(installDir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	vivadoPath := filepath.Join(binDir, "vivado")
+	if err := os.WriteFile(vivadoPath, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := Find(vivadoPath)
+	if err != nil {
+		t.Fatalf("Find(binary path) error: %v", err)
+	}
+	if v.Path != installDir {
+		t.Fatalf("Find(binary path) Path = %q, want %q", v.Path, installDir)
+	}
+}
+
+func TestRunTCLEnvIncludesLicenseFile(t *testing.T) {
+	v := &Vivado{
+		Path:        "/tools/Xilinx/Vivado/2023.2",
+		Version:     "2023.2",
+		LicenseFile: "/home/user/Xilinx.lic",
+	}
+
+	env := v.env()
+
+	for _, want := range []string{
+		"XILINX_VIVADO=/tools/Xilinx/Vivado/2023.2",
+		"XILINXD_LICENSE_FILE=/home/user/Xilinx.lic",
+		"LM_LICENSE_FILE=/home/user/Xilinx.lic",
+	} {
+		if !containsEnv(env, want) {
+			t.Fatalf("env missing %q in %v", want, env)
+		}
+	}
+}
+
 func TestBuilderDefaults(t *testing.T) {
 	b, _ := Find("") // will fail but ok for testing builder creation
 	_ = b
@@ -140,4 +180,13 @@ exit 0
 	if !strings.Contains(err.Error(), "libtinfo.so.5") {
 		t.Fatalf("RunTCL error = %q, want loader detail", err.Error())
 	}
+}
+
+func containsEnv(env []string, want string) bool {
+	for _, got := range env {
+		if got == want {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- add `--vivado-license-file` for passing Vivado license configuration into synthesis subprocesses
- set both `XILINXD_LICENSE_FILE` and `LM_LICENSE_FILE` when the flag is provided
- accept either a Vivado install directory or the `bin/vivado` executable path for `--vivado-path`

## Root cause
Running the build under `sudo` can strip user shell environment variables, so Vivado may be found but still fail license discovery. The build already carries the Vivado path explicitly; this adds the same explicit path for the license environment used by Vivado.

Fixes #63.

## Validation
- `go test ./...` under WSL/Linux