### PR TITLE
fix: finalize complete and safe build manifests

### DIFF
--- a/internal/firmware/output/manifest.go
+++ b/internal/firmware/output/manifest.go
@@ -2,11 +2,15 @@ package output
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 )
 
@@ -27,6 +31,10 @@ type ManifestEntry struct {
 }
 
 func GenerateManifest(outputDir, toolVersion, boardName string, vendorID, deviceID uint16) (*BuildManifest, error) {
+	return generateManifest(outputDir, toolVersion, boardName, vendorID, deviceID, true)
+}
+
+func generateManifest(outputDir, toolVersion, boardName string, vendorID, deviceID uint16, includeSynthesized bool) (*BuildManifest, error) {
 	m := &BuildManifest{
 		GeneratedAt: time.Now(),
 		ToolVersion: toolVersion,
@@ -35,67 +43,149 @@ func GenerateManifest(outputDir, toolVersion, boardName string, vendorID, device
 		DeviceID:    deviceID,
 	}
 
-	expectedFiles := ListOutputFiles()
-	for _, name := range expectedFiles {
-		if name == "src/" {
-			continue
-		}
-		path := filepath.Join(outputDir, name)
-		info, err := os.Stat(path)
-		if err != nil {
-			continue
-		}
-		if info.IsDir() {
-			continue
-		}
-
-		hash, err := fileHash(path)
-		if err != nil {
-			hash = "error"
-		}
-
-		m.Files = append(m.Files, ManifestEntry{
-			Name:   name,
-			Size:   info.Size(),
-			SHA256: hash,
-		})
+	rootArtifacts, err := discoverRootArtifacts(outputDir, includeSynthesized)
+	if err != nil {
+		return nil, err
+	}
+	candidates := make(map[string]struct{}, len(rootArtifacts))
+	for _, name := range rootArtifacts {
+		candidates[name] = struct{}{}
 	}
 
 	srcDir := filepath.Join(outputDir, "src")
-	if entries, err := os.ReadDir(srcDir); err == nil {
-		for _, e := range entries {
-			if e.IsDir() {
-				continue
+	if _, err := os.Stat(srcDir); err == nil {
+		err = filepath.WalkDir(srcDir, func(filePath string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
 			}
-			path := filepath.Join(srcDir, e.Name())
-			info, err := e.Info()
+			if entry.IsDir() {
+				return nil
+			}
+			if entry.Type()&os.ModeSymlink != 0 {
+				return fmt.Errorf("refusing to include symlink %s", filePath)
+			}
+			rel, err := filepath.Rel(outputDir, filePath)
 			if err != nil {
-				continue
+				return err
 			}
-			hash, err := fileHash(path)
-			if err != nil {
-				hash = "error"
-			}
-			m.Files = append(m.Files, ManifestEntry{
-				Name:   filepath.Join("src", e.Name()),
-				Size:   info.Size(),
-				SHA256: hash,
-			})
+			candidates[filepath.ToSlash(rel)] = struct{}{}
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("inventory source artifacts: %w", err)
 		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("inspect source artifacts: %w", err)
+	}
+
+	names := make([]string, 0, len(candidates))
+	for name := range candidates {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		filePath := filepath.Join(outputDir, filepath.FromSlash(name))
+		info, err := os.Lstat(filePath)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("stat artifact %q: %w", name, err)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("artifact %q is not a regular file", name)
+		}
+		hash, err := fileHash(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("hash artifact %q: %w", name, err)
+		}
+		m.Files = append(m.Files, ManifestEntry{Name: name, Size: info.Size(), SHA256: hash})
 	}
 	return m, nil
 }
 
-func (m *BuildManifest) WriteJSON(path string) error {
+var manifestRootExtensions = map[string]struct{}{
+	".bin":  {},
+	".bit":  {},
+	".coe":  {},
+	".hex":  {},
+	".json": {},
+	".sv":   {},
+	".svh":  {},
+	".tcl":  {},
+	".txt":  {},
+	".v":    {},
+	".vh":   {},
+	".xdc":  {},
+	".xci":  {},
+}
+
+func discoverRootArtifacts(outputDir string, includeSynthesized bool) ([]string, error) {
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		return nil, fmt.Errorf("inventory output artifacts: %w", err)
+	}
+
+	artifacts := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Name() == "build_manifest.json" {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(entry.Name()))
+		if _, ok := manifestRootExtensions[ext]; !ok {
+			continue
+		}
+		if !includeSynthesized && (ext == ".bit" || ext == ".bin") {
+			continue
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("refusing to include symlink %s", filepath.Join(outputDir, entry.Name()))
+		}
+		artifacts = append(artifacts, filepath.ToSlash(entry.Name()))
+	}
+	sort.Strings(artifacts)
+	return artifacts, nil
+}
+
+func (m *BuildManifest) WriteJSON(filePath string) error {
 	data, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal manifest: %w", err)
 	}
-	return os.WriteFile(path, data, 0644)
+	data = append(data, '\n')
+
+	dir := filepath.Dir(filePath)
+	tmp, err := os.CreateTemp(dir, ".build-manifest-*")
+	if err != nil {
+		return fmt.Errorf("create temporary manifest: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temporary manifest: %w", err)
+	}
+	if err := tmp.Chmod(0644); err != nil {
+		tmp.Close()
+		return fmt.Errorf("set manifest permissions: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync temporary manifest: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary manifest: %w", err)
+	}
+	if err := os.Rename(tmpName, filePath); err != nil {
+		return fmt.Errorf("replace manifest: %w", err)
+	}
+	return nil
 }
 
-func fileHash(path string) (string, error) {
-	f, err := os.Open(path)
+func fileHash(filePath string) (string, error) {
+	f, err := os.Open(filePath)
 	if err != nil {
 		return "", err
 	}
@@ -109,8 +199,8 @@ func fileHash(path string) (string, error) {
 }
 
 // LoadManifest reads a build manifest from a JSON file.
-func LoadManifest(path string) (*BuildManifest, error) {
-	data, err := os.ReadFile(path)
+func LoadManifest(filePath string) (*BuildManifest, error) {
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read manifest: %w", err)
 	}
@@ -121,7 +211,6 @@ func LoadManifest(path string) (*BuildManifest, error) {
 	return &m, nil
 }
 
-// ManifestVerification holds the result of verifying a build manifest.
 type ManifestVerification struct {
 	Passed  []string
 	Failed  []string
@@ -133,48 +222,103 @@ func (v *ManifestVerification) OK() bool {
 }
 
 func (v *ManifestVerification) Summary() string {
-	return fmt.Sprintf("%d passed, %d failed, %d missing",
-		len(v.Passed), len(v.Failed), len(v.Missing))
+	return fmt.Sprintf("%d passed, %d failed, %d missing", len(v.Passed), len(v.Failed), len(v.Missing))
 }
 
-// VerifyManifest checks that all files in the manifest exist and match their checksums.
+func validateManifestName(name string) error {
+	if name == "" || name == "." {
+		return fmt.Errorf("invalid empty artifact path")
+	}
+	if strings.ContainsRune(name, '\x00') {
+		return fmt.Errorf("artifact path %q contains a NUL byte", name)
+	}
+	if strings.Contains(name, "\\") {
+		return fmt.Errorf("artifact path %q must use forward slashes", name)
+	}
+	if strings.HasPrefix(name, "/") || path.IsAbs(name) || path.Clean(name) != name || name == ".." || strings.HasPrefix(name, "../") {
+		return fmt.Errorf("artifact path %q escapes the output directory", name)
+	}
+	return nil
+}
+
+func validSHA256(value string) bool {
+	if len(value) != sha256.Size*2 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
 func VerifyManifest(manifestPath, outputDir string) (*ManifestVerification, error) {
 	m, err := LoadManifest(manifestPath)
 	if err != nil {
 		return nil, err
 	}
 
+	root, err := filepath.Abs(outputDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve output directory: %w", err)
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve output directory symlinks: %w", err)
+	}
+	seen := make(map[string]struct{}, len(m.Files))
 	v := &ManifestVerification{}
 
-	for _, entry := range m.Files {
-		filePath := filepath.Join(outputDir, entry.Name)
+	for i, entry := range m.Files {
+		if err := validateManifestName(entry.Name); err != nil {
+			return nil, fmt.Errorf("manifest entry %d: %w", i, err)
+		}
+		if _, exists := seen[entry.Name]; exists {
+			return nil, fmt.Errorf("manifest entry %d: duplicate artifact path %q", i, entry.Name)
+		}
+		seen[entry.Name] = struct{}{}
+		if entry.Size < 0 {
+			return nil, fmt.Errorf("manifest entry %d (%q): negative size", i, entry.Name)
+		}
+		if !validSHA256(entry.SHA256) {
+			return nil, fmt.Errorf("manifest entry %d (%q): invalid SHA-256", i, entry.Name)
+		}
 
-		info, err := os.Stat(filePath)
-		if err != nil {
+		filePath := filepath.Join(root, filepath.FromSlash(entry.Name))
+		info, err := os.Lstat(filePath)
+		if os.IsNotExist(err) {
 			v.Missing = append(v.Missing, entry.Name)
 			continue
 		}
-
-		if info.Size() != entry.Size {
-			v.Failed = append(v.Failed,
-				fmt.Sprintf("%s: size mismatch (got %d, expected %d)", entry.Name, info.Size(), entry.Size))
+		if err != nil {
+			v.Failed = append(v.Failed, fmt.Sprintf("%s: stat error: %v", entry.Name, err))
 			continue
 		}
-
+		if !info.Mode().IsRegular() {
+			v.Failed = append(v.Failed, fmt.Sprintf("%s: not a regular file", entry.Name))
+			continue
+		}
+		resolvedFile, err := filepath.EvalSymlinks(filePath)
+		if err != nil {
+			v.Failed = append(v.Failed, fmt.Sprintf("%s: resolve path: %v", entry.Name, err))
+			continue
+		}
+		rel, err := filepath.Rel(resolvedRoot, resolvedFile)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			v.Failed = append(v.Failed, fmt.Sprintf("%s: resolved path escapes output directory", entry.Name))
+			continue
+		}
+		if info.Size() != entry.Size {
+			v.Failed = append(v.Failed, fmt.Sprintf("%s: size mismatch (got %d, expected %d)", entry.Name, info.Size(), entry.Size))
+			continue
+		}
 		hash, err := fileHash(filePath)
 		if err != nil {
 			v.Failed = append(v.Failed, fmt.Sprintf("%s: hash error: %v", entry.Name, err))
 			continue
 		}
-
-		if hash != entry.SHA256 {
-			v.Failed = append(v.Failed,
-				fmt.Sprintf("%s: SHA256 mismatch", entry.Name))
+		if hash != strings.ToLower(entry.SHA256) {
+			v.Failed = append(v.Failed, fmt.Sprintf("%s: SHA256 mismatch", entry.Name))
 			continue
 		}
-
 		v.Passed = append(v.Passed, entry.Name)
 	}
-
 	return v, nil
 }

--- a/internal/firmware/output/manifest_test.go
+++ b/internal/firmware/output/manifest_test.go
@@ -4,7 +4,13 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/board"
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/pci"
 )
 
 func TestGenerateManifest_Empty(t *testing.T) {
@@ -180,7 +186,7 @@ func TestVerifyManifest_MissingFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	m := &BuildManifest{
 		Files: []ManifestEntry{
-			{Name: "missing.coe", Size: 100, SHA256: "abc"},
+			{Name: "missing.coe", Size: 100, SHA256: strings.Repeat("0", 64)},
 		},
 	}
 	manifestPath := filepath.Join(tmpDir, "manifest.json")
@@ -208,7 +214,7 @@ func TestVerifyManifest_HashMismatch(t *testing.T) {
 
 	m := &BuildManifest{
 		Files: []ManifestEntry{
-			{Name: "test.coe", Size: 7, SHA256: "wrong_hash"},
+			{Name: "test.coe", Size: 7, SHA256: strings.Repeat("0", 64)},
 		},
 	}
 	manifestPath := filepath.Join(tmpDir, "manifest.json")
@@ -241,5 +247,241 @@ func TestLoadManifest_Invalid(t *testing.T) {
 	_, err = LoadManifest(filepath.Join(tmpDir, "bad.json"))
 	if err == nil {
 		t.Error("LoadManifest should fail for invalid JSON")
+	}
+}
+
+func TestGenerateManifest_DiscoversRootDeliverablesByExtension(t *testing.T) {
+	tmpDir := t.TempDir()
+	files := map[string]string{
+		"src/nested/core.sv":         "module core; endmodule",
+		"a-output.bit":               "bit",
+		"z-output.bin":               "bin",
+		"identify_init.hex":          "identify",
+		"pcileech_hda_msi.sv":        "module pcileech_hda_msi; endmodule",
+		"pcileech_hda_rirb_dma.sv":   "module pcileech_hda_rirb_dma; endmodule",
+		"build_manifest.json":        `{"files":[]}`,
+		"vivado.log":                 "build log",
+		"vivado.jou":                 "build journal",
+		"post-synthesis-scratch.tmp": "temporary",
+	}
+	for name, content := range files {
+		filePath := filepath.Join(tmpDir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	m, err := GenerateManifest(tmpDir, "1.2.3", "CaptainDMA_35T", 0x1234, 0x5678)
+	if err != nil {
+		t.Fatalf("GenerateManifest error: %v", err)
+	}
+	names := make([]string, 0, len(m.Files))
+	for _, entry := range m.Files {
+		names = append(names, entry.Name)
+	}
+	want := []string{
+		"a-output.bit",
+		"identify_init.hex",
+		"pcileech_hda_msi.sv",
+		"pcileech_hda_rirb_dma.sv",
+		"src/nested/core.sv",
+		"z-output.bin",
+	}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("manifest names = %v, want only generated deliverables %v", names, want)
+	}
+}
+
+func TestGenerateManifest_RejectsSourceSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(tmpDir, "src"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside.sv")
+	if err := os.WriteFile(outside, []byte("secret"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(tmpDir, "src", "linked.sv")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := GenerateManifest(tmpDir, "dev", "board", 0, 0); err == nil {
+		t.Fatal("GenerateManifest should reject symlinked artifacts")
+	}
+}
+
+func TestGenerateManifest_RejectsRootDeliverableSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.sv")
+	if err := os.WriteFile(outside, []byte("module outside; endmodule"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	linkPath := filepath.Join(tmpDir, "pcileech_hda_msi.sv")
+	if err := os.Symlink(outside, linkPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	_, err := GenerateManifest(tmpDir, "dev", "board", 0, 0)
+	if err == nil {
+		t.Fatal("GenerateManifest accepted a root deliverable symlink")
+	}
+	want := "refusing to include symlink " + linkPath
+	if err.Error() != want {
+		t.Fatalf("GenerateManifest error = %q, want %q", err, want)
+	}
+}
+
+func TestVerifyManifest_RejectsUnsafeAndMalformedEntries(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry ManifestEntry
+	}{
+		{"parent traversal", ManifestEntry{Name: "../secret", Size: 0, SHA256: strings.Repeat("0", 64)}},
+		{"absolute path", ManifestEntry{Name: "/etc/passwd", Size: 0, SHA256: strings.Repeat("0", 64)}},
+		{"unclean path", ManifestEntry{Name: "src/../file", Size: 0, SHA256: strings.Repeat("0", 64)}},
+		{"backslash path", ManifestEntry{Name: `src\\file`, Size: 0, SHA256: strings.Repeat("0", 64)}},
+		{"negative size", ManifestEntry{Name: "file", Size: -1, SHA256: strings.Repeat("0", 64)}},
+		{"invalid digest", ManifestEntry{Name: "file", Size: 0, SHA256: "not-a-digest"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			m := &BuildManifest{Files: []ManifestEntry{tc.entry}}
+			manifestPath := filepath.Join(tmpDir, "manifest.json")
+			if err := m.WriteJSON(manifestPath); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := VerifyManifest(manifestPath, tmpDir); err == nil {
+				t.Fatal("VerifyManifest should reject malformed entry")
+			}
+		})
+	}
+}
+
+func TestVerifyManifest_ReportsNULBytePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	manifestPath := filepath.Join(tmpDir, "manifest.json")
+	m := &BuildManifest{
+		Files: []ManifestEntry{{
+			Name:   "artifact\x00.sv",
+			Size:   1,
+			SHA256: strings.Repeat("0", 64),
+		}},
+	}
+	if err := m.WriteJSON(manifestPath); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := VerifyManifest(manifestPath, tmpDir)
+	if err == nil {
+		t.Fatal("VerifyManifest accepted an artifact path containing a NUL byte")
+	}
+	if !strings.Contains(err.Error(), "contains a NUL byte") {
+		t.Fatalf("VerifyManifest error = %q, want a distinct NUL-byte error", err)
+	}
+}
+
+func TestVerifyManifest_RejectsDuplicateAndSymlinkEntries(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "artifact.bin")
+	if err := os.WriteFile(filePath, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	hash, err := fileHash(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := ManifestEntry{Name: "artifact.bin", Size: 7, SHA256: hash}
+	m := &BuildManifest{Files: []ManifestEntry{entry, entry}}
+	manifestPath := filepath.Join(tmpDir, "manifest.json")
+	if err := m.WriteJSON(manifestPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := VerifyManifest(manifestPath, tmpDir); err == nil {
+		t.Fatal("VerifyManifest should reject duplicate entries")
+	}
+
+	linkPath := filepath.Join(tmpDir, "artifact-link.bin")
+	if err := os.Symlink(filePath, linkPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	m.Files = []ManifestEntry{{Name: "artifact-link.bin", Size: 7, SHA256: hash}}
+	if err := m.WriteJSON(manifestPath); err != nil {
+		t.Fatal(err)
+	}
+	verification, err := VerifyManifest(manifestPath, tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if verification.OK() || len(verification.Failed) != 1 {
+		t.Fatalf("symlink verification = %+v, want one failure", verification)
+	}
+
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "outside.bin")
+	if err := os.WriteFile(outsideFile, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideDir, filepath.Join(tmpDir, "linked-dir")); err != nil {
+		t.Skipf("directory symlink unavailable: %v", err)
+	}
+	m.Files = []ManifestEntry{{Name: "linked-dir/outside.bin", Size: 7, SHA256: hash}}
+	if err := m.WriteJSON(manifestPath); err != nil {
+		t.Fatal(err)
+	}
+	verification, err = VerifyManifest(manifestPath, tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if verification.OK() || len(verification.Failed) != 1 || !strings.Contains(verification.Failed[0], "escapes") {
+		t.Fatalf("intermediate symlink verification = %+v, want escape failure", verification)
+	}
+}
+
+func TestWriteBuildManifest_PopulatesMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	cs := pci.NewConfigSpace()
+	cs.WriteU16(0x00, 0x8086)
+	cs.WriteU16(0x02, 0x15b7)
+	ctx := &donor.DeviceContext{
+		ToolVersion: "v1.2.3",
+		Device: pci.PCIDevice{
+			BDF: pci.BDF{Domain: 0, Bus: 3, Device: 0, Function: 1},
+		},
+		ConfigSpace: cs,
+	}
+	b := &board.Board{Name: "CaptainDMA_35T"}
+	if err := WriteBuildManifest(tmpDir, ctx, b); err != nil {
+		t.Fatalf("WriteBuildManifest error: %v", err)
+	}
+	m, err := LoadManifest(filepath.Join(tmpDir, "build_manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Board != b.Name || m.DeviceBDF != "0000:03:00.1" || m.ToolVersion != "v1.2.3" {
+		t.Fatalf("manifest metadata = board %q, BDF %q, version %q", m.Board, m.DeviceBDF, m.ToolVersion)
+	}
+	if m.VendorID != 0x8086 || m.DeviceID != 0x15b7 {
+		t.Fatalf("manifest IDs = %04x:%04x", m.VendorID, m.DeviceID)
+	}
+}
+
+func TestGeneratePreSynthesisManifest_ExcludesStaleDeliverables(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, name := range []string{"stale.bit", "stale.bin"} {
+		if err := os.WriteFile(filepath.Join(tmpDir, name), []byte("stale"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m, err := generateManifest(tmpDir, "dev", "board", 0, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range m.Files {
+		if strings.HasSuffix(entry.Name, ".bit") || strings.HasSuffix(entry.Name, ".bin") {
+			t.Fatalf("pre-synthesis manifest included stale deliverable %q", entry.Name)
+		}
 	}
 }

--- a/internal/firmware/output/writer.go
+++ b/internal/firmware/output/writer.go
@@ -95,7 +95,9 @@ func (ow *OutputWriter) WriteAll(ctx *donor.DeviceContext, b *board.Board) error
 		}
 	}
 
-	ow.writeManifest(ctx, ids)
+	if err := writeBuildManifest(ow.OutputDir, ctx, b, false); err != nil {
+		return fmt.Errorf("failed to write build manifest: %w", err)
+	}
 	return nil
 }
 
@@ -169,19 +171,23 @@ func (ow *OutputWriter) writeTCLScripts(ctx *donor.DeviceContext, b *board.Board
 	return nil
 }
 
-// writeManifest generates the build manifest with file checksums.
-func (ow *OutputWriter) writeManifest(ctx *donor.DeviceContext, ids firmware.DeviceIDs) {
-	manifest, err := GenerateManifest(ow.OutputDir, ctx.ToolVersion, "", ids.VendorID, ids.DeviceID)
+func WriteBuildManifest(outputDir string, ctx *donor.DeviceContext, b *board.Board) error {
+	return writeBuildManifest(outputDir, ctx, b, true)
+}
+
+func writeBuildManifest(outputDir string, ctx *donor.DeviceContext, b *board.Board, includeSynthesized bool) error {
+	ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, ctx.ExtCapabilities)
+	manifest, err := generateManifest(outputDir, ctx.ToolVersion, b.Name, ids.VendorID, ids.DeviceID, includeSynthesized)
 	if err != nil {
-		slog.Warn("manifest generation failed", "error", err)
-		return
+		return err
 	}
-	manifestPath := ow.OutputDir + "/build_manifest.json"
+	manifest.DeviceBDF = ctx.Device.BDF.String()
+	manifestPath := filepath.Join(outputDir, "build_manifest.json")
 	if err := manifest.WriteJSON(manifestPath); err != nil {
-		slog.Warn("manifest write failed", "error", err)
-	} else {
-		slog.Info("build manifest written", "files", len(manifest.Files))
+		return err
 	}
+	slog.Info("build manifest written", "files", len(manifest.Files))
+	return nil
 }
 
 // svFilesReplacedByGenerator: board source files we replace with

--- a/internal/vivado/builder.go
+++ b/internal/vivado/builder.go
@@ -115,11 +115,23 @@ func (b *Builder) Build(ctx *donor.DeviceContext) error {
 		}
 	}
 
-	// Hand the deliverables to the invoking user after a sudo build.
+	refreshBuildManifest(fwout.WriteBuildManifest, b.opts.OutputDir, ctx, b.board)
+
 	if err := chownOutputs(b.opts.OutputDir); err != nil {
 		slog.Warn("chown output files", "error", err)
 	}
 
 	slog.Info("build completed successfully")
 	return nil
+}
+
+func refreshBuildManifest(
+	writeManifest func(string, *donor.DeviceContext, *board.Board) error,
+	outputDir string,
+	ctx *donor.DeviceContext,
+	b *board.Board,
+) {
+	if err := writeManifest(outputDir, ctx, b); err != nil {
+		slog.Warn("failed to refresh post-synthesis build manifest; bitstream remains available", "error", err)
+	}
 }

--- a/internal/vivado/vivado_test.go
+++ b/internal/vivado/vivado_test.go
@@ -1,11 +1,18 @@
 package vivado
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/board"
+	"github.com/sercanarga/pcileechgen/internal/donor"
 )
 
 func TestFindValidation(t *testing.T) {
@@ -139,5 +146,37 @@ exit 0
 	}
 	if !strings.Contains(err.Error(), "libtinfo.so.5") {
 		t.Fatalf("RunTCL error = %q, want loader detail", err.Error())
+	}
+}
+
+func TestRefreshBuildManifest_WarnsAndContinuesOnFailure(t *testing.T) {
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	refreshBuildManifest(
+		func(string, *donor.DeviceContext, *board.Board) error {
+			return errors.New("manifest storage unavailable")
+		},
+		t.TempDir(),
+		&donor.DeviceContext{},
+		&board.Board{Name: "TestBoard"},
+	)
+
+	var record struct {
+		Level string `json:"level"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(logs.Bytes()), &record); err != nil {
+		t.Fatalf("decode manifest refresh log: %v; log = %q", err, logs.String())
+	}
+	if record.Level != "WARN" {
+		t.Fatalf("manifest refresh failure level = %q, want WARN", record.Level)
+	}
+	if record.Error != "manifest storage unavailable" {
+		t.Fatalf("manifest refresh warning error = %q, want injected failure", record.Error)
 	}
 }


### PR DESCRIPTION
## Problem

`build_manifest.json` was written during artifact generation, before Vivado ran. As a result, the manifest never covered the final `.bit`/`.bin` deliverables it was meant to protect. It also only inventoried the first level of `src/`, silently replaced hash failures with the string `error`, and left the board/BDF metadata empty.

The verifier also accepted duplicate, malformed, and traversal-style paths from externally supplied manifests.

## Changes

- regenerate the manifest after Vivado outputs are copied to the output root
- include final `.bit` and `.bin` deliverables after synthesis
- recursively inventory `src/` and sort entries for deterministic output
- keep pre-synthesis manifests from adopting stale bitstreams from older builds
- populate board and donor BDF metadata
- fail manifest generation on stat/hash/type errors instead of recording invalid hashes
- atomically replace `build_manifest.json`
- validate paths, sizes, SHA-256 values, duplicates, regular-file types, and resolved-path containment during verification
- add regression coverage for nested sources, post-synthesis outputs, stale outputs, metadata, malformed entries, duplicates, and symlink escapes

## Verification

- `go test -race ./...`
- `go vet ./...`
- `staticcheck ./internal/firmware/output ./internal/vivado`
- end-to-end offline build with `--from-json --skip-vivado`, followed by `verify-manifest` (30/30 artifacts passed)

HDL generation is unchanged.
