### PR TITLE
feat: add validated declarative PCIe device model

### DIFF
--- a/internal/firmware/devicemodel/builder.go
+++ b/internal/firmware/devicemodel/builder.go
@@ -1,0 +1,305 @@
+package devicemodel
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sort"
+
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func New(ctx *donor.DeviceContext) (*Model, error) { return Build(ctx) }
+
+func Build(ctx *donor.DeviceContext) (*Model, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("device model: nil donor context")
+	}
+	if ctx.ConfigSpace == nil {
+		return nil, fmt.Errorf("device model: donor config space is missing")
+	}
+
+	m := &Model{
+		SchemaVersion:       CurrentSchemaVersion,
+		Name:                fmt.Sprintf("pci-%04x-%04x", ctx.ConfigSpace.VendorID(), ctx.ConfigSpace.DeviceID()),
+		Functions:           []Function{buildFunction(ctx)},
+		ConfigSpace:         buildConfigSpace(ctx),
+		Capabilities:        buildCapabilities(ctx),
+		BARs:                buildBARs(ctx),
+		Registers:           buildRegisters(ctx),
+		Interrupts:          []InterruptDescriptor{},
+		Transformations:     []Transformation{},
+		UnsupportedFeatures: buildUnsupported(ctx.ExtCapabilities),
+		Confidence:          buildConfidence(ctx),
+		Provenance: Provenance{
+			Source:      "donor.DeviceContext",
+			ToolVersion: ctx.ToolVersion,
+			CollectedAt: ctx.CollectedAt,
+			DonorBDF:    ctx.Device.BDF.String(),
+			Host:        ctx.Hostname,
+		},
+	}
+	m.Interrupts, m.MSIX = buildInterrupts(ctx, m.Capabilities)
+	if err := m.Validate(); err != nil {
+		return nil, fmt.Errorf("device model: donor context produced invalid model: %w", err)
+	}
+	return m, nil
+}
+
+func buildFunction(ctx *donor.DeviceContext) Function {
+	cs := ctx.ConfigSpace
+	return Function{
+		BDF:               ctx.Device.BDF.String(),
+		VendorID:          cs.VendorID(),
+		DeviceID:          cs.DeviceID(),
+		SubsystemVendorID: cs.SubsysVendorID(),
+		SubsystemDeviceID: cs.SubsysDeviceID(),
+		RevisionID:        cs.RevisionID(),
+		ClassCode:         cs.ClassCode(),
+		HeaderType:        cs.HeaderType(),
+	}
+}
+
+func buildConfigSpace(ctx *donor.DeviceContext) ConfigSpace {
+	size := ctx.ConfigSpace.Size
+	if size < 0 {
+		size = 0
+	}
+	if size > pci.ConfigSpaceSize {
+		size = pci.ConfigSpaceSize
+	}
+	image := append([]byte(nil), ctx.ConfigSpace.Data[:size]...)
+	command := uint64(ctx.ConfigSpace.ReadU16(0x04))
+	status := uint64(ctx.ConfigSpace.ReadU16(0x06))
+	fields := []ConfigField{
+		{Name: "vendor_id", Offset: 0x00, Width: 2, Mask: 0xffff, Access: AccessRO, ResetValue: uint64(ctx.ConfigSpace.ReadU16(0x00))},
+		{Name: "device_id", Offset: 0x02, Width: 2, Mask: 0xffff, Access: AccessRO, ResetValue: uint64(ctx.ConfigSpace.ReadU16(0x02))},
+		{Name: "command_rw", Offset: 0x04, Width: 2, Mask: 0x077f, Access: AccessRW, ResetValue: command & 0x077f},
+		{Name: "command_reserved", Offset: 0x04, Width: 2, Mask: 0xf880, Access: AccessReserved, ResetValue: command & 0xf880},
+		{Name: "status_rw1c", Offset: 0x06, Width: 2, Mask: 0xf900, Access: AccessRW1C, ResetValue: status & 0xf900},
+		{Name: "status_ro", Offset: 0x06, Width: 2, Mask: 0x06f8, Access: AccessRO, ResetValue: status & 0x06f8},
+		{Name: "status_reserved", Offset: 0x06, Width: 2, Mask: 0x0007, Access: AccessReserved, ResetValue: status & 0x0007},
+		{Name: "revision_class", Offset: 0x08, Width: 4, Mask: 0xffffffff, Access: AccessRO, ResetValue: uint64(ctx.ConfigSpace.ReadU32(0x08))},
+		{Name: "header", Offset: 0x0c, Width: 4, Mask: 0xffffffff, Access: AccessRO, ResetValue: uint64(ctx.ConfigSpace.ReadU32(0x0c))},
+	}
+	return ConfigSpace{Size: uint32(size), ResetImage: image, Fields: fields}
+}
+
+func buildCapabilities(ctx *donor.DeviceContext) []Capability {
+	caps := make([]Capability, 0, len(ctx.Capabilities)+len(ctx.ExtCapabilities))
+	standardStarts := make([]int, 0, len(ctx.Capabilities))
+	for _, capability := range ctx.Capabilities {
+		standardStarts = append(standardStarts, capability.Offset)
+	}
+	sort.Ints(standardStarts)
+	for _, c := range ctx.Capabilities {
+		data := normalizeCapabilityData(c.Offset, c.Data, standardStarts)
+		next := uint16(0)
+		if len(data) >= 2 {
+			next = uint16(data[1] & 0xfc)
+		}
+		caps = append(caps, Capability{
+			ID: uint16(c.ID), Name: pci.CapabilityName(c.ID), Offset: uint16(c.Offset),
+			NextOffset: next, Length: uint16(len(data)), Data: data,
+		})
+	}
+	extendedStarts := make([]int, 0, len(ctx.ExtCapabilities))
+	for _, capability := range ctx.ExtCapabilities {
+		extendedStarts = append(extendedStarts, capability.Offset)
+	}
+	sort.Ints(extendedStarts)
+	for _, c := range ctx.ExtCapabilities {
+		data := normalizeCapabilityData(c.Offset, c.Data, extendedStarts)
+		next := uint16(0)
+		if len(data) >= 4 {
+			next = uint16((binary.LittleEndian.Uint32(data[:4]) >> 20) & 0xffc)
+		}
+		caps = append(caps, Capability{
+			ID: c.ID, Name: pci.ExtCapabilityName(c.ID), Version: c.Version,
+			Offset: uint16(c.Offset), NextOffset: next, Length: uint16(len(data)),
+			Extended: true, Data: data,
+		})
+	}
+	sort.Slice(caps, func(i, j int) bool {
+		if caps[i].Extended != caps[j].Extended {
+			return !caps[i].Extended
+		}
+		return caps[i].Offset < caps[j].Offset
+	})
+	return caps
+}
+
+func normalizeCapabilityData(offset int, data []byte, starts []int) []byte {
+	length := len(data)
+	for _, start := range starts {
+		if start > offset && start-offset < length {
+			length = start - offset
+			break
+		}
+	}
+	return append([]byte(nil), data[:length]...)
+}
+
+func buildBARs(ctx *donor.DeviceContext) []BAR {
+	sources := append([]pci.BAR(nil), ctx.BARs...)
+	sort.Slice(sources, func(i, j int) bool { return sources[i].Index < sources[j].Index })
+	bars := make([]BAR, 0, len(sources))
+	for _, source := range sources {
+		if source.Type == pci.BARTypeDisabled {
+			continue
+		}
+		t := BARType(source.Type)
+		width := uint8(32)
+		var pair *int
+		if source.Type == pci.BARTypeMem64 || source.Is64Bit && source.Type != pci.BARTypeDisabled {
+			t = BARTypeMem64
+			width = 64
+			upper := source.Index + 1
+			pair = &upper
+		}
+		size := source.Size
+		if captured := uint64(len(ctx.BARContents[source.Index])); captured > size {
+			size = captured
+		}
+		if profile := ctx.BARProfiles[source.Index]; profile != nil && profile.Size > 0 && uint64(profile.Size) > size {
+			size = uint64(profile.Size)
+		}
+		image := append([]byte(nil), ctx.BARContents[source.Index]...)
+		bars = append(bars, BAR{
+			BIR: source.Index, Type: t, Size: size, SizeKnown: size > 0, Prefetchable: source.Prefetchable,
+			AddressWidth: width, PairBIR: pair, ResetImage: image,
+		})
+	}
+	sort.Slice(bars, func(i, j int) bool { return bars[i].BIR < bars[j].BIR })
+	return bars
+}
+
+func buildRegisters(ctx *donor.DeviceContext) []Register {
+	regs := buildConfigRegisters(ctx)
+	barIndexes := make([]int, 0, len(ctx.BARProfiles))
+	for index := range ctx.BARProfiles {
+		barIndexes = append(barIndexes, index)
+	}
+	sort.Ints(barIndexes)
+	for _, index := range barIndexes {
+		profile := ctx.BARProfiles[index]
+		if profile == nil || len(profile.Probes) == 0 {
+			continue
+		}
+		probes := append([]donor.BARProbeResult(nil), profile.Probes...)
+		sort.Slice(probes, func(i, j int) bool { return probes[i].Offset < probes[j].Offset })
+		for _, probe := range probes {
+			regs = append(regs, registerFromProbe(index, probe, ctx.BARContents[index]))
+		}
+	}
+	return regs
+}
+
+func buildConfigRegisters(ctx *donor.DeviceContext) []Register {
+	cs := ctx.ConfigSpace
+	return []Register{
+		{Name: "vendor_device", Space: SpaceConfig, BIR: ConfigBIR, Offset: 0, Width: 4, ResetDomain: ResetPowerOn, ResetValue: uint64(cs.ReadU32(0)), Confidence: ConfidenceSpecified, Fields: []RegisterField{{Name: "identity", Mask: 0xffffffff, Access: AccessRO, ResetValue: uint64(cs.ReadU32(0))}}},
+		{Name: "command_status", Space: SpaceConfig, BIR: ConfigBIR, Offset: 4, Width: 4, ResetDomain: ResetFundamental, ResetValue: uint64(cs.ReadU32(4)), Confidence: ConfidenceSpecified, Fields: []RegisterField{{Name: "command_rw", Mask: 0x0000077f, Access: AccessRW, ResetValue: uint64(cs.ReadU32(4)) & 0x0000077f}, {Name: "command_reserved", Mask: 0x0000f880, Access: AccessReserved, ResetValue: uint64(cs.ReadU32(4)) & 0x0000f880}, {Name: "status_rw1c", Mask: 0xf9000000, Access: AccessRW1C, ResetValue: uint64(cs.ReadU32(4)) & 0xf9000000}, {Name: "status_ro", Mask: 0x06f80000, Access: AccessRO, ResetValue: uint64(cs.ReadU32(4)) & 0x06f80000}, {Name: "status_reserved", Mask: 0x00070000, Access: AccessReserved, ResetValue: uint64(cs.ReadU32(4)) & 0x00070000}}},
+		{Name: "revision_class", Space: SpaceConfig, BIR: ConfigBIR, Offset: 8, Width: 4, ResetDomain: ResetPowerOn, ResetValue: uint64(cs.ReadU32(8)), Confidence: ConfidenceSpecified, Fields: []RegisterField{{Name: "value", Mask: 0xffffffff, Access: AccessRO, ResetValue: uint64(cs.ReadU32(8))}}},
+	}
+}
+
+func registerFromProbe(index int, probe donor.BARProbeResult, resetImage []byte) Register {
+	w1c := uint64(probe.W1CMask)
+	rw := uint64(probe.RWMask &^ probe.W1CMask)
+	ro := uint64(0xffffffff) &^ (rw | w1c)
+	reset := uint64(probe.Original)
+	for lane := range 4 {
+		imageOffset := int(probe.Offset) + lane
+		if imageOffset >= len(resetImage) {
+			continue
+		}
+		mask := uint64(0xff) << (lane * 8)
+		reset = reset&^mask | uint64(resetImage[imageOffset])<<(lane*8)
+	}
+	fields := make([]RegisterField, 0, 3)
+	if rw != 0 {
+		fields = append(fields, RegisterField{Name: "rw", Mask: rw, Access: AccessRW, ResetValue: reset & rw})
+	}
+	if w1c != 0 {
+		fields = append(fields, RegisterField{Name: "rw1c", Mask: w1c, Access: AccessRW1C, ResetValue: reset & w1c})
+	}
+	if ro != 0 {
+		fields = append(fields, RegisterField{Name: "ro", Mask: ro, Access: AccessRO, ResetValue: reset & ro})
+	}
+	return Register{
+		Name: fmt.Sprintf("bar%d_%04x", index, probe.Offset), Space: SpaceBAR, BIR: index,
+		Offset: uint64(probe.Offset), Width: 4, ResetDomain: ResetPowerOn,
+		ResetValue: reset, Fields: fields, Confidence: ConfidenceMeasured,
+	}
+}
+
+func buildInterrupts(ctx *donor.DeviceContext, caps []Capability) ([]InterruptDescriptor, *MSIXDescriptor) {
+	interrupts := make([]InterruptDescriptor, 0, 3)
+	if pin := ctx.ConfigSpace.InterruptPin(); pin != 0 {
+		interrupts = append(interrupts, InterruptDescriptor{Kind: "intx", Vectors: 1, Pin: pin})
+	}
+	var msixCapOffset uint16
+	for _, cap := range caps {
+		if cap.Extended {
+			continue
+		}
+		switch uint8(cap.ID) {
+		case pci.CapIDMSI:
+			vectors := uint16(1)
+			if len(cap.Data) >= 4 {
+				vectors <<= (binary.LittleEndian.Uint16(cap.Data[2:4]) >> 1) & 0x7
+			}
+			interrupts = append(interrupts, InterruptDescriptor{Kind: "msi", CapabilityOffset: cap.Offset, Vectors: vectors})
+		case pci.CapIDMSIX:
+			msixCapOffset = cap.Offset
+		}
+	}
+	if ctx.MSIXData == nil {
+		return interrupts, nil
+	}
+	d := &MSIXDescriptor{
+		CapabilityOffset: msixCapOffset, TableSize: uint16(ctx.MSIXData.TableSize),
+		TableBIR: ctx.MSIXData.TableBIR, TableOffset: uint64(ctx.MSIXData.TableOffset),
+		PBABIR: ctx.MSIXData.PBABIR, PBAOffset: uint64(ctx.MSIXData.PBAOffset),
+	}
+	interrupts = append(interrupts, InterruptDescriptor{
+		Kind: "msix", CapabilityOffset: msixCapOffset, Vectors: d.TableSize,
+		BIR: d.TableBIR, TableOffset: d.TableOffset, PBAOffset: d.PBAOffset,
+	})
+	return interrupts, d
+}
+
+func buildUnsupported(caps []pci.ExtCapability) []UnsupportedFeature {
+	known := map[uint16][2]string{
+		pci.ExtCapIDSRIOV:        {"SR-IOV", "virtual-function lifecycle is not modeled"},
+		pci.ExtCapIDMRIOV:        {"MR-IOV", "multi-root routing is not modeled"},
+		pci.ExtCapIDResizableBAR: {"Resizable BAR", "dynamic BAR resizing is not modeled"},
+		pci.ExtCapIDATS:          {"ATS", "translated DMA requests are not modeled"},
+		pci.ExtCapIDPageRequest:  {"Page Request", "page-fault requests are not modeled"},
+		pci.ExtCapIDPASID:        {"PASID", "process address spaces are not modeled"},
+		pci.ExtCapIDDPC:          {"DPC", "containment signaling is not modeled"},
+		pci.ExtCapIDPTM:          {"PTM", "precision time synchronization is not modeled"},
+		pci.ExtCapIDMulticast:    {"Multicast", "TLP multicast routing is not modeled"},
+	}
+	out := make([]UnsupportedFeature, 0)
+	for _, cap := range caps {
+		if item, ok := known[cap.ID]; ok {
+			out = append(out, UnsupportedFeature{Name: item[0], Reason: item[1], Source: fmt.Sprintf("extended capability 0x%04x", cap.ID)})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func buildConfidence(ctx *donor.DeviceContext) Confidence {
+	level := ConfidenceInferred
+	evidence := []string{"configuration space captured from donor"}
+	if len(ctx.BARProfiles) > 0 {
+		level = ConfidenceMeasured
+		evidence = append(evidence, "BAR access behavior measured by probe")
+	} else if len(ctx.BARContents) > 0 {
+		evidence = append(evidence, "BAR reset images captured without access probing")
+	}
+	return Confidence{Overall: level, Evidence: evidence}
+}

--- a/internal/firmware/devicemodel/builder_contract_test.go
+++ b/internal/firmware/devicemodel/builder_contract_test.go
@@ -1,0 +1,342 @@
+package devicemodel
+
+import (
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func TestBuildRepresentsUnknownBARSizeExplicitly(t *testing.T) {
+	ctx := deterministicContext()
+	ctx.BARs = []pci.BAR{{Index: 0, Type: pci.BARTypeMem32}}
+	ctx.BARContents = nil
+	ctx.BARProfiles = nil
+	ctx.MSIXData = nil
+
+	model, err := Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(model.BARs) != 1 {
+		t.Fatalf("BAR count = %d, want 1", len(model.BARs))
+	}
+	if model.BARs[0].SizeKnown || model.BARs[0].Size != 0 {
+		t.Fatalf("unknown BAR size represented as known: %+v", model.BARs[0])
+	}
+	if err := model.Validate(); err != nil {
+		t.Fatalf("unknown-size BAR model failed validation: %v", err)
+	}
+}
+
+func TestBuildMarksMeasuredBARSizeKnown(t *testing.T) {
+	ctx := deterministicContext()
+	ctx.BARs = []pci.BAR{{Index: 0, Type: pci.BARTypeMem32, Size: 0x100}}
+	ctx.BARContents = nil
+	ctx.BARProfiles = nil
+	ctx.MSIXData = nil
+
+	model, err := Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(model.BARs) != 1 || !model.BARs[0].SizeKnown || model.BARs[0].Size != 0x100 {
+		t.Fatalf("known BAR size was not preserved: %+v", model.BARs)
+	}
+}
+
+func TestBuildOmitsUnprobedBARRegisters(t *testing.T) {
+	ctx := deterministicContext()
+	ctx.BARs = []pci.BAR{{Index: 0, Type: pci.BARTypeMem32, Size: 0x100}}
+	ctx.BARContents = map[int][]byte{0: make([]byte, 0x100)}
+	ctx.BARProfiles = nil
+	ctx.MSIXData = nil
+
+	model, err := Build(ctx)
+	if err != nil {
+		t.Fatalf("Build unprobed model: %v", err)
+	}
+	for _, register := range model.Registers {
+		if register.Space == SpaceBAR {
+			t.Fatalf("unprobed BAR content became a behavioral register: %+v", register)
+		}
+	}
+
+	ctx.BARProfiles = map[int]*donor.BARProfile{
+		0: {
+			BarIndex: 0,
+			Size:     0x100,
+			Probes: []donor.BARProbeResult{{
+				Offset: 0x20, Original: 0xa5a5a5a5, RWMask: 0x0000ffff, W1CMask: 0x00ff0000,
+			}},
+		},
+	}
+	ctx.BARContents[0][0x20] = 0xa5
+	ctx.BARContents[0][0x21] = 0xa5
+	ctx.BARContents[0][0x22] = 0xa5
+	ctx.BARContents[0][0x23] = 0xa5
+	model, err = Build(ctx)
+	if err != nil {
+		t.Fatalf("Build probed model: %v", err)
+	}
+	var barRegisters []Register
+	for _, register := range model.Registers {
+		if register.Space == SpaceBAR {
+			barRegisters = append(barRegisters, register)
+		}
+	}
+	if len(barRegisters) != 1 || barRegisters[0].Offset != 0x20 {
+		t.Fatalf("probed BAR registers = %+v, want one register at 0x20", barRegisters)
+	}
+}
+
+func TestBuildUsesConfigSpaceAsIdentityAuthority(t *testing.T) {
+	ctx := deterministicContext()
+	ctx.Device.VendorID = 0xaaaa
+	ctx.Device.DeviceID = 0xbbbb
+	ctx.Device.SubsysVendorID = 0xcccc
+	ctx.Device.SubsysDeviceID = 0xdddd
+	ctx.Device.RevisionID = 0xee
+	ctx.Device.ClassCode = 0xffffff
+	ctx.Device.HeaderType = 0xff
+	ctx.ConfigSpace.WriteU16(0x00, 0x1111)
+	ctx.ConfigSpace.WriteU16(0x02, 0x2222)
+	ctx.ConfigSpace.WriteU8(0x08, 0x33)
+	ctx.ConfigSpace.WriteU8(0x09, 0x03)
+	ctx.ConfigSpace.WriteU8(0x0a, 0x02)
+	ctx.ConfigSpace.WriteU8(0x0b, 0x01)
+	ctx.ConfigSpace.WriteU8(0x0e, 0x80)
+	ctx.ConfigSpace.WriteU16(0x2c, 0x4444)
+	ctx.ConfigSpace.WriteU16(0x2e, 0x5555)
+
+	model, err := Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if model.Name != "pci-1111-2222" {
+		t.Fatalf("model name = %q, want config-space identity", model.Name)
+	}
+	function := model.Functions[0]
+	if function.VendorID != 0x1111 || function.DeviceID != 0x2222 ||
+		function.SubsystemVendorID != 0x4444 || function.SubsystemDeviceID != 0x5555 ||
+		function.RevisionID != 0x33 || function.ClassCode != 0x010203 || function.HeaderType != 0x80 {
+		t.Fatalf("function identity did not come from config space: %+v", function)
+	}
+}
+
+func TestBuildUsesPCICommandAndStatusAccessMasks(t *testing.T) {
+	ctx := deterministicContext()
+	ctx.ConfigSpace.WriteU16(0x04, 0xffff)
+	ctx.ConfigSpace.WriteU16(0x06, 0xffff)
+
+	model, err := Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	configExpected := map[string]struct {
+		mask   uint64
+		access AccessPolicy
+	}{
+		"command_rw":       {mask: 0x077f, access: AccessRW},
+		"command_reserved": {mask: 0xf880, access: AccessReserved},
+		"status_rw1c":      {mask: 0xf900, access: AccessRW1C},
+		"status_ro":        {mask: 0x06f8, access: AccessRO},
+		"status_reserved":  {mask: 0x0007, access: AccessReserved},
+	}
+	for name, expected := range configExpected {
+		found := false
+		for _, field := range model.ConfigSpace.Fields {
+			if field.Name == name {
+				found = true
+				if field.Mask != expected.mask || field.Access != expected.access {
+					t.Fatalf("config field %s = mask %#x access %q, want %#x %q", name, field.Mask, field.Access, expected.mask, expected.access)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("config field %s is missing", name)
+		}
+	}
+
+	var commandStatus *Register
+	for i := range model.Registers {
+		if model.Registers[i].Name == "command_status" {
+			commandStatus = &model.Registers[i]
+			break
+		}
+	}
+	if commandStatus == nil {
+		t.Fatal("command_status register is missing")
+	}
+	registerExpected := map[string]struct {
+		mask   uint64
+		access AccessPolicy
+	}{
+		"command_rw":       {mask: 0x0000077f, access: AccessRW},
+		"command_reserved": {mask: 0x0000f880, access: AccessReserved},
+		"status_rw1c":      {mask: 0xf9000000, access: AccessRW1C},
+		"status_ro":        {mask: 0x06f80000, access: AccessRO},
+		"status_reserved":  {mask: 0x00070000, access: AccessReserved},
+	}
+	for name, expected := range registerExpected {
+		found := false
+		for _, field := range commandStatus.Fields {
+			if field.Name == name {
+				found = true
+				if field.Mask != expected.mask || field.Access != expected.access {
+					t.Fatalf("register field %s = mask %#x access %q, want %#x %q", name, field.Mask, field.Access, expected.mask, expected.access)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("register field %s is missing", name)
+		}
+	}
+}
+
+func TestBuildCanonicalizesMem64BARPair(t *testing.T) {
+	ctx := deterministicContext()
+	ctx.BARs = []pci.BAR{
+		{Index: 0, Type: pci.BARTypeMem64, Size: 0x1000, Is64Bit: true},
+		{Index: 1, Type: pci.BARTypeDisabled},
+		{Index: 2, Type: pci.BARTypeDisabled},
+		{Index: 3, Type: pci.BARTypeDisabled},
+		{Index: 4, Type: pci.BARTypeDisabled},
+		{Index: 5, Type: pci.BARTypeDisabled},
+	}
+	ctx.BARContents = nil
+	ctx.BARProfiles = nil
+	ctx.MSIXData = nil
+
+	model, err := Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(model.BARs) != 1 {
+		t.Fatalf("canonical BAR count = %d, want 1: %+v", len(model.BARs), model.BARs)
+	}
+	bar := model.BARs[0]
+	if bar.BIR != 0 || bar.Type != BARTypeMem64 || bar.PairBIR == nil || *bar.PairBIR != 1 {
+		t.Fatalf("canonical 64-bit BAR pair = %+v, want BAR0 paired with BIR1", bar)
+	}
+}
+
+func TestBuildNormalizesParsedDescendingCapabilityChains(t *testing.T) {
+	config := pci.NewConfigSpace()
+	config.WriteU16(0x00, 0x1234)
+	config.WriteU16(0x02, 0x5678)
+	config.WriteU16(0x06, 0x0010)
+	config.WriteU8(0x34, 0x80)
+	config.WriteU8(0x80, pci.CapIDPowerManagement)
+	config.WriteU8(0x81, 0x50)
+	config.WriteU8(0x50, pci.CapIDMSI)
+	config.WriteU8(0x51, 0)
+	config.WriteU32(0x100, uint32(pci.ExtCapIDAER)|uint32(1)<<16|uint32(0x300)<<20)
+	config.WriteU32(0x300, uint32(pci.ExtCapIDACS)|uint32(1)<<16|uint32(0x200)<<20)
+	config.WriteU32(0x200, uint32(pci.ExtCapIDDeviceSerialNumber)|uint32(1)<<16)
+
+	ctx := deterministicContext()
+	ctx.ConfigSpace = config
+	ctx.Capabilities = pci.ParseCapabilities(config)
+	ctx.ExtCapabilities = pci.ParseExtCapabilities(config)
+	ctx.BARs = nil
+	ctx.BARContents = nil
+	ctx.BARProfiles = nil
+	ctx.MSIXData = nil
+
+	if len(ctx.Capabilities) != 2 || ctx.Capabilities[0].Offset != 0x80 || ctx.Capabilities[1].Offset != 0x50 {
+		t.Fatalf("standard parser did not traverse descending chain: %+v", ctx.Capabilities)
+	}
+	if len(ctx.ExtCapabilities) != 3 ||
+		ctx.ExtCapabilities[0].Offset != 0x100 ||
+		ctx.ExtCapabilities[1].Offset != 0x300 ||
+		ctx.ExtCapabilities[2].Offset != 0x200 {
+		t.Fatalf("extended parser did not traverse descending chain: %+v", ctx.ExtCapabilities)
+	}
+
+	model, err := Build(ctx)
+	if err != nil {
+		t.Fatalf("Build descending capability chains: %v", err)
+	}
+	if err := model.Validate(); err != nil {
+		t.Fatalf("normalized descending capability model failed validation: %v", err)
+	}
+
+	lengths := make(map[uint16]uint16)
+	next := make(map[uint16]uint16)
+	for _, capability := range model.Capabilities {
+		lengths[capability.Offset] = capability.Length
+		next[capability.Offset] = capability.NextOffset
+	}
+	if lengths[0x50] != 0x30 || next[0x50] != 0 || next[0x80] != 0x50 {
+		t.Fatalf("standard capability normalization = lengths %#v next %#v", lengths, next)
+	}
+	if lengths[0x100] != 0x100 || lengths[0x200] != 0x100 ||
+		next[0x100] != 0x300 || next[0x300] != 0x200 || next[0x200] != 0 {
+		t.Fatalf("extended capability normalization = lengths %#v next %#v", lengths, next)
+	}
+}
+
+func TestBuildUsesCapturedBARResetImageOverLaterProbeValue(t *testing.T) {
+	ctx := deterministicContext()
+	ctx.BARs = []pci.BAR{{Index: 0, Type: pci.BARTypeMem32, Size: 0x100}}
+	ctx.BARContents = map[int][]byte{0: {0x44, 0x33, 0x22, 0x11}}
+	ctx.BARProfiles = map[int]*donor.BARProfile{
+		0: {
+			BarIndex: 0,
+			Size:     0x100,
+			Probes: []donor.BARProbeResult{
+				{Offset: 0, Original: 0xaabbccdd, RWMask: 0x0000ffff, W1CMask: 0x00ff0000},
+				{Offset: 4, Original: 0x55667788, RWMask: 0xffffffff},
+			},
+		},
+	}
+	ctx.MSIXData = nil
+
+	model, err := Build(ctx)
+	if err != nil {
+		t.Fatalf("Build changing BAR snapshot: %v", err)
+	}
+	registers := make(map[uint64]Register)
+	for _, register := range model.Registers {
+		if register.Space == SpaceBAR {
+			registers[register.Offset] = register
+		}
+	}
+	captured, ok := registers[0]
+	if !ok {
+		t.Fatal("captured BAR register is missing")
+	}
+	if captured.ResetValue != 0x11223344 || captured.Confidence != ConfidenceMeasured {
+		t.Fatalf("captured register reset evidence = value %#x confidence %q", captured.ResetValue, captured.Confidence)
+	}
+	expectedFields := map[AccessPolicy]struct {
+		mask  uint64
+		reset uint64
+	}{
+		AccessRW:   {mask: 0x0000ffff, reset: 0x00003344},
+		AccessRW1C: {mask: 0x00ff0000, reset: 0x00220000},
+		AccessRO:   {mask: 0xff000000, reset: 0x11000000},
+	}
+	for _, field := range captured.Fields {
+		expected, exists := expectedFields[field.Access]
+		if !exists {
+			t.Fatalf("unexpected captured field: %+v", field)
+		}
+		if field.Mask != expected.mask || field.ResetValue != expected.reset {
+			t.Fatalf("captured field %q = mask %#x reset %#x, want %#x %#x", field.Access, field.Mask, field.ResetValue, expected.mask, expected.reset)
+		}
+		delete(expectedFields, field.Access)
+	}
+	if len(expectedFields) != 0 {
+		t.Fatalf("captured register omitted access evidence: %#v", expectedFields)
+	}
+	uncaptured, ok := registers[4]
+	if !ok {
+		t.Fatal("uncaptured BAR register is missing")
+	}
+	if uncaptured.ResetValue != 0x55667788 {
+		t.Fatalf("uncaptured register reset = %#x, want probe original %#x", uncaptured.ResetValue, uint64(0x55667788))
+	}
+}

--- a/internal/firmware/devicemodel/capability_contract_test.go
+++ b/internal/firmware/devicemodel/capability_contract_test.go
@@ -1,0 +1,36 @@
+package devicemodel
+
+import "testing"
+
+func TestValidateAcceptsDescendingStandardCapabilityLink(t *testing.T) {
+	model := validTestModel()
+	model.Capabilities = []Capability{
+		{ID: 0x01, Name: "power_management", Offset: 0x80, NextOffset: 0x50, Length: 4, Data: []byte{0x01, 0x50, 0, 0}},
+		{ID: 0x05, Name: "msi", Offset: 0x50, NextOffset: 0, Length: 4, Data: []byte{0x05, 0, 0, 0}},
+	}
+	if err := model.Validate(); err != nil {
+		t.Fatalf("descending standard capability link was rejected: %v", err)
+	}
+}
+
+func TestValidateRejectsStandardCapabilityCycle(t *testing.T) {
+	model := validTestModel()
+	model.Capabilities = []Capability{
+		{ID: 0x01, Name: "power_management", Offset: 0x80, NextOffset: 0x50, Length: 4, Data: []byte{0x01, 0x50, 0, 0}},
+		{ID: 0x05, Name: "msi", Offset: 0x50, NextOffset: 0x80, Length: 4, Data: []byte{0x05, 0x80, 0, 0}},
+	}
+	if err := model.Validate(); err == nil {
+		t.Fatal("capability cycle was accepted")
+	}
+}
+
+func TestValidateRejectsOverlappingCapabilityRanges(t *testing.T) {
+	model := validTestModel()
+	model.Capabilities = []Capability{
+		{ID: 0x01, Name: "power_management", Offset: 0x50, Length: 8, Data: make([]byte, 8)},
+		{ID: 0x05, Name: "msi", Offset: 0x54, Length: 4, Data: make([]byte, 4)},
+	}
+	if err := model.Validate(); err == nil {
+		t.Fatal("overlapping capability byte ranges were accepted")
+	}
+}

--- a/internal/firmware/devicemodel/json.go
+++ b/internal/firmware/devicemodel/json.go
@@ -1,0 +1,70 @@
+package devicemodel
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type modelWire Model
+
+func (m Model) MarshalJSON() ([]byte, error) {
+	if err := (&m).Validate(); err != nil {
+		return nil, fmt.Errorf("marshal device model: %w", err)
+	}
+	return json.Marshal(modelWire(m))
+}
+
+func (m *Model) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return fmt.Errorf("unmarshal device model: nil destination")
+	}
+	var decoded modelWire
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&decoded); err != nil {
+		return fmt.Errorf("unmarshal device model: %w", err)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return fmt.Errorf("unmarshal device model: %w", err)
+	}
+	candidate := Model(decoded)
+	if err := candidate.Validate(); err != nil {
+		return fmt.Errorf("unmarshal device model: %w", err)
+	}
+	*m = candidate
+	return nil
+}
+
+func (m *Model) ToJSON() ([]byte, error) {
+	if m == nil {
+		return nil, fmt.Errorf("marshal device model: nil model")
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func ParseJSON(data []byte) (*Model, error) {
+	var model Model
+	if err := json.Unmarshal(data, &model); err != nil {
+		return nil, err
+	}
+	return &model, nil
+}
+
+func FromJSON(data []byte) (*Model, error) { return ParseJSON(data) }
+
+func requireJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/firmware/devicemodel/model.go
+++ b/internal/firmware/devicemodel/model.go
@@ -1,0 +1,183 @@
+package devicemodel
+
+import "time"
+
+const CurrentSchemaVersion = 1
+
+const ConfigBIR = -1
+
+type AddressSpace string
+
+const (
+	SpaceConfig AddressSpace = "config"
+	SpaceBAR    AddressSpace = "bar"
+)
+
+type BARType string
+
+const (
+	BARTypeIO       BARType = "io"
+	BARTypeMem32    BARType = "mem32"
+	BARTypeMem64    BARType = "mem64"
+	BARTypeDisabled BARType = "disabled"
+)
+
+type AccessPolicy string
+
+const (
+	AccessRO       AccessPolicy = "ro"
+	AccessRW       AccessPolicy = "rw"
+	AccessRW1C     AccessPolicy = "rw1c"
+	AccessW1C      AccessPolicy = AccessRW1C
+	AccessW1S      AccessPolicy = "w1s"
+	AccessW0C      AccessPolicy = "w0c"
+	AccessRC       AccessPolicy = "rc"
+	AccessReserved AccessPolicy = "reserved"
+)
+
+type ResetDomain string
+
+const (
+	ResetPowerOn     ResetDomain = "power_on"
+	ResetFundamental ResetDomain = "fundamental"
+	ResetFunction    ResetDomain = "function"
+	ResetSoftware    ResetDomain = "software"
+)
+
+type ConfidenceLevel string
+
+const (
+	ConfidenceUnknown   ConfidenceLevel = "unknown"
+	ConfidenceInferred  ConfidenceLevel = "inferred"
+	ConfidenceMeasured  ConfidenceLevel = "measured"
+	ConfidenceSpecified ConfidenceLevel = "specified"
+)
+
+type Model struct {
+	SchemaVersion       int                   `json:"schema_version"`
+	Name                string                `json:"name"`
+	Functions           []Function            `json:"functions"`
+	ConfigSpace         ConfigSpace           `json:"config_space"`
+	Capabilities        []Capability          `json:"capabilities"`
+	BARs                []BAR                 `json:"bars"`
+	Registers           []Register            `json:"registers"`
+	Interrupts          []InterruptDescriptor `json:"interrupts"`
+	MSIX                *MSIXDescriptor       `json:"msix,omitempty"`
+	Transformations     []Transformation      `json:"transformations"`
+	UnsupportedFeatures []UnsupportedFeature  `json:"unsupported_features"`
+	Confidence          Confidence            `json:"confidence"`
+	Provenance          Provenance            `json:"provenance"`
+}
+
+type DeviceModel = Model
+
+type Function struct {
+	BDF               string `json:"bdf"`
+	VendorID          uint16 `json:"vendor_id"`
+	DeviceID          uint16 `json:"device_id"`
+	SubsystemVendorID uint16 `json:"subsystem_vendor_id"`
+	SubsystemDeviceID uint16 `json:"subsystem_device_id"`
+	RevisionID        uint8  `json:"revision_id"`
+	ClassCode         uint32 `json:"class_code"`
+	HeaderType        uint8  `json:"header_type"`
+}
+
+type ConfigSpace struct {
+	Size       uint32        `json:"size"`
+	ResetImage []byte        `json:"reset_image"`
+	Fields     []ConfigField `json:"fields"`
+}
+
+type ConfigField struct {
+	Name       string       `json:"name"`
+	Offset     uint16       `json:"offset"`
+	Width      uint8        `json:"width"`
+	Mask       uint64       `json:"mask"`
+	Access     AccessPolicy `json:"access"`
+	ResetValue uint64       `json:"reset_value"`
+}
+
+type Capability struct {
+	ID         uint16 `json:"id"`
+	Name       string `json:"name"`
+	Version    uint8  `json:"version,omitempty"`
+	Offset     uint16 `json:"offset"`
+	NextOffset uint16 `json:"next_offset"`
+	Length     uint16 `json:"length"`
+	Extended   bool   `json:"extended"`
+	Data       []byte `json:"data"`
+}
+
+type BAR struct {
+	BIR          int     `json:"bir"`
+	Type         BARType `json:"type"`
+	Size         uint64  `json:"size"`
+	SizeKnown    bool    `json:"size_known"`
+	Prefetchable bool    `json:"prefetchable"`
+	AddressWidth uint8   `json:"address_width"`
+	PairBIR      *int    `json:"pair_bir,omitempty"`
+	ResetImage   []byte  `json:"reset_image,omitempty"`
+}
+
+type Register struct {
+	Name        string          `json:"name"`
+	Space       AddressSpace    `json:"space"`
+	BIR         int             `json:"bir"`
+	Offset      uint64          `json:"offset"`
+	Width       uint8           `json:"width"`
+	ResetDomain ResetDomain     `json:"reset_domain"`
+	ResetValue  uint64          `json:"reset_value"`
+	Fields      []RegisterField `json:"fields"`
+	Confidence  ConfidenceLevel `json:"confidence"`
+}
+
+type RegisterField struct {
+	Name       string       `json:"name"`
+	Mask       uint64       `json:"mask"`
+	Access     AccessPolicy `json:"access"`
+	ResetValue uint64       `json:"reset_value"`
+}
+
+type InterruptDescriptor struct {
+	Kind             string `json:"kind"`
+	CapabilityOffset uint16 `json:"capability_offset,omitempty"`
+	Vectors          uint16 `json:"vectors"`
+	Pin              uint8  `json:"pin,omitempty"`
+	BIR              int    `json:"bir,omitempty"`
+	TableOffset      uint64 `json:"table_offset,omitempty"`
+	PBAOffset        uint64 `json:"pba_offset,omitempty"`
+}
+
+type MSIXDescriptor struct {
+	CapabilityOffset uint16 `json:"capability_offset"`
+	TableSize        uint16 `json:"table_size"`
+	TableBIR         int    `json:"table_bir"`
+	TableOffset      uint64 `json:"table_offset"`
+	PBABIR           int    `json:"pba_bir"`
+	PBAOffset        uint64 `json:"pba_offset"`
+}
+
+type Transformation struct {
+	Kind        string `json:"kind"`
+	Target      string `json:"target"`
+	Description string `json:"description"`
+}
+
+type UnsupportedFeature struct {
+	Name   string `json:"name"`
+	Reason string `json:"reason"`
+	Source string `json:"source"`
+}
+
+type Confidence struct {
+	Overall  ConfidenceLevel `json:"overall"`
+	Evidence []string        `json:"evidence"`
+}
+
+type Provenance struct {
+	Source      string    `json:"source"`
+	ToolVersion string    `json:"tool_version"`
+	CollectedAt time.Time `json:"collected_at"`
+	DonorBDF    string    `json:"donor_bdf"`
+	Host        string    `json:"host,omitempty"`
+}

--- a/internal/firmware/devicemodel/model_contract_test.go
+++ b/internal/firmware/devicemodel/model_contract_test.go
@@ -1,0 +1,478 @@
+package devicemodel
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func validConfigResetImage() []byte {
+	image := make([]byte, pci.ConfigSpaceLegacySize)
+	image[0x00], image[0x01] = 0x34, 0x12
+	image[0x02], image[0x03] = 0x78, 0x56
+	image[0x08] = 0x01
+	image[0x0b] = 0x02
+	image[0x2c], image[0x2d] = 0x34, 0x12
+	image[0x2e], image[0x2f] = 0xcd, 0xab
+	return image
+}
+
+func validTestModel() *Model {
+	pair := 3
+	return &Model{
+		SchemaVersion: CurrentSchemaVersion,
+		Name:          "contract-device",
+		Functions: []Function{{
+			BDF:               "0000:03:00.0",
+			VendorID:          0x1234,
+			DeviceID:          0x5678,
+			SubsystemVendorID: 0x1234,
+			SubsystemDeviceID: 0xabcd,
+			RevisionID:        1,
+			ClassCode:         0x020000,
+		}},
+		ConfigSpace: ConfigSpace{
+			Size:       pci.ConfigSpaceLegacySize,
+			ResetImage: validConfigResetImage(),
+		},
+		BARs: []BAR{
+			{BIR: 0, Type: BARTypeMem32, Size: 0x100, SizeKnown: true, AddressWidth: 32, ResetImage: make([]byte, 0x100)},
+			{BIR: 2, Type: BARTypeMem64, Size: 0x1000, SizeKnown: true, Prefetchable: true, AddressWidth: 64, PairBIR: &pair, ResetImage: make([]byte, 0x1000)},
+		},
+		MSIX: &MSIXDescriptor{
+			CapabilityOffset: 0,
+			TableSize:        2,
+			TableBIR:         0,
+			TableOffset:      0x40,
+			PBABIR:           0,
+			PBAOffset:        0x80,
+		},
+		Confidence: Confidence{Overall: ConfidenceMeasured, Evidence: []string{"unit-test fixture"}},
+		Provenance: Provenance{
+			Source:      "test",
+			ToolVersion: "test-version",
+			CollectedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+			DonorBDF:    "0000:03:00.0",
+		},
+	}
+}
+
+func deterministicContext() *donor.DeviceContext {
+	cs := pci.NewConfigSpaceFromBytes(make([]byte, pci.ConfigSpaceLegacySize))
+	cs.WriteU16(0x00, 0x1234)
+	cs.WriteU16(0x02, 0x5678)
+	cs.WriteU32(0x10, 0x80000000)
+	cs.WriteU32(0x18, 0x9000000c)
+	cs.WriteU32(0x1c, 0x00000001)
+	return &donor.DeviceContext{
+		CollectedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		ToolVersion: "test-version",
+		Hostname:    "test-host",
+		Device: pci.PCIDevice{
+			BDF:            pci.BDF{Domain: 0, Bus: 3, Device: 0, Function: 0},
+			VendorID:       0x1234,
+			DeviceID:       0x5678,
+			SubsysVendorID: 0x1234,
+			SubsysDeviceID: 0xabcd,
+			RevisionID:     1,
+			ClassCode:      0x020000,
+		},
+		ConfigSpace: cs,
+		BARs: []pci.BAR{
+			{Index: 2, Type: pci.BARTypeMem64, Size: 0x1000, Is64Bit: true, Prefetchable: true},
+			{Index: 0, Type: pci.BARTypeMem32, Size: 0x100},
+		},
+		BARContents: map[int][]byte{
+			2: make([]byte, 0x1000),
+			0: make([]byte, 0x100),
+		},
+		MSIXData: &donor.MSIXData{
+			TableSize: 2, TableBIR: 0, TableOffset: 0x40,
+			PBABIR: 0, PBAOffset: 0x80,
+		},
+	}
+}
+
+func TestBuildIsDeterministicAndCanonical(t *testing.T) {
+	first, err := Build(deterministicContext())
+	if err != nil {
+		t.Fatalf("Build(first): %v", err)
+	}
+	second, err := Build(deterministicContext())
+	if err != nil {
+		t.Fatalf("Build(second): %v", err)
+	}
+
+	firstJSON, err := first.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON(first): %v", err)
+	}
+	secondJSON, err := second.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON(second): %v", err)
+	}
+	if string(firstJSON) != string(secondJSON) {
+		t.Fatalf("identical donor snapshots produced different JSON\nfirst: %s\nsecond: %s", firstJSON, secondJSON)
+	}
+	if len(first.BARs) != 2 || first.BARs[0].BIR != 0 || first.BARs[1].BIR != 2 {
+		t.Fatalf("BARs are not in canonical BIR order: %+v", first.BARs)
+	}
+	if first.BARs[1].PairBIR == nil || *first.BARs[1].PairBIR != 3 {
+		t.Fatalf("64-bit BAR pair was not represented explicitly: %+v", first.BARs[1])
+	}
+}
+
+func TestJSONRoundTripPreservesModel(t *testing.T) {
+	model := validTestModel()
+	data, err := model.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON: %v", err)
+	}
+	got, err := FromJSON(data)
+	if err != nil {
+		t.Fatalf("FromJSON: %v", err)
+	}
+	if !reflect.DeepEqual(got, model) {
+		t.Fatalf("round trip changed model\ngot:  %#v\nwant: %#v", got, model)
+	}
+
+	again, err := got.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON(round-tripped): %v", err)
+	}
+	if string(again) != string(data) {
+		t.Fatalf("JSON is not canonical after round trip\nfirst:  %s\nsecond: %s", data, again)
+	}
+}
+
+func TestFromJSONRejectsUnsupportedSchemaAndUnknownFields(t *testing.T) {
+	data, err := validTestModel().ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var document map[string]any
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("future schema", func(t *testing.T) {
+		document["schema_version"] = float64(CurrentSchemaVersion + 1)
+		bad, err := json.Marshal(document)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := FromJSON(bad); err == nil {
+			t.Fatal("FromJSON accepted an unsupported schema version")
+		}
+	})
+
+	t.Run("unknown field", func(t *testing.T) {
+		document["schema_version"] = float64(CurrentSchemaVersion)
+		document["silently_ignored_contract_change"] = true
+		bad, err := json.Marshal(document)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := FromJSON(bad); err == nil {
+			t.Fatal("FromJSON accepted an unknown top-level field")
+		}
+	})
+}
+
+func TestValidateBARPairInvariants(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Model)
+	}{
+		{
+			name: "64-bit BAR must name adjacent upper BIR",
+			mutate: func(m *Model) {
+				wrong := 4
+				m.BARs[1].PairBIR = &wrong
+			},
+		},
+		{
+			name: "64-bit BAR cannot start at BIR5",
+			mutate: func(m *Model) {
+				pair := 6
+				m.BARs[1].BIR = 5
+				m.BARs[1].PairBIR = &pair
+			},
+		},
+		{
+			name: "32-bit BAR cannot consume a pair",
+			mutate: func(m *Model) {
+				pair := 1
+				m.BARs[0].PairBIR = &pair
+			},
+		},
+		{
+			name: "paired upper BIR cannot have an independent descriptor",
+			mutate: func(m *Model) {
+				m.BARs = append(m.BARs, BAR{BIR: 3, Type: BARTypeDisabled})
+			},
+		},
+		{
+			name: "BAR aperture must be a power of two",
+			mutate: func(m *Model) {
+				m.BARs[0].Size = 0x180
+				m.BARs[0].ResetImage = make([]byte, 0x180)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := validTestModel()
+			tt.mutate(model)
+			if err := model.Validate(); err == nil {
+				t.Fatal("Validate accepted an unlawful BAR topology")
+			}
+		})
+	}
+}
+
+func TestValidateMSIXInvariants(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Model)
+	}{
+		{"table BIR must exist", func(m *Model) { m.MSIX.TableBIR = 1 }},
+		{"PBA BIR must exist", func(m *Model) { m.MSIX.PBABIR = 1 }},
+		{"table must fit BAR", func(m *Model) { m.MSIX.TableOffset = 0xf8 }},
+		{"PBA must fit BAR", func(m *Model) { m.MSIX.PBAOffset = 0x100 }},
+		{"table offset must be aligned", func(m *Model) { m.MSIX.TableOffset = 0x43 }},
+		{"PBA offset must be aligned", func(m *Model) { m.MSIX.PBAOffset = 0x83 }},
+		{"table must contain a vector", func(m *Model) { m.MSIX.TableSize = 0 }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := validTestModel()
+			tt.mutate(model)
+			if err := model.Validate(); err == nil {
+				t.Fatal("Validate accepted an invalid MSI-X layout")
+			}
+		})
+	}
+}
+
+func TestValidateRejectsOverlappingRegisterFields(t *testing.T) {
+	model := validTestModel()
+	model.Registers = []Register{{
+		Name:        "status_control",
+		Space:       SpaceBAR,
+		BIR:         0,
+		Offset:      0,
+		Width:       4,
+		ResetDomain: ResetFunction,
+		Confidence:  ConfidenceSpecified,
+		Fields: []RegisterField{
+			{Name: "control", Mask: 0x000000ff, Access: AccessRW},
+			{Name: "status", Mask: 0x000000f0, Access: AccessW1C},
+		},
+	}}
+	if err := model.Validate(); err == nil {
+		t.Fatal("Validate accepted overlapping field masks")
+	}
+}
+
+func TestValidateRejectsInvalidFieldPoliciesAndMasks(t *testing.T) {
+	tests := []struct {
+		name  string
+		field RegisterField
+	}{
+		{
+			name:  "unknown access policy",
+			field: RegisterField{Name: "bad_access", Mask: 0xff, Access: AccessPolicy("write-anything")},
+		},
+		{
+			name:  "mask outside register width",
+			field: RegisterField{Name: "too_wide", Mask: 0x100, Access: AccessRW},
+		},
+		{
+			name:  "empty field mask",
+			field: RegisterField{Name: "empty", Mask: 0, Access: AccessRW},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := validTestModel()
+			model.Registers = []Register{{
+				Name:        "invalid",
+				Space:       SpaceBAR,
+				BIR:         0,
+				Offset:      0,
+				Width:       1,
+				ResetDomain: ResetFunction,
+				Confidence:  ConfidenceSpecified,
+				Fields:      []RegisterField{tt.field},
+			}}
+			if err := model.Validate(); err == nil {
+				t.Fatal("Validate accepted an invalid register field")
+			}
+		})
+	}
+}
+
+func TestValidateRejectsRegisterFieldResetValueMismatch(t *testing.T) {
+	model := validTestModel()
+	model.Registers = []Register{{
+		Name:        "reset_mismatch",
+		Space:       SpaceBAR,
+		BIR:         0,
+		Offset:      0,
+		Width:       1,
+		ResetDomain: ResetFunction,
+		ResetValue:  0xa5,
+		Confidence:  ConfidenceSpecified,
+		Fields: []RegisterField{{
+			Name:       "value",
+			Mask:       0xff,
+			Access:     AccessRW,
+			ResetValue: 0x5a,
+		}},
+	}}
+	if err := model.Validate(); err == nil {
+		t.Fatal("Validate accepted a register field reset value inconsistent with its register")
+	}
+}
+
+func TestValidateConfigFieldResetValueUsesLittleEndianResetImage(t *testing.T) {
+	model := validTestModel()
+	model.ConfigSpace.ResetImage[0x20] = 0x34
+	model.ConfigSpace.ResetImage[0x21] = 0x12
+	model.ConfigSpace.Fields = []ConfigField{{
+		Name:       "little_endian",
+		Offset:     0x20,
+		Width:      2,
+		Mask:       0x0fff,
+		Access:     AccessRO,
+		ResetValue: 0x0234,
+	}}
+	if err := model.Validate(); err != nil {
+		t.Fatalf("Validate rejected matching little-endian config reset value: %v", err)
+	}
+
+	model.ConfigSpace.Fields[0].ResetValue = 0x0235
+	if err := model.Validate(); err == nil {
+		t.Fatal("Validate accepted a config field reset value inconsistent with reset image bytes")
+	}
+}
+
+func TestValidateRejectsEachFunctionIdentityMismatchWithConfigImage(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Function)
+	}{
+		{name: "vendor ID", mutate: func(function *Function) { function.VendorID ^= 1 }},
+		{name: "device ID", mutate: func(function *Function) { function.DeviceID ^= 1 }},
+		{name: "subsystem vendor ID", mutate: func(function *Function) { function.SubsystemVendorID ^= 1 }},
+		{name: "subsystem device ID", mutate: func(function *Function) { function.SubsystemDeviceID ^= 1 }},
+		{name: "revision ID", mutate: func(function *Function) { function.RevisionID ^= 1 }},
+		{name: "class code", mutate: func(function *Function) { function.ClassCode ^= 1 }},
+		{name: "header type", mutate: func(function *Function) { function.HeaderType ^= 1 }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := validTestModel()
+			tt.mutate(&model.Functions[0])
+			if err := model.Validate(); err == nil {
+				t.Fatal("Validate accepted function identity inconsistent with config reset image")
+			}
+		})
+	}
+}
+
+func TestValidateRejectsConfigRegisterResetValueMismatchWithImage(t *testing.T) {
+	model := validTestModel()
+	model.Registers = []Register{{
+		Name:        "vendor_device",
+		Space:       SpaceConfig,
+		BIR:         ConfigBIR,
+		Offset:      0,
+		Width:       4,
+		ResetDomain: ResetPowerOn,
+		ResetValue:  0x56781235,
+		Confidence:  ConfidenceSpecified,
+	}}
+	if err := model.Validate(); err == nil {
+		t.Fatal("Validate accepted config register reset value inconsistent with config reset image")
+	}
+}
+
+func TestValidateRejectsBARRegisterResetValueMismatchWithImage(t *testing.T) {
+	model := validTestModel()
+	model.Registers = []Register{{
+		Name:        "bar_reset_mismatch",
+		Space:       SpaceBAR,
+		BIR:         0,
+		Offset:      0,
+		Width:       4,
+		ResetDomain: ResetPowerOn,
+		ResetValue:  1,
+		Confidence:  ConfidenceSpecified,
+	}}
+	if err := model.Validate(); err == nil {
+		t.Fatal("Validate accepted BAR register reset value inconsistent with BAR reset image")
+	}
+}
+
+func TestValidateRejectsMissingProvenanceFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Provenance)
+	}{
+		{name: "source", mutate: func(provenance *Provenance) { provenance.Source = "" }},
+		{name: "tool version", mutate: func(provenance *Provenance) { provenance.ToolVersion = "" }},
+		{name: "collection time", mutate: func(provenance *Provenance) { provenance.CollectedAt = time.Time{} }},
+		{name: "donor BDF", mutate: func(provenance *Provenance) { provenance.DonorBDF = "" }},
+		{name: "blank source", mutate: func(provenance *Provenance) { provenance.Source = " \t" }},
+		{name: "blank tool version", mutate: func(provenance *Provenance) { provenance.ToolVersion = "\n" }},
+		{name: "blank donor BDF", mutate: func(provenance *Provenance) { provenance.DonorBDF = " " }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := validTestModel()
+			tt.mutate(&model.Provenance)
+			if err := model.Validate(); err == nil {
+				t.Fatal("Validate accepted incomplete provenance")
+			}
+		})
+	}
+}
+
+func TestValidateRequiresExactlyOneFunction(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Model)
+	}{
+		{name: "missing", mutate: func(model *Model) { model.Functions = nil }},
+		{
+			name: "multiple",
+			mutate: func(model *Model) {
+				second := model.Functions[0]
+				second.BDF = "0000:04:00.0"
+				model.Functions = append(model.Functions, second)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := validTestModel()
+			tt.mutate(model)
+			if err := model.Validate(); err == nil {
+				t.Fatal("Validate accepted a model without exactly one function")
+			}
+		})
+	}
+}

--- a/internal/firmware/devicemodel/oracle.go
+++ b/internal/firmware/devicemodel/oracle.go
@@ -1,0 +1,152 @@
+package devicemodel
+
+import (
+	"fmt"
+	"sync"
+)
+
+type Oracle struct {
+	mu        sync.Mutex
+	registers []oracleRegister
+}
+
+type oracleRegister struct {
+	definition Register
+	value      uint64
+}
+
+func NewOracle(model *Model) (*Oracle, error) {
+	if err := model.Validate(); err != nil {
+		return nil, fmt.Errorf("create oracle: %w", err)
+	}
+	o := &Oracle{registers: make([]oracleRegister, len(model.Registers))}
+	for i, reg := range model.Registers {
+		reg.Fields = append([]RegisterField(nil), reg.Fields...)
+		o.registers[i] = oracleRegister{definition: reg, value: reg.ResetValue & widthMask(reg.Width)}
+	}
+	return o, nil
+}
+
+func (o *Oracle) Read(bir int, offset uint64, width int) (uint64, error) {
+	if o == nil {
+		return 0, fmt.Errorf("read: nil oracle")
+	}
+	if !validTransactionWidth(width) {
+		return 0, fmt.Errorf("read: width %d is not 1, 2, 4, or 8 bytes", width)
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	reg, shift, err := o.findRegister(bir, offset, width)
+	if err != nil {
+		return 0, fmt.Errorf("read: %w", err)
+	}
+	transactionMask := maskForBytes(width) << shift
+	visible := reg.value
+	for _, field := range reg.definition.Fields {
+		if field.Access == AccessReserved {
+			visible &^= field.Mask
+		}
+	}
+	result := (visible & transactionMask) >> shift
+	for _, field := range reg.definition.Fields {
+		if field.Access == AccessRC && field.Mask&transactionMask != 0 {
+			reg.value &^= field.Mask & transactionMask
+		}
+	}
+	return result, nil
+}
+
+func (o *Oracle) Write(bir int, offset uint64, width int, value uint64, byteEnable uint8) error {
+	if o == nil {
+		return fmt.Errorf("write: nil oracle")
+	}
+	if !validTransactionWidth(width) {
+		return fmt.Errorf("write: width %d is not 1, 2, 4, or 8 bytes", width)
+	}
+	if width < 8 && byteEnable>>width != 0 {
+		return fmt.Errorf("write: byte enable 0x%x selects lanes outside width %d", byteEnable, width)
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	reg, shift, err := o.findRegister(bir, offset, width)
+	if err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	laneMask := uint64(0)
+	for lane := range width {
+		if byteEnable&(1<<lane) != 0 {
+			laneMask |= uint64(0xff) << (lane * 8)
+		}
+	}
+	laneMask <<= shift
+	writeValue := (value & maskForBytes(width)) << shift
+	for _, field := range reg.definition.Fields {
+		affected := field.Mask & laneMask
+		if affected == 0 {
+			continue
+		}
+		switch field.Access {
+		case AccessRW:
+			reg.value = (reg.value &^ affected) | (writeValue & affected)
+		case AccessRW1C:
+			reg.value &^= writeValue & affected
+		case AccessW1S:
+			reg.value |= writeValue & affected
+		case AccessW0C:
+			reg.value &^= (^writeValue) & affected
+		case AccessRO, AccessRC, AccessReserved:
+		}
+	}
+	reg.value &= widthMask(reg.definition.Width)
+	return nil
+}
+
+func (o *Oracle) Reset(domain ResetDomain) error {
+	if o == nil {
+		return fmt.Errorf("reset: nil oracle")
+	}
+	if !validResetDomain(domain) {
+		return fmt.Errorf("reset: invalid domain %q", domain)
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	for i := range o.registers {
+		if resetAffects(domain, o.registers[i].definition.ResetDomain) {
+			o.registers[i].value = o.registers[i].definition.ResetValue & widthMask(o.registers[i].definition.Width)
+		}
+	}
+	return nil
+}
+
+func (o *Oracle) findRegister(bir int, offset uint64, width int) (*oracleRegister, uint, error) {
+	end := offset + uint64(width)
+	if end < offset {
+		return nil, 0, fmt.Errorf("transaction address overflows")
+	}
+	for i := range o.registers {
+		reg := &o.registers[i]
+		if reg.definition.BIR != bir {
+			continue
+		}
+		regEnd := reg.definition.Offset + uint64(reg.definition.Width)
+		if offset >= reg.definition.Offset && end <= regEnd {
+			return reg, uint((offset - reg.definition.Offset) * 8), nil
+		}
+	}
+	return nil, 0, fmt.Errorf("unmodeled BIR %d range 0x%x..0x%x", bir, offset, end)
+}
+
+func resetAffects(event, register ResetDomain) bool {
+	return event == register
+}
+
+func validTransactionWidth(width int) bool {
+	return width == 1 || width == 2 || width == 4 || width == 8
+}
+
+func maskForBytes(width int) uint64 {
+	if width == 8 {
+		return ^uint64(0)
+	}
+	return uint64(1)<<(width*8) - 1
+}

--- a/internal/firmware/devicemodel/oracle_contract_test.go
+++ b/internal/firmware/devicemodel/oracle_contract_test.go
@@ -1,0 +1,186 @@
+package devicemodel
+
+import "testing"
+
+func oracleContractModel() *Model {
+	model := validTestModel()
+	model.MSIX = nil
+	model.BARs = []BAR{{
+		BIR:          0,
+		Type:         BARTypeMem32,
+		Size:         0x100,
+		SizeKnown:    true,
+		AddressWidth: 32,
+		ResetImage:   make([]byte, 0x100),
+	}}
+	model.Registers = []Register{
+		{
+			Name: "read_only", Space: SpaceBAR, BIR: 0, Offset: 0x00, Width: 4,
+			ResetDomain: ResetPowerOn, ResetValue: 0xa5a5a5a5,
+			Fields: []RegisterField{{Name: "value", Mask: 0xffffffff, Access: AccessRO, ResetValue: 0xa5a5a5a5}},
+		},
+		{
+			Name: "byte_lanes", Space: SpaceBAR, BIR: 0, Offset: 0x04, Width: 4,
+			ResetDomain: ResetPowerOn, ResetValue: 0x11223344,
+			Fields: []RegisterField{{Name: "value", Mask: 0xffffffff, Access: AccessRW, ResetValue: 0x11223344}},
+		},
+		{
+			Name: "mixed_rw_w1c", Space: SpaceBAR, BIR: 0, Offset: 0x08, Width: 4,
+			ResetDomain: ResetFunction, ResetValue: 0x00f00012,
+			Fields: []RegisterField{
+				{Name: "control", Mask: 0x000000ff, Access: AccessRW, ResetValue: 0x12},
+				{Name: "status", Mask: 0x00ff0000, Access: AccessW1C, ResetValue: 0x00f00000},
+			},
+		},
+		{
+			Name: "read_clear", Space: SpaceBAR, BIR: 0, Offset: 0x0c, Width: 2,
+			ResetDomain: ResetFunction, ResetValue: 0xabcd,
+			Fields: []RegisterField{
+				{Name: "events", Mask: 0x00ff, Access: AccessRC, ResetValue: 0x00cd},
+				{Name: "control", Mask: 0xff00, Access: AccessRW, ResetValue: 0xab00},
+			},
+		},
+		{
+			Name: "write_one_set", Space: SpaceBAR, BIR: 0, Offset: 0x10, Width: 1,
+			ResetDomain: ResetSoftware, ResetValue: 0x0f,
+			Fields: []RegisterField{{Name: "flags", Mask: 0xff, Access: AccessW1S, ResetValue: 0x0f}},
+		},
+		{
+			Name: "write_zero_clear", Space: SpaceBAR, BIR: 0, Offset: 0x11, Width: 1,
+			ResetDomain: ResetSoftware, ResetValue: 0xff,
+			Fields: []RegisterField{{Name: "flags", Mask: 0xff, Access: AccessW0C, ResetValue: 0xff}},
+		},
+		{
+			Name: "reserved", Space: SpaceBAR, BIR: 0, Offset: 0x12, Width: 1,
+			ResetDomain: ResetPowerOn, ResetValue: 0x5a,
+			Fields: []RegisterField{{Name: "reserved", Mask: 0xff, Access: AccessReserved, ResetValue: 0x5a}},
+		},
+		{
+			Name: "fundamental_domain", Space: SpaceBAR, BIR: 0, Offset: 0x14, Width: 4,
+			ResetDomain: ResetFundamental, ResetValue: 0x11111111,
+			Fields: []RegisterField{{Name: "value", Mask: 0xffffffff, Access: AccessRW, ResetValue: 0x11111111}},
+		},
+		{
+			Name: "function_domain", Space: SpaceBAR, BIR: 0, Offset: 0x18, Width: 4,
+			ResetDomain: ResetFunction, ResetValue: 0x22222222,
+			Fields: []RegisterField{{Name: "value", Mask: 0xffffffff, Access: AccessRW, ResetValue: 0x22222222}},
+		},
+	}
+	for i := range model.Registers {
+		register := &model.Registers[i]
+		register.Confidence = ConfidenceSpecified
+		for lane := range int(register.Width) {
+			model.BARs[0].ResetImage[int(register.Offset)+lane] = byte(register.ResetValue >> (lane * 8))
+		}
+	}
+	return model
+}
+
+func newContractOracle(t *testing.T) *Oracle {
+	t.Helper()
+	oracle, err := NewOracle(oracleContractModel())
+	if err != nil {
+		t.Fatalf("NewOracle: %v", err)
+	}
+	return oracle
+}
+
+func readOracle(t *testing.T, oracle *Oracle, offset uint64, width int) uint64 {
+	t.Helper()
+	value, err := oracle.Read(0, offset, width)
+	if err != nil {
+		t.Fatalf("Read(BAR0, %#x, %d): %v", offset, width, err)
+	}
+	return value
+}
+
+func writeOracle(t *testing.T, oracle *Oracle, offset uint64, width int, value uint64, byteEnable uint8) {
+	t.Helper()
+	if err := oracle.Write(0, offset, width, value, byteEnable); err != nil {
+		t.Fatalf("Write(BAR0, %#x, %d, %#x, %#x): %v", offset, width, value, byteEnable, err)
+	}
+}
+
+func TestOracleByteEnablesAreLittleEndianLaneMasks(t *testing.T) {
+	oracle := newContractOracle(t)
+	writeOracle(t, oracle, 0x04, 4, 0xaabbccdd, 0b0101)
+	if got, want := readOracle(t, oracle, 0x04, 4), uint64(0x11bb33dd); got != want {
+		t.Fatalf("partial write = %#08x, want %#08x", got, want)
+	}
+}
+
+func TestOracleReadOnlyBitsRemainStable(t *testing.T) {
+	oracle := newContractOracle(t)
+	before := readOracle(t, oracle, 0x00, 4)
+	writeOracle(t, oracle, 0x00, 4, 0x00000000, 0xf)
+	writeOracle(t, oracle, 0x00, 4, 0xffffffff, 0xf)
+	if after := readOracle(t, oracle, 0x00, 4); after != before {
+		t.Fatalf("RO register changed from %#08x to %#08x", before, after)
+	}
+}
+
+func TestOracleReservedBitsRemainStable(t *testing.T) {
+	oracle := newContractOracle(t)
+	writeOracle(t, oracle, 0x12, 1, 0, 0x1)
+	if got, want := readOracle(t, oracle, 0x12, 1), uint64(0); got != want {
+		t.Fatalf("reserved register read = %#02x, want hardwired %#02x", got, want)
+	}
+}
+
+func TestOracleMixedRWAndW1CFields(t *testing.T) {
+	oracle := newContractOracle(t)
+	writeOracle(t, oracle, 0x08, 4, 0x00550034, 0xf)
+	if got, want := readOracle(t, oracle, 0x08, 4), uint64(0x00a00034); got != want {
+		t.Fatalf("mixed RW/W1C write = %#08x, want %#08x", got, want)
+	}
+}
+
+func TestOracleReadClearReturnsOldValueThenClearsOnlyRCBits(t *testing.T) {
+	oracle := newContractOracle(t)
+	if got, want := readOracle(t, oracle, 0x0c, 2), uint64(0xabcd); got != want {
+		t.Fatalf("first RC read = %#04x, want %#04x", got, want)
+	}
+	if got, want := readOracle(t, oracle, 0x0c, 2), uint64(0xab00); got != want {
+		t.Fatalf("second RC read = %#04x, want preserved RW bits %#04x", got, want)
+	}
+}
+
+func TestOracleWriteOneSetAndWriteZeroClear(t *testing.T) {
+	oracle := newContractOracle(t)
+
+	writeOracle(t, oracle, 0x10, 1, 0x30, 0x1)
+	if got, want := readOracle(t, oracle, 0x10, 1), uint64(0x3f); got != want {
+		t.Fatalf("W1S result = %#02x, want %#02x", got, want)
+	}
+
+	writeOracle(t, oracle, 0x11, 1, 0xf0, 0x1)
+	if got, want := readOracle(t, oracle, 0x11, 1), uint64(0xf0); got != want {
+		t.Fatalf("W0C result = %#02x, want %#02x", got, want)
+	}
+}
+
+func TestOracleResetDomainsAreIndependent(t *testing.T) {
+	oracle := newContractOracle(t)
+	writeOracle(t, oracle, 0x14, 4, 0, 0xf)
+	writeOracle(t, oracle, 0x18, 4, 0, 0xf)
+
+	if err := oracle.Reset(ResetFunction); err != nil {
+		t.Fatalf("Reset(function): %v", err)
+	}
+	if got := readOracle(t, oracle, 0x14, 4); got != 0 {
+		t.Fatalf("function reset changed fundamental-domain register to %#x", got)
+	}
+	if got, want := readOracle(t, oracle, 0x18, 4), uint64(0x22222222); got != want {
+		t.Fatalf("function-domain reset = %#x, want %#x", got, want)
+	}
+
+	if err := oracle.Reset(ResetFundamental); err != nil {
+		t.Fatalf("Reset(fundamental): %v", err)
+	}
+	if got, want := readOracle(t, oracle, 0x14, 4), uint64(0x11111111); got != want {
+		t.Fatalf("fundamental-domain reset = %#x, want %#x", got, want)
+	}
+	if got, want := readOracle(t, oracle, 0x18, 4), uint64(0x22222222); got != want {
+		t.Fatalf("fundamental reset disturbed function-domain register: got %#x, want %#x", got, want)
+	}
+}

--- a/internal/firmware/devicemodel/validate.go
+++ b/internal/firmware/devicemodel/validate.go
@@ -1,0 +1,484 @@
+package devicemodel
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func (m *Model) Validate() error {
+	if m == nil {
+		return fmt.Errorf("nil model")
+	}
+	if m.SchemaVersion != CurrentSchemaVersion {
+		return fmt.Errorf("unsupported schema_version %d (supported: %d)", m.SchemaVersion, CurrentSchemaVersion)
+	}
+	if m.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if len(m.Functions) != 1 {
+		return fmt.Errorf("exactly one function is required")
+	}
+	if err := validateConfigSpace(m.ConfigSpace); err != nil {
+		return err
+	}
+	if err := validateFunctions(m.Functions, m.ConfigSpace); err != nil {
+		return err
+	}
+	if err := validateCapabilities(m.Capabilities, m.ConfigSpace.Size); err != nil {
+		return err
+	}
+	bars, err := validateBARs(m.BARs)
+	if err != nil {
+		return err
+	}
+	if err := validateRegisters(m.Registers, m.ConfigSpace, bars); err != nil {
+		return err
+	}
+	if err := validateInterrupts(m.Interrupts, m.MSIX, m.Capabilities, bars); err != nil {
+		return err
+	}
+	if !validConfidence(m.Confidence.Overall) {
+		return fmt.Errorf("invalid confidence level %q", m.Confidence.Overall)
+	}
+	if strings.TrimSpace(m.Provenance.Source) == "" {
+		return fmt.Errorf("provenance source is required")
+	}
+	if strings.TrimSpace(m.Provenance.ToolVersion) == "" {
+		return fmt.Errorf("provenance tool_version is required")
+	}
+	if strings.TrimSpace(m.Provenance.DonorBDF) == "" {
+		return fmt.Errorf("provenance donor_bdf is required")
+	}
+	if m.Provenance.CollectedAt.IsZero() {
+		return fmt.Errorf("provenance collected_at is required")
+	}
+	return nil
+}
+
+func validateFunctions(functions []Function, config ConfigSpace) error {
+	seen := make(map[string]bool)
+	for i, fn := range functions {
+		if fn.BDF == "" {
+			return fmt.Errorf("functions[%d]: bdf is required", i)
+		}
+		if seen[fn.BDF] {
+			return fmt.Errorf("functions[%d]: duplicate bdf %q", i, fn.BDF)
+		}
+		seen[fn.BDF] = true
+		if fn.ClassCode > 0xffffff {
+			return fmt.Errorf("functions[%d]: class_code exceeds 24 bits", i)
+		}
+		if config.Size >= 4 {
+			identity := readLittleEndian(config.ResetImage, 0, 4)
+			if fn.VendorID != uint16(identity) || fn.DeviceID != uint16(identity>>16) {
+				return fmt.Errorf("functions[%d]: vendor or device identity does not match config reset image", i)
+			}
+		}
+		if config.Size >= 12 {
+			classRevision := readLittleEndian(config.ResetImage, 8, 4)
+			if fn.RevisionID != uint8(classRevision) || fn.ClassCode != uint32(classRevision>>8) {
+				return fmt.Errorf("functions[%d]: revision or class identity does not match config reset image", i)
+			}
+		}
+		if config.Size >= 15 && fn.HeaderType != config.ResetImage[0x0e] {
+			return fmt.Errorf("functions[%d]: header type does not match config reset image", i)
+		}
+		if config.Size >= 48 {
+			subsystem := readLittleEndian(config.ResetImage, 0x2c, 4)
+			if fn.SubsystemVendorID != uint16(subsystem) || fn.SubsystemDeviceID != uint16(subsystem>>16) {
+				return fmt.Errorf("functions[%d]: subsystem identity does not match config reset image", i)
+			}
+		}
+	}
+	return nil
+}
+
+func validateConfigSpace(config ConfigSpace) error {
+	if config.Size == 0 || config.Size > 4096 {
+		return fmt.Errorf("config_space.size %d is outside 1..4096", config.Size)
+	}
+	if uint32(len(config.ResetImage)) != config.Size {
+		return fmt.Errorf("config_space.reset_image length %d does not match size %d", len(config.ResetImage), config.Size)
+	}
+	occupied := make(map[uint32]uint8)
+	for i, field := range config.Fields {
+		if field.Name == "" {
+			return fmt.Errorf("config_space.fields[%d]: name is required", i)
+		}
+		if !validWidth(field.Width) {
+			return fmt.Errorf("config_space.fields[%d]: width %d is not 1, 2, 4, or 8 bytes", i, field.Width)
+		}
+		end := uint32(field.Offset) + uint32(field.Width)
+		if end > config.Size {
+			return fmt.Errorf("config_space.fields[%d]: range exceeds config space", i)
+		}
+		if field.Mask == 0 || field.Mask&^widthMask(field.Width) != 0 {
+			return fmt.Errorf("config_space.fields[%d]: mask 0x%x is invalid for width %d", i, field.Mask, field.Width)
+		}
+		if !validAccess(field.Access) {
+			return fmt.Errorf("config_space.fields[%d]: invalid access policy %q", i, field.Access)
+		}
+		if field.ResetValue&^field.Mask != 0 {
+			return fmt.Errorf("config_space.fields[%d]: reset value sets bits outside mask", i)
+		}
+		var imageValue uint64
+		for lane := range int(field.Width) {
+			imageValue |= uint64(config.ResetImage[int(field.Offset)+lane]) << (lane * 8)
+		}
+		if field.ResetValue != imageValue&field.Mask {
+			return fmt.Errorf("config_space.fields[%d]: reset value does not match reset image", i)
+		}
+		for lane := range int(field.Width) {
+			byteMask := uint8(field.Mask >> (lane * 8))
+			offset := uint32(field.Offset) + uint32(lane)
+			if occupied[offset]&byteMask != 0 {
+				return fmt.Errorf("config_space field %q overlaps another field at byte 0x%x", field.Name, offset)
+			}
+			occupied[offset] |= byteMask
+		}
+	}
+	return nil
+}
+
+func validateCapabilities(caps []Capability, configSize uint32) error {
+	standard := make(map[uint16]Capability)
+	extended := make(map[uint16]Capability)
+	for i, cap := range caps {
+		if cap.Length == 0 || int(cap.Length) != len(cap.Data) {
+			return fmt.Errorf("capabilities[%d]: length %d does not match data length %d", i, cap.Length, len(cap.Data))
+		}
+		if cap.Offset&3 != 0 {
+			return fmt.Errorf("capabilities[%d]: offset 0x%x is not DWORD aligned", i, cap.Offset)
+		}
+		set := standard
+		minimum, limit, minLength := uint16(0x40), configSize, uint16(2)
+		if limit > 0x100 {
+			limit = 0x100
+		}
+		if cap.Extended {
+			set = extended
+			minimum, limit, minLength = 0x100, configSize, 4
+			if cap.Version == 0 {
+				return fmt.Errorf("capabilities[%d]: extended capability version must be nonzero", i)
+			}
+		}
+		if cap.Offset < minimum || uint32(cap.Offset)+uint32(cap.Length) > limit || cap.Length < minLength {
+			return fmt.Errorf("capabilities[%d]: range 0x%x+0x%x is invalid", i, cap.Offset, cap.Length)
+		}
+		if _, exists := set[cap.Offset]; exists {
+			return fmt.Errorf("capabilities[%d]: duplicate offset 0x%x", i, cap.Offset)
+		}
+		set[cap.Offset] = cap
+	}
+	if err := validateCapabilityRanges("standard", standard); err != nil {
+		return err
+	}
+	if err := validateCapabilityRanges("extended", extended); err != nil {
+		return err
+	}
+
+	if err := validateCapabilityLinks("standard", standard); err != nil {
+		return err
+	}
+	if err := validateCapabilityLinks("extended", extended); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateCapabilityRanges(kind string, caps map[uint16]Capability) error {
+	ordered := make([]Capability, 0, len(caps))
+	for _, cap := range caps {
+		ordered = append(ordered, cap)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Offset < ordered[j].Offset })
+	for i := 1; i < len(ordered); i++ {
+		previousEnd := uint32(ordered[i-1].Offset) + uint32(ordered[i-1].Length)
+		if uint32(ordered[i].Offset) < previousEnd {
+			return fmt.Errorf("%s capabilities at 0x%x and 0x%x overlap", kind, ordered[i-1].Offset, ordered[i].Offset)
+		}
+	}
+	return nil
+}
+
+func validateCapabilityLinks(kind string, caps map[uint16]Capability) error {
+	for offset, cap := range caps {
+		if cap.NextOffset == 0 {
+			continue
+		}
+		if cap.NextOffset&3 != 0 {
+			return fmt.Errorf("%s capability at 0x%x has unaligned next pointer 0x%x", kind, offset, cap.NextOffset)
+		}
+		if _, ok := caps[cap.NextOffset]; !ok {
+			return fmt.Errorf("%s capability at 0x%x points to missing capability 0x%x", kind, offset, cap.NextOffset)
+		}
+	}
+	state := make(map[uint16]uint8, len(caps))
+	var visit func(uint16) error
+	visit = func(offset uint16) error {
+		switch state[offset] {
+		case 1:
+			return fmt.Errorf("%s capability chain contains a cycle at 0x%x", kind, offset)
+		case 2:
+			return nil
+		}
+		state[offset] = 1
+		if next := caps[offset].NextOffset; next != 0 {
+			if err := visit(next); err != nil {
+				return err
+			}
+		}
+		state[offset] = 2
+		return nil
+	}
+	for offset := range caps {
+		if err := visit(offset); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateBARs(bars []BAR) (map[int]BAR, error) {
+	byBIR := make(map[int]BAR, len(bars))
+	for i, bar := range bars {
+		if bar.BIR < 0 || bar.BIR > 5 {
+			return nil, fmt.Errorf("bars[%d]: BIR %d is outside 0..5", i, bar.BIR)
+		}
+		if _, exists := byBIR[bar.BIR]; exists {
+			return nil, fmt.Errorf("bars[%d]: duplicate BIR %d", i, bar.BIR)
+		}
+		if !validBARType(bar.Type) {
+			return nil, fmt.Errorf("bars[%d]: invalid type %q", i, bar.Type)
+		}
+		if bar.Type == BARTypeDisabled {
+			if bar.Size != 0 || bar.SizeKnown || bar.PairBIR != nil {
+				return nil, fmt.Errorf("bars[%d]: disabled BAR must have unknown zero size and no pair", i)
+			}
+		} else if bar.SizeKnown {
+			if bar.Size == 0 || bar.Size&(bar.Size-1) != 0 {
+				return nil, fmt.Errorf("bars[%d]: known enabled BAR size %d must be a nonzero power of two", i, bar.Size)
+			}
+			if uint64(len(bar.ResetImage)) > bar.Size {
+				return nil, fmt.Errorf("bars[%d]: reset image is larger than BAR", i)
+			}
+		} else if bar.Size != 0 || len(bar.ResetImage) != 0 {
+			return nil, fmt.Errorf("bars[%d]: unknown BAR size must be zero with no reset image", i)
+		}
+		if bar.Type == BARTypeMem64 {
+			if bar.AddressWidth != 64 || bar.PairBIR == nil || *bar.PairBIR != bar.BIR+1 || *bar.PairBIR > 5 {
+				return nil, fmt.Errorf("bars[%d]: 64-bit BAR must claim the immediately following BIR", i)
+			}
+		} else if bar.PairBIR != nil {
+			return nil, fmt.Errorf("bars[%d]: only a 64-bit BAR may claim a pair", i)
+		} else if bar.Type != BARTypeDisabled && bar.AddressWidth != 32 {
+			return nil, fmt.Errorf("bars[%d]: non-64-bit BAR address_width must be 32", i)
+		}
+		byBIR[bar.BIR] = bar
+	}
+	for _, bar := range bars {
+		if bar.PairBIR == nil {
+			continue
+		}
+		if _, exists := byBIR[*bar.PairBIR]; exists {
+			return nil, fmt.Errorf("64-bit BAR%d upper BIR %d must not have an independent descriptor", bar.BIR, *bar.PairBIR)
+		}
+	}
+	return byBIR, nil
+}
+
+func validateRegisters(registers []Register, config ConfigSpace, bars map[int]BAR) error {
+	type key struct {
+		space AddressSpace
+		bir   int
+	}
+	type span struct {
+		start, end uint64
+		index      int
+	}
+	groups := make(map[key][]span)
+	for i, reg := range registers {
+		if reg.Name == "" {
+			return fmt.Errorf("registers[%d]: name is required", i)
+		}
+		if !validWidth(reg.Width) {
+			return fmt.Errorf("registers[%d]: width %d is not 1, 2, 4, or 8 bytes", i, reg.Width)
+		}
+		if reg.Offset%uint64(reg.Width) != 0 {
+			return fmt.Errorf("registers[%d]: offset 0x%x is not aligned to width %d", i, reg.Offset, reg.Width)
+		}
+		if reg.ResetValue&^widthMask(reg.Width) != 0 {
+			return fmt.Errorf("registers[%d]: reset value exceeds width", i)
+		}
+		if !validResetDomain(reg.ResetDomain) {
+			return fmt.Errorf("registers[%d]: invalid reset domain %q", i, reg.ResetDomain)
+		}
+		if !validConfidence(reg.Confidence) {
+			return fmt.Errorf("registers[%d]: invalid confidence %q", i, reg.Confidence)
+		}
+		limit := uint64(config.Size)
+		resetImage := config.ResetImage
+		switch reg.Space {
+		case SpaceConfig:
+			if reg.BIR != ConfigBIR {
+				return fmt.Errorf("registers[%d]: config register BIR must be %d", i, ConfigBIR)
+			}
+		case SpaceBAR:
+			bar, ok := bars[reg.BIR]
+			if !ok || bar.Type == BARTypeDisabled {
+				return fmt.Errorf("registers[%d]: references missing or disabled BAR%d", i, reg.BIR)
+			}
+			limit = bar.Size
+			resetImage = bar.ResetImage
+		default:
+			return fmt.Errorf("registers[%d]: invalid address space %q", i, reg.Space)
+		}
+		end := reg.Offset + uint64(reg.Width)
+		if end < reg.Offset || end > limit {
+			return fmt.Errorf("registers[%d]: range exceeds its address space", i)
+		}
+		for lane := range int(reg.Width) {
+			imageOffset := int(reg.Offset) + lane
+			if imageOffset >= len(resetImage) {
+				continue
+			}
+			actual := uint8(reg.ResetValue >> (lane * 8))
+			if actual != resetImage[imageOffset] {
+				return fmt.Errorf("registers[%d]: reset value does not match address-space reset image", i)
+			}
+		}
+		var occupied uint64
+		for j, field := range reg.Fields {
+			if field.Name == "" || field.Mask == 0 || field.Mask&^widthMask(reg.Width) != 0 {
+				return fmt.Errorf("registers[%d].fields[%d]: invalid name or mask", i, j)
+			}
+			if occupied&field.Mask != 0 {
+				return fmt.Errorf("registers[%d].fields[%d]: field mask overlaps another field", i, j)
+			}
+			if !validAccess(field.Access) {
+				return fmt.Errorf("registers[%d].fields[%d]: invalid access policy %q", i, j, field.Access)
+			}
+			if field.ResetValue&^field.Mask != 0 {
+				return fmt.Errorf("registers[%d].fields[%d]: reset value sets bits outside mask", i, j)
+			}
+			if field.ResetValue != reg.ResetValue&field.Mask {
+				return fmt.Errorf("registers[%d].fields[%d]: reset value does not match register reset value", i, j)
+			}
+			occupied |= field.Mask
+		}
+		groups[key{reg.Space, reg.BIR}] = append(groups[key{reg.Space, reg.BIR}], span{reg.Offset, end, i})
+	}
+	for _, spans := range groups {
+		sort.Slice(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
+		for i := 1; i < len(spans); i++ {
+			if spans[i].start < spans[i-1].end {
+				return fmt.Errorf("registers[%d] overlaps registers[%d]", spans[i].index, spans[i-1].index)
+			}
+		}
+	}
+	return nil
+}
+
+func validateInterrupts(interrupts []InterruptDescriptor, msix *MSIXDescriptor, caps []Capability, bars map[int]BAR) error {
+	for i, irq := range interrupts {
+		switch irq.Kind {
+		case "intx", "msi", "msix":
+		default:
+			return fmt.Errorf("interrupts[%d]: unsupported kind %q", i, irq.Kind)
+		}
+		if irq.Vectors == 0 {
+			return fmt.Errorf("interrupts[%d]: vectors must be nonzero", i)
+		}
+	}
+	if msix == nil {
+		return nil
+	}
+	if msix.TableSize == 0 || msix.TableSize > 2048 {
+		return fmt.Errorf("msix.table_size %d is outside 1..2048", msix.TableSize)
+	}
+	if msix.CapabilityOffset != 0 {
+		found := false
+		for _, cap := range caps {
+			if !cap.Extended && cap.ID == 0x11 && cap.Offset == msix.CapabilityOffset {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("msix capability offset 0x%x does not reference an MSI-X capability", msix.CapabilityOffset)
+		}
+	}
+	tableBAR, ok := bars[msix.TableBIR]
+	if !ok || (tableBAR.Type != BARTypeMem32 && tableBAR.Type != BARTypeMem64) {
+		return fmt.Errorf("msix table BIR %d does not reference a memory BAR", msix.TableBIR)
+	}
+	pbaBAR, ok := bars[msix.PBABIR]
+	if !ok || (pbaBAR.Type != BARTypeMem32 && pbaBAR.Type != BARTypeMem64) {
+		return fmt.Errorf("msix PBA BIR %d does not reference a memory BAR", msix.PBABIR)
+	}
+	if msix.TableOffset&7 != 0 || msix.PBAOffset&7 != 0 {
+		return fmt.Errorf("msix table and PBA offsets must be 8-byte aligned")
+	}
+	tableEnd := msix.TableOffset + uint64(msix.TableSize)*16
+	pbaBytes := uint64((uint32(msix.TableSize)+63)/64) * 8
+	pbaEnd := msix.PBAOffset + pbaBytes
+	if tableEnd < msix.TableOffset || (tableBAR.SizeKnown && tableEnd > tableBAR.Size) {
+		return fmt.Errorf("msix table range exceeds BAR%d", msix.TableBIR)
+	}
+	if pbaEnd < msix.PBAOffset || (pbaBAR.SizeKnown && pbaEnd > pbaBAR.Size) {
+		return fmt.Errorf("msix PBA range exceeds BAR%d", msix.PBABIR)
+	}
+	if msix.TableBIR == msix.PBABIR && msix.TableOffset < pbaEnd && msix.PBAOffset < tableEnd {
+		return fmt.Errorf("msix table and PBA ranges overlap")
+	}
+	return nil
+}
+
+func readLittleEndian(data []byte, offset, width int) uint64 {
+	var value uint64
+	for lane := range width {
+		value |= uint64(data[offset+lane]) << (lane * 8)
+	}
+	return value
+}
+
+func validWidth(width uint8) bool { return width == 1 || width == 2 || width == 4 || width == 8 }
+
+func widthMask(width uint8) uint64 {
+	if width == 8 {
+		return ^uint64(0)
+	}
+	return uint64(1)<<(width*8) - 1
+}
+
+func validAccess(access AccessPolicy) bool {
+	switch access {
+	case AccessRO, AccessRW, AccessRW1C, AccessW1S, AccessW0C, AccessRC, AccessReserved:
+		return true
+	default:
+		return false
+	}
+}
+
+func validResetDomain(domain ResetDomain) bool {
+	switch domain {
+	case ResetPowerOn, ResetFundamental, ResetFunction, ResetSoftware:
+		return true
+	default:
+		return false
+	}
+}
+
+func validConfidence(level ConfidenceLevel) bool {
+	switch level {
+	case ConfidenceUnknown, ConfidenceInferred, ConfidenceMeasured, ConfidenceSpecified:
+		return true
+	default:
+		return false
+	}
+}
+
+func validBARType(t BARType) bool {
+	return t == BARTypeIO || t == BARTypeMem32 || t == BARTypeMem64 || t == BARTypeDisabled
+}

--- a/internal/firmware/output/device_model_test.go
+++ b/internal/firmware/output/device_model_test.go
@@ -3,10 +3,12 @@ package output
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/sercanarga/pcileechgen/internal/board"
 	"github.com/sercanarga/pcileechgen/internal/donor"
 	"github.com/sercanarga/pcileechgen/internal/firmware/devicemodel"
 	"github.com/sercanarga/pcileechgen/internal/pci"
@@ -61,6 +63,70 @@ func TestOutputWriterDeviceModelArtifactAndManifest(t *testing.T) {
 		}
 	}
 	t.Fatal("build manifest does not include device_model.json")
+}
+
+func TestOutputWriterWriteAllWithRealisticDonor(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	ctx, err := donor.LoadContext(filepath.Join(filepath.Dir(file), "..", "..", "..", "testdata", "donors", "nvme.json"))
+	if err != nil {
+		t.Fatalf("load realistic donor fixture: %v", err)
+	}
+
+	libDir := t.TempDir()
+	srcDir := filepath.Join(libDir, "test-board", "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"pcileech_fifo.sv": `module pcileech_fifo;
+    rw[175:160] <= 16'h0000; // CFG_VEND_ID
+    rw[191:176] <= 16'h0000; // CFG_DEV_ID
+endmodule`,
+		"pcileech_pcie_cfg_a7.sv": `module pcileech_pcie_cfg_a7; endmodule`,
+		"pcileech_pcie_a7.sv":     `module pcileech_pcie_a7; endmodule`,
+		"pcileech_tlps128_bar_controller.sv": `module pcileech_tlps128_bar_controller;
+endmodule`,
+	} {
+		if err := os.WriteFile(filepath.Join(srcDir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("write board source %s: %v", name, err)
+		}
+	}
+
+	outDir := t.TempDir()
+	writer := NewOutputWriter(outDir, libDir, 1, 1)
+	writer.StockBar = true
+	b := &board.Board{
+		Name: "test-board", ProjectDir: "test-board", FPGAPart: "xc7a35tfgg484-2",
+		PCIeLanes: 1, BRAMSize: 0x10000, TopModule: "test_top",
+	}
+	if err := writer.WriteAll(ctx, b); err != nil {
+		t.Fatalf("WriteAll realistic donor: %v", err)
+	}
+	for _, name := range []string{
+		"device_context.json",
+		"device_model.json",
+		"pcileech_cfgspace.coe",
+		"vivado_generate_project.tcl",
+		"build_manifest.json",
+	} {
+		if _, err := os.Stat(filepath.Join(outDir, name)); err != nil {
+			t.Errorf("WriteAll did not produce %s: %v", name, err)
+		}
+	}
+	data, err := os.ReadFile(filepath.Join(outDir, "device_model.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	model, err := devicemodel.FromJSON(data)
+	if err != nil {
+		t.Fatalf("WriteAll device model is invalid: %v", err)
+	}
+	if len(model.Functions) != 1 || model.Functions[0].VendorID != ctx.Device.VendorID {
+		t.Fatalf("WriteAll device model lost donor identity: %+v", model.Functions)
+	}
 }
 
 func outputModelContext() *donor.DeviceContext {

--- a/internal/firmware/output/device_model_test.go
+++ b/internal/firmware/output/device_model_test.go
@@ -1,0 +1,143 @@
+package output
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/firmware/devicemodel"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func TestOutputWriterDeviceModelArtifactAndManifest(t *testing.T) {
+	ctx := outputModelContext()
+
+	outputDir := t.TempDir()
+	writer := NewOutputWriter(outputDir, "unused", 1, 1)
+	if err := writer.writeDeviceModel(ctx); err != nil {
+		t.Fatalf("writeDeviceModel: %v", err)
+	}
+
+	artifactPath := filepath.Join(outputDir, "device_model.json")
+	data, err := os.ReadFile(artifactPath)
+	if err != nil {
+		t.Fatalf("device_model.json was not written: %v", err)
+	}
+	model, err := devicemodel.FromJSON(data)
+	if err != nil {
+		t.Fatalf("device_model.json is not a valid model artifact: %v", err)
+	}
+	if len(model.Functions) != 1 || model.Functions[0].VendorID != 0x1234 || model.Functions[0].DeviceID != 0x5678 {
+		t.Fatalf("artifact lost donor identity: %+v", model.Functions)
+	}
+
+	listed := false
+	for _, name := range ListOutputFiles() {
+		if name == "device_model.json" {
+			listed = true
+			break
+		}
+	}
+	if !listed {
+		t.Fatal("ListOutputFiles does not include device_model.json")
+	}
+
+	manifest, err := GenerateManifest(outputDir, ctx.ToolVersion, "test-board", ctx.Device.VendorID, ctx.Device.DeviceID)
+	if err != nil {
+		t.Fatalf("GenerateManifest: %v", err)
+	}
+	for _, entry := range manifest.Files {
+		if entry.Name == "device_model.json" {
+			if entry.Size != int64(len(data)) {
+				t.Fatalf("manifest size = %d, want %d", entry.Size, len(data))
+			}
+			if entry.SHA256 == "" || entry.SHA256 == "error" {
+				t.Fatalf("manifest has invalid device model checksum %q", entry.SHA256)
+			}
+			return
+		}
+	}
+	t.Fatal("build manifest does not include device_model.json")
+}
+
+func outputModelContext() *donor.DeviceContext {
+	config := pci.NewConfigSpaceFromBytes(make([]byte, pci.ConfigSpaceLegacySize))
+	config.WriteU16(0x00, 0x1234)
+	config.WriteU16(0x02, 0x5678)
+	config.WriteU8(0x0b, 0x02)
+	return &donor.DeviceContext{
+		CollectedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		ToolVersion: "test-version",
+		Hostname:    "test-host",
+		Device: pci.PCIDevice{
+			BDF:       pci.BDF{Domain: 0, Bus: 3, Device: 0, Function: 0},
+			VendorID:  0x1234,
+			DeviceID:  0x5678,
+			ClassCode: 0x020000,
+		},
+		ConfigSpace: config,
+		BARs: []pci.BAR{{
+			Index: 0,
+			Type:  pci.BARTypeMem32,
+			Size:  0x100,
+		}},
+		BARContents: map[int][]byte{0: make([]byte, 0x100)},
+	}
+}
+
+func validOutputDeviceModelJSON(t *testing.T) []byte {
+	t.Helper()
+	model, err := devicemodel.Build(outputModelContext())
+	if err != nil {
+		t.Fatalf("Build device model fixture: %v", err)
+	}
+	data, err := model.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON device model fixture: %v", err)
+	}
+	return data
+}
+
+func TestValidateOutputDirRejectsInvalidDeviceModel(t *testing.T) {
+	optional := map[string]bool{
+		"pcileech_msix_table.sv":           true,
+		"msix_table_init.hex":              true,
+		"pcileech_nvme_admin_responder.sv": true,
+		"pcileech_nvme_dma_bridge.sv":      true,
+	}
+	deviceConfig := "package device_config;\n" +
+		"localparam HAS_NVME_RESP = 0;\n" +
+		"localparam HAS_MSIX_INT = 0;\n" +
+		"endpackage\n"
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "malformed JSON", content: "not-json"},
+		{name: "invalid schema", content: `{"schema_version":999}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeOutputFixture(t, dir, optional, deviceConfig)
+			if err := os.WriteFile(filepath.Join(dir, "device_model.json"), []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			result := ValidateOutputDir(dir)
+			found := false
+			for _, failure := range result.Failed {
+				if strings.Contains(failure, "device_model.json") {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("invalid device_model.json was not rejected: %v", result.Failed)
+			}
+		})
+	}
+}

--- a/internal/firmware/output/validator.go
+++ b/internal/firmware/output/validator.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/sercanarga/pcileechgen/internal/firmware"
+	"github.com/sercanarga/pcileechgen/internal/firmware/devicemodel"
 )
 
 type ValidationResult struct {
@@ -55,6 +56,17 @@ func ValidateOutputDir(dir string) *ValidationResult {
 		if info.Size() == 0 {
 			result.fail(fmt.Sprintf("%s: empty file", name))
 			continue
+		}
+		if name == "device_model.json" {
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				result.fail(fmt.Sprintf("%s: unreadable: %v", name, readErr))
+				continue
+			}
+			if _, parseErr := devicemodel.FromJSON(data); parseErr != nil {
+				result.fail(fmt.Sprintf("%s: invalid: %v", name, parseErr))
+				continue
+			}
 		}
 		result.pass(fmt.Sprintf("%s: OK (%d bytes)", name, info.Size()))
 	}

--- a/internal/firmware/output/validator_optional_test.go
+++ b/internal/firmware/output/validator_optional_test.go
@@ -68,11 +68,14 @@ func writeOutputFixture(t *testing.T, tmpDir string, skip map[string]bool, devic
 			}
 			continue
 		}
-		content := "content"
+		content := []byte("content")
 		if name == "device_config.sv" {
-			content = deviceConfig
+			content = []byte(deviceConfig)
 		}
-		if err := os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0644); err != nil {
+		if name == "device_model.json" {
+			content = validOutputDeviceModelJSON(t)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, name), content, 0644); err != nil {
 			t.Fatalf("WriteFile(%s): %v", name, err)
 		}
 	}

--- a/internal/firmware/output/validator_test.go
+++ b/internal/firmware/output/validator_test.go
@@ -113,7 +113,11 @@ func TestValidateOutputDir_WithFiles(t *testing.T) {
 				t.Fatal(err)
 			}
 		} else {
-			if err := os.WriteFile(filepath.Join(tmpDir, name), []byte("content"), 0644); err != nil {
+			content := []byte("content")
+			if name == "device_model.json" {
+				content = validOutputDeviceModelJSON(t)
+			}
+			if err := os.WriteFile(filepath.Join(tmpDir, name), content, 0644); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/internal/firmware/output/writer.go
+++ b/internal/firmware/output/writer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sercanarga/pcileechgen/internal/firmware/barmodel"
 	"github.com/sercanarga/pcileechgen/internal/firmware/codegen"
 	"github.com/sercanarga/pcileechgen/internal/firmware/devclass"
+	"github.com/sercanarga/pcileechgen/internal/firmware/devicemodel"
 	"github.com/sercanarga/pcileechgen/internal/firmware/nvme"
 	"github.com/sercanarga/pcileechgen/internal/firmware/overlay"
 	"github.com/sercanarga/pcileechgen/internal/firmware/scrub"
@@ -59,6 +60,9 @@ func (ow *OutputWriter) WriteAll(ctx *donor.DeviceContext, b *board.Board) error
 	ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, ctx.ExtCapabilities)
 
 	if err := ow.writeDeviceContext(ctx); err != nil {
+		return err
+	}
+	if err := ow.writeDeviceModel(ctx); err != nil {
 		return err
 	}
 
@@ -107,6 +111,21 @@ func (ow *OutputWriter) writeDeviceContext(ctx *donor.DeviceContext) error {
 	}
 	if err := ow.writeFile("device_context.json", string(data)); err != nil {
 		return fmt.Errorf("failed to write device context: %w", err)
+	}
+	return nil
+}
+
+func (ow *OutputWriter) writeDeviceModel(ctx *donor.DeviceContext) error {
+	model, err := devicemodel.Build(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to build device model: %w", err)
+	}
+	data, err := model.ToJSON()
+	if err != nil {
+		return fmt.Errorf("failed to marshal device model: %w", err)
+	}
+	if err := ow.writeFile("device_model.json", string(data)); err != nil {
+		return fmt.Errorf("failed to write device model: %w", err)
 	}
 	return nil
 }
@@ -337,6 +356,7 @@ func (ow *OutputWriter) writeFile(name, content string) error {
 func ListOutputFiles() []string {
 	return []string{
 		"device_context.json",
+		"device_model.json",
 		"pcileech_cfgspace.coe",
 		"pcileech_cfgspace_writemask.coe",
 		"pcileech_bar_zero4k.coe",


### PR DESCRIPTION
## Summary

Introduces a versioned, deterministic `DeviceModel` intermediate representation and software oracle for donor-derived PCIe firmware generation.

- models functions, config space, capabilities, BAR topology, registers, reset domains, access policies, interrupts, transformations, unsupported features, confidence, and provenance
- normalizes six-slot BAR input into canonical logical resources, including 64-bit lower/upper pairing
- validates BAR geometry, config bounds, standard/extended capability topology, MSI-X placement, reset-image consistency, identity consistency, field masks, and provenance
- emits deterministic `device_model.json` with strict unknown-field rejection and stable ordering
- adds a thread-safe little-endian software oracle for RO/RW/RW1C/W1S/W0C/RC semantics, byte enables, reset domains, and cross-field access
- integrates model generation and semantic validation into the output pipeline

## Correctness details

- descending but acyclic capability links remain supported; payload ranges are normalized by physical placement while encoded `NextOffset` metadata is preserved
- parser-produced terminal capability payloads no longer overlap earlier capabilities
- upper slots consumed by 64-bit BARs are never emitted as independent resources
- captured BAR reset bytes are authoritative over later volatile probe reads; uncaptured bytes retain the probe fallback
- function identity and register reset values are cross-checked against reset images
- capability interval overlap, missing provenance, contradictory reset metadata, and malformed BAR pairs are rejected

## Verification

- `go test -race -count=1 ./...` under Ubuntu WSL2
- focused DeviceModel and output integration suites
- independent implementation review, regression-test pass, and two closure reviews
- comment-free additions as required by the project contribution constraint

## References used for design review

- Linux PCI BAR sizing and capability traversal behavior
- QEMU PCI config mask/oracle patterns
- libvfio-user reset and device-model lifecycle contracts

This PR intentionally adds the canonical model/oracle foundation without yet replacing every existing RTL generator path; later PRs can compile this IR into class plugins and generated RTL incrementally.