### PR TITLE
feat: add normalized PCIe transaction layer

### DIFF
--- a/README
+++ b/README
@@ -159,6 +159,9 @@ OUTPUT
     pcileech_bar_zero4k.coe             BAR0 content (sized to donor/BRAM)
     pcileech_bar_impl_device.sv         register-level BAR implementation
     pcileech_tlps128_bar_controller.sv  TLP BAR controller
+    pcileech_tlp_normalizer.sv           normalized MRd/MWr decode + decisions
+    pcileech_tlps128_bar_rdengine.sv     BE/RCB/MPS-aware read completions
+    pcileech_tlp_ur_completer.sv        unsupported non-posted completions
     pcileech_msix_table.sv              MSI-X table + PBA
     pcileech_nvme_admin_responder.sv    (if NVMe)
     pcileech_nvme_dma_bridge.sv         (if NVMe)

--- a/internal/board/board.go
+++ b/internal/board/board.go
@@ -48,6 +48,7 @@ func (b *Board) BRAMSizeOrDefault() int {
 	return DefaultBRAMSize
 }
 
+
 // BRAM36Capacity returns the FPGA's RAMB36 block count parsed from the part
 // number, used to size the NVMe disk cache. Returns 0 for non-Artix-7 parts.
 func (b *Board) BRAM36Capacity() int {

--- a/internal/firmware/output/transaction_artifacts_test.go
+++ b/internal/firmware/output/transaction_artifacts_test.go
@@ -1,0 +1,72 @@
+package output
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/board"
+	"github.com/sercanarga/pcileechgen/internal/firmware"
+	"github.com/sercanarga/pcileechgen/internal/firmware/svgen"
+)
+
+func TestTransactionRTLArtifactsAreGenerated(t *testing.T) {
+	want := map[string]string{
+		"pcileech_tlp_normalizer.sv":          "module pcileech_tlp_normalizer",
+		"pcileech_tlps128_bar_rdengine.sv":    "module pcileech_tlps128_bar_rdengine",
+		"pcileech_tlps128_bar_controller.sv":  ") i_tlp_normalizer(",
+		"pcileech_tlp_ur_completer.sv":        "module pcileech_tlp_ur_completer",
+	}
+	seen := make(map[string]bool, len(want))
+	cfg := &svgen.SVGeneratorConfig{}
+	for _, artifact := range coreSVArtifacts {
+		module, required := want[artifact.filename]
+		if !required {
+			continue
+		}
+		seen[artifact.filename] = true
+		source, err := artifact.generate(cfg)
+		if err != nil {
+			t.Fatalf("generate %s: %v", artifact.filename, err)
+		}
+		if !strings.Contains(source, module) {
+			t.Errorf("generated %s does not contain %q", artifact.filename, module)
+		}
+	}
+	for filename := range want {
+		if !seen[filename] {
+			t.Errorf("coreSVArtifacts does not emit required transaction RTL %s", filename)
+		}
+	}
+
+	listed := make(map[string]bool)
+	for _, filename := range ListOutputFiles() {
+		listed[filename] = true
+	}
+	for filename := range want {
+		if !listed[filename] {
+			t.Errorf("ListOutputFiles omits generated transaction RTL %s", filename)
+		}
+	}
+}
+
+
+func TestBuildSVConfigUsesConservativeTransactionLimits(t *testing.T) {
+	ctx := makeDonorContext(0x8086, 0x15B7, 0x020000)
+	ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, ctx.ExtCapabilities)
+	ow := NewOutputWriter(t.TempDir(), "", 0, 0)
+	for _, b := range []*board.Board{
+		{},
+		{Name: "other", FPGAPart: "xc7a200tsbg484-1"},
+	} {
+		cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0x1234, b)
+		if err != nil {
+			t.Fatalf("buildSVConfig() error = %v", err)
+		}
+		if cfg.ReadCompletionBoundaryBytes != 64 {
+			t.Errorf("ReadCompletionBoundaryBytes = %d, want 64", cfg.ReadCompletionBoundaryBytes)
+		}
+		if cfg.MaxPayloadBytes != 128 {
+			t.Errorf("MaxPayloadBytes = %d, want 128", cfg.MaxPayloadBytes)
+		}
+	}
+}

--- a/internal/firmware/output/writer.go
+++ b/internal/firmware/output/writer.go
@@ -196,7 +196,6 @@ var svFilesReplacedByGenerator = map[string]bool{
 // is replaced by the generated version, but these shared modules are still
 // needed by the generated controller.
 var barControllerSubModules = []string{
-	"pcileech_tlps128_bar_rdengine",
 	"pcileech_tlps128_bar_wrengine",
 	"pcileech_bar_impl_none",
 	"pcileech_bar_impl_loopaddr",
@@ -346,6 +345,9 @@ func ListOutputFiles() []string {
 		"src/",
 		"pcileech_bar_impl_device.sv",
 		"pcileech_tlps128_bar_controller.sv",
+		"pcileech_tlp_normalizer.sv",
+		"pcileech_tlps128_bar_rdengine.sv",
+		"pcileech_tlp_ur_completer.sv",
 		"pcileech_bar_impl_msi.sv",
 		"pcileech_msix_table.sv",
 		"pcileech_nvme_admin_responder.sv",
@@ -370,6 +372,9 @@ type svArtifact struct {
 var coreSVArtifacts = []svArtifact{
 	{"pcileech_bar_impl_device.sv", svgen.GenerateBarImplDeviceSV},
 	{"pcileech_tlps128_bar_controller.sv", svgen.GenerateBarControllerSV},
+	{"pcileech_tlp_normalizer.sv", svgen.GenerateTransactionNormalizerSV},
+	{"pcileech_tlps128_bar_rdengine.sv", svgen.GenerateBarReadEngineSV},
+	{"pcileech_tlp_ur_completer.sv", svgen.GenerateURCompleterSV},
 	{"pcileech_bar_impl_msi.sv", svgen.GenerateBarImplMSISV},
 	{"tlp_latency_emulator.sv", svgen.GenerateLatencyEmulatorSV},
 	{"device_config.sv", svgen.GenerateDeviceConfigSV},
@@ -502,6 +507,8 @@ func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.
 		PRNGSeeds:         svgen.BuildPRNGSeeds(ids.VendorID, ids.DeviceID, entropy),
 		DeviceClass:       devClass,
 		Bar0Size:          bar0Size,
+		ReadCompletionBoundaryBytes: 64,
+		MaxPayloadBytes:             128,
 	}
 
 	if devClass == devclass.ClassNVMe {

--- a/internal/firmware/pcietxn/planner_test.go
+++ b/internal/firmware/pcietxn/planner_test.go
@@ -1,0 +1,376 @@
+package pcietxn_test
+
+import (
+	"fmt"
+	"math/bits"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/firmware/pcietxn"
+)
+
+func limits(rcb, mps int) pcietxn.Limits {
+	return pcietxn.Limits{
+		ReadCompletionBoundary: uint16(rcb),
+		MaxPayloadBytes:        uint16(mps),
+	}
+}
+
+func fullRead(format pcietxn.HeaderFormat, address uint64, lengthDW int) pcietxn.Request {
+	lastBE := uint8(0xF)
+	if lengthDW == 1 {
+		lastBE = 0
+	}
+	return pcietxn.Request{
+		Kind:         pcietxn.MemoryRead,
+		Format:       format,
+		Address:      address,
+		LengthDW:     uint16(lengthDW),
+		FirstBE:      0xF,
+		LastBE:       lastBE,
+		RequesterID:  0xA15E,
+		Tag:          0xD3,
+		TrafficClass: 5,
+		Attributes:   3,
+		BIR:          0,
+	}
+}
+
+func mustPlan(t *testing.T, req pcietxn.Request, lim pcietxn.Limits) pcietxn.Plan {
+	t.Helper()
+	plan, err := pcietxn.PlanRequest(req, lim)
+	if err != nil {
+		t.Fatalf("PlanRequest() error = %v", err)
+	}
+	return plan
+}
+
+func completionLengths(plan pcietxn.Plan) []int {
+	lengths := make([]int, len(plan.Completions))
+	for i, completion := range plan.Completions {
+		lengths[i] = int(completion.LengthDW)
+	}
+	return lengths
+}
+
+func requireLengths(t *testing.T, plan pcietxn.Plan, want ...int) {
+	t.Helper()
+	got := completionLengths(plan)
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("completion lengths = %v, want %v", got, want)
+	}
+}
+
+func TestPlanMemoryReadHeadersAndBoundaryLengths(t *testing.T) {
+	for _, format := range []pcietxn.HeaderFormat{pcietxn.Header3DW, pcietxn.Header4DW} {
+		for _, tc := range []struct {
+			lengthDW int
+			want      []int
+		}{
+			{lengthDW: 1, want: []int{1}},
+			{lengthDW: 2, want: []int{2}},
+			{lengthDW: 31, want: []int{31}},
+			{lengthDW: 32, want: []int{32}},
+			{lengthDW: 33, want: []int{32, 1}},
+		} {
+			t.Run(fmt.Sprintf("format_%d/length_%d", format, tc.lengthDW), func(t *testing.T) {
+				address := uint64(0x1000)
+				if format == pcietxn.Header4DW {
+					address = 0x1_0000_1000
+				}
+				plan := mustPlan(t, fullRead(format, address, tc.lengthDW), limits(128, 128))
+				if plan.Decision != pcietxn.DecisionComplete || plan.Posted {
+					t.Fatalf("decision/posted = %v/%t, want Complete/false", plan.Decision, plan.Posted)
+				}
+				requireLengths(t, plan, tc.want...)
+				for i, completion := range plan.Completions {
+					if completion.Status != pcietxn.CompletionSuccessful || !completion.HasData {
+						t.Errorf("completion[%d] status/data = %v/%t, want Successful/true", i, completion.Status, completion.HasData)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestPlanSingleDWAllMeaningfulFirstByteEnables(t *testing.T) {
+	for firstBE := uint8(1); firstBE <= 0xF; firstBE++ {
+		t.Run(fmt.Sprintf("first_be_%X", firstBE), func(t *testing.T) {
+			req := fullRead(pcietxn.Header3DW, 0x2240, 1)
+			req.FirstBE = firstBE
+			plan := mustPlan(t, req, limits(128, 128))
+			requireLengths(t, plan, 1)
+			completion := plan.Completions[0]
+			if got, want := int(completion.ByteCount), bits.OnesCount8(firstBE); got != want {
+				t.Errorf("ByteCount = %d, want popcount(%04b) = %d", got, firstBE, want)
+			}
+			if got, want := int(completion.LowerAddress), 0x40+bits.TrailingZeros8(firstBE); got != want {
+				t.Errorf("LowerAddress = %#x, want %#x", got, want)
+			}
+		})
+	}
+}
+
+func TestPlanZeroLengthMemoryReadReturnsRequiredOneDWCplD(t *testing.T) {
+	req := fullRead(pcietxn.Header3DW, 0x22C0, 1)
+	req.FirstBE = 0
+	plan := mustPlan(t, req, limits(128, 128))
+	if plan.Decision != pcietxn.DecisionComplete || plan.Posted {
+		t.Fatalf("decision/posted = %v/%t, want Complete/false", plan.Decision, plan.Posted)
+	}
+	if plan.EnabledByteCount != 0 {
+		t.Errorf("zero-length read EnabledByteCount = %d, want 0", plan.EnabledByteCount)
+	}
+	requireLengths(t, plan, 1)
+	completion := plan.Completions[0]
+	if got := int(completion.ByteCount); got != 4 {
+		t.Errorf("zero-length read Completion ByteCount = %d, want 4", got)
+	}
+	if got := int(completion.LowerAddress); got != 0x40 {
+		t.Errorf("zero-length read Completion LowerAddress = %#x, want request address %#x", got, 0x40)
+	}
+}
+
+func TestPlanQWAlignedTwoDWAllNonzeroByteEnablePatterns(t *testing.T) {
+	for firstBE := uint8(1); firstBE <= 0xF; firstBE++ {
+		for lastBE := uint8(1); lastBE <= 0xF; lastBE++ {
+			t.Run(fmt.Sprintf("first_%X/last_%X", firstBE, lastBE), func(t *testing.T) {
+				req := fullRead(pcietxn.Header3DW, 0x2800, 2)
+				req.FirstBE = firstBE
+				req.LastBE = lastBE
+				plan := mustPlan(t, req, limits(128, 128))
+				requireLengths(t, plan, 2)
+				completion := plan.Completions[0]
+				wantBytes := bits.OnesCount8(firstBE) + bits.OnesCount8(lastBE)
+				if got := int(completion.ByteCount); got != wantBytes {
+					t.Errorf("ByteCount = %d, want popcount(FirstBE)+popcount(LastBE) = %d", got, wantBytes)
+				}
+				if got, want := int(completion.LowerAddress), bits.TrailingZeros8(firstBE); got != want {
+					t.Errorf("LowerAddress = %#x, want %#x", got, want)
+				}
+			})
+		}
+	}
+}
+
+
+func TestPlanMultiDWAllMeaningfulEdgeByteEnables(t *testing.T) {
+	firstPatterns := []uint8{0x8, 0xC, 0xE, 0xF}
+	lastPatterns := []uint8{0x1, 0x3, 0x7, 0xF}
+	for _, lengthDW := range []int{31, 32, 33} {
+		for _, firstBE := range firstPatterns {
+			for _, lastBE := range lastPatterns {
+				t.Run(fmt.Sprintf("length_%d/first_%X/last_%X", lengthDW, firstBE, lastBE), func(t *testing.T) {
+					req := fullRead(pcietxn.Header3DW, 0x3000, lengthDW)
+					req.FirstBE = firstBE
+					req.LastBE = lastBE
+					plan := mustPlan(t, req, limits(128, 128))
+					first := plan.Completions[0]
+					wantBytes := bits.OnesCount8(firstBE) + 4*(lengthDW-2) + bits.OnesCount8(lastBE)
+					if got := int(first.ByteCount); got != wantBytes {
+						t.Errorf("first completion ByteCount = %d, want %d", got, wantBytes)
+					}
+					if got, want := int(first.LowerAddress), bits.TrailingZeros8(firstBE); got != want {
+						t.Errorf("first completion LowerAddress = %#x, want %#x", got, want)
+					}
+					if lengthDW == 33 {
+						last := plan.Completions[1]
+						if got, want := int(last.ByteCount), bits.OnesCount8(lastBE); got != want {
+							t.Errorf("last completion ByteCount = %d, want remaining enabled bytes %d", got, want)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestPlanReadCompletionBoundary64And128(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		rcb      int
+		address  uint64
+		wantLens []int
+		wantBC   []int
+		wantLA   []int
+	}{
+		{name: "64_byte_RCB", rcb: 64, address: 0x203C, wantLens: []int{1, 16, 16}, wantBC: []int{132, 128, 64}, wantLA: []int{0x3C, 0x40, 0}},
+		{name: "128_byte_RCB", rcb: 128, address: 0x207C, wantLens: []int{1, 32}, wantBC: []int{132, 128}, wantLA: []int{0x7C, 0}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := mustPlan(t, fullRead(pcietxn.Header3DW, tc.address, 33), limits(tc.rcb, 256))
+			requireLengths(t, plan, tc.wantLens...)
+			for i, completion := range plan.Completions {
+				if got := int(completion.ByteCount); got != tc.wantBC[i] {
+					t.Errorf("completion[%d].ByteCount = %d, want %d", i, got, tc.wantBC[i])
+				}
+				if got := int(completion.LowerAddress); got != tc.wantLA[i] {
+					t.Errorf("completion[%d].LowerAddress = %#x, want %#x", i, got, tc.wantLA[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPlanReadMPSBoundaryAndPartialEdges(t *testing.T) {
+	req := fullRead(pcietxn.Header4DW, 0x1_0000_3000, 33)
+	req.FirstBE = 0xC
+	req.LastBE = 0x3
+	plan := mustPlan(t, req, limits(128, 128))
+	requireLengths(t, plan, 32, 1)
+
+	if got, want := int(plan.Completions[0].ByteCount), 128; got != want {
+		t.Errorf("first ByteCount = %d, want %d", got, want)
+	}
+	if got, want := int(plan.Completions[0].LowerAddress), 2; got != want {
+		t.Errorf("first LowerAddress = %#x, want %#x", got, want)
+	}
+	if got, want := int(plan.Completions[1].ByteCount), 2; got != want {
+		t.Errorf("second ByteCount = %d, want partial last-DW bytes %d", got, want)
+	}
+	if got := int(plan.Completions[1].LowerAddress); got != 0 {
+		t.Errorf("second LowerAddress = %#x, want 0", got)
+	}
+}
+
+func TestPlanPreservesRequesterTagTrafficClassAndAttributes(t *testing.T) {
+	req := fullRead(pcietxn.Header4DW, 0x1_0000_407C, 33)
+	plan := mustPlan(t, req, limits(128, 128))
+	if len(plan.Completions) < 2 {
+		t.Fatalf("got %d completions, want a split request", len(plan.Completions))
+	}
+	for i, completion := range plan.Completions {
+		if completion.RequesterID != req.RequesterID || completion.Tag != req.Tag ||
+			completion.TrafficClass != req.TrafficClass || completion.Attributes != req.Attributes {
+			t.Errorf("completion[%d] metadata = requester %#x tag %#x TC %#x attr %#x; want %#x/%#x/%#x/%#x",
+				i, completion.RequesterID, completion.Tag, completion.TrafficClass, completion.Attributes,
+				req.RequesterID, req.Tag, req.TrafficClass, req.Attributes)
+		}
+	}
+}
+
+func TestPlanPostedMemoryWrites(t *testing.T) {
+	for _, format := range []pcietxn.HeaderFormat{pcietxn.Header3DW, pcietxn.Header4DW} {
+		for _, lengthDW := range []int{1, 2, 31, 32, 33} {
+			t.Run(fmt.Sprintf("format_%d/length_%d", format, lengthDW), func(t *testing.T) {
+				req := fullRead(format, 0x5000, lengthDW)
+				req.Kind = pcietxn.MemoryWrite
+				plan := mustPlan(t, req, limits(128, 128))
+				if plan.Decision != pcietxn.DecisionPosted || !plan.Posted {
+					t.Fatalf("decision/posted = %v/%t, want Posted/true", plan.Decision, plan.Posted)
+				}
+				if len(plan.Completions) != 0 {
+					t.Fatalf("posted write produced %d completions, want none", len(plan.Completions))
+				}
+			})
+		}
+	}
+}
+
+func TestPlanZeroByteMemoryWriteRemainsPosted(t *testing.T) {
+	req := fullRead(pcietxn.Header3DW, 0x5800, 1)
+	req.Kind = pcietxn.MemoryWrite
+	req.FirstBE = 0
+	plan := mustPlan(t, req, limits(128, 128))
+	if plan.Decision != pcietxn.DecisionPosted || !plan.Posted {
+		t.Fatalf("decision/posted = %v/%t, want Posted/true", plan.Decision, plan.Posted)
+	}
+	if plan.EnabledByteCount != 0 {
+		t.Errorf("zero-byte write EnabledByteCount = %d, want 0", plan.EnabledByteCount)
+	}
+	if len(plan.Completions) != 0 {
+		t.Fatalf("zero-byte posted write produced %d completions, want none", len(plan.Completions))
+	}
+}
+
+
+func TestPlanUnsupportedTransactions(t *testing.T) {
+	for _, kind := range []pcietxn.Kind{pcietxn.IORead, pcietxn.IOWrite, pcietxn.Atomic} {
+		t.Run(fmt.Sprintf("kind_%d", kind), func(t *testing.T) {
+			req := fullRead(pcietxn.Header3DW, 0x6000, 1)
+			req.Kind = kind
+			plan := mustPlan(t, req, limits(128, 128))
+			if plan.Decision != pcietxn.DecisionUnsupportedRequest || plan.Posted {
+				t.Fatalf("decision/posted = %v/%t, want UnsupportedRequest/false", plan.Decision, plan.Posted)
+			}
+			if len(plan.Completions) != 1 {
+				t.Fatalf("unsupported request produced %d completions, want one UR", len(plan.Completions))
+			}
+			completion := plan.Completions[0]
+			if completion.Status != pcietxn.CompletionUnsupportedRequest || completion.HasData {
+				t.Errorf("UR status/data = %v/%t, want UnsupportedRequest/false", completion.Status, completion.HasData)
+			}
+			if completion.RequesterID != req.RequesterID || completion.Tag != req.Tag ||
+				completion.TrafficClass != req.TrafficClass || completion.Attributes != req.Attributes {
+				t.Errorf("UR metadata = requester %#x tag %#x TC %#x attr %#x; want %#x/%#x/%#x/%#x",
+					completion.RequesterID, completion.Tag, completion.TrafficClass, completion.Attributes,
+					req.RequesterID, req.Tag, req.TrafficClass, req.Attributes)
+			}
+			if completion.LengthDW != 0 || completion.ByteCount != 0 || completion.LowerAddress != 0 {
+				t.Errorf("UR data fields = length %d byte count %d lower %#x, want zero", completion.LengthDW, completion.ByteCount, completion.LowerAddress)
+			}
+		})
+	}
+}
+
+func TestPlanLockedRead3DWAnd4DWEmitsUR(t *testing.T) {
+	for _, format := range []pcietxn.HeaderFormat{pcietxn.Header3DW, pcietxn.Header4DW} {
+		t.Run(fmt.Sprintf("format_%d", format), func(t *testing.T) {
+			req := fullRead(format, 0x6800, 1)
+			if format == pcietxn.Header4DW {
+				req.Address = 0x1_0000_6800
+			}
+			req.Kind = pcietxn.MemoryReadLocked
+			plan := mustPlan(t, req, limits(64, 128))
+			if plan.Decision != pcietxn.DecisionUnsupportedRequest || plan.Posted {
+				t.Fatalf("decision/posted = %v/%t, want UnsupportedRequest/false", plan.Decision, plan.Posted)
+			}
+			if len(plan.Completions) != 1 {
+				t.Fatalf("locked read produced %d completions, want one UR", len(plan.Completions))
+			}
+			completion := plan.Completions[0]
+			if completion.Status != pcietxn.CompletionUnsupportedRequest || completion.HasData {
+				t.Errorf("locked-read UR status/data = %v/%t, want UnsupportedRequest/false", completion.Status, completion.HasData)
+			}
+			if completion.RequesterID != req.RequesterID || completion.Tag != req.Tag ||
+				completion.TrafficClass != req.TrafficClass {
+				t.Errorf("locked-read UR metadata = %#x/%#x/%#x, want %#x/%#x/%#x",
+					completion.RequesterID, completion.Tag, completion.TrafficClass,
+					req.RequesterID, req.Tag, req.TrafficClass)
+			}
+		})
+	}
+}
+
+func TestPlanMalformedRequests(t *testing.T) {
+	valid := fullRead(pcietxn.Header3DW, 0x7000, 2)
+	cases := map[string]func(*pcietxn.Request){
+		"decoder_marked_malformed": func(req *pcietxn.Request) { req.Malformed = true },
+		"zero_length":              func(req *pcietxn.Request) { req.LengthDW = 0 },
+		"length_over_1024":          func(req *pcietxn.Request) { req.LengthDW = 1025 },
+		"unknown_header_format":      func(req *pcietxn.Request) { req.Format = pcietxn.HeaderUnknown },
+		"3DW_address_above_4GiB":     func(req *pcietxn.Request) { req.Address = 0x1_0000_7000 },
+		"BE_outside_DWORD":           func(req *pcietxn.Request) { req.FirstBE = 0x18 },
+		"traffic_class_overflow":     func(req *pcietxn.Request) { req.TrafficClass = 8 },
+		"attribute_overflow":         func(req *pcietxn.Request) { req.Attributes = 8 },
+		"one_DW_last_BE":           func(req *pcietxn.Request) { req.LengthDW, req.LastBE = 1, 1 },
+		"multi_DW_first_BE":        func(req *pcietxn.Request) { req.LengthDW, req.FirstBE = 3, 3 },
+		"multi_DW_last_BE":         func(req *pcietxn.Request) { req.LengthDW, req.LastBE = 3, 0xC },
+		"non_QW_2DW_discontinuous":  func(req *pcietxn.Request) { req.Address, req.FirstBE = 0x7004, 3 },
+		"unaligned_address":        func(req *pcietxn.Request) { req.Address++ },
+		"crosses_4KiB":             func(req *pcietxn.Request) { req.Address, req.LengthDW = 0xFF0, 8 },
+		"reserved_BIR":             func(req *pcietxn.Request) { req.BIR = 7 },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := valid
+			mutate(&req)
+			plan := mustPlan(t, req, limits(128, 128))
+			if plan.Decision != pcietxn.DecisionMalformedRequest || plan.Posted {
+				t.Fatalf("decision/posted = %v/%t, want MalformedRequest/false", plan.Decision, plan.Posted)
+			}
+			if len(plan.Completions) != 0 {
+				t.Fatalf("malformed request produced %d completions, want none", len(plan.Completions))
+			}
+		})
+	}
+}

--- a/internal/firmware/pcietxn/transaction.go
+++ b/internal/firmware/pcietxn/transaction.go
@@ -1,0 +1,302 @@
+package pcietxn
+
+import (
+	"errors"
+	"fmt"
+	"math/bits"
+)
+
+type Kind uint8
+
+const (
+	KindUnknown Kind = iota
+	MemoryRead
+	MemoryWrite
+	IORead
+	IOWrite
+	Atomic
+	MemoryReadLocked
+	ConfigurationRead
+	ConfigurationWrite
+)
+
+const (
+	KindMemoryRead  = MemoryRead
+	KindMemoryWrite = MemoryWrite
+	KindIORead      = IORead
+	KindIOWrite     = IOWrite
+	KindAtomic      = Atomic
+	KindMemoryReadLocked  = MemoryReadLocked
+	KindConfigurationRead = ConfigurationRead
+	KindConfigurationWrite = ConfigurationWrite
+)
+
+type HeaderFormat uint8
+
+const (
+	HeaderUnknown HeaderFormat = iota
+	Header3DW
+	Header4DW
+)
+
+const (
+	Format3DW = Header3DW
+	Format4DW = Header4DW
+)
+
+type Decision uint8
+
+const (
+	DecisionUnknown Decision = iota
+	DecisionComplete
+	DecisionPosted
+	DecisionUnsupportedRequest
+	DecisionMalformedRequest
+)
+
+const (
+	DecisionUR          = DecisionUnsupportedRequest
+	DecisionUnsupported = DecisionUnsupportedRequest
+	DecisionMalformed   = DecisionMalformedRequest
+)
+
+type CompletionStatus uint8
+
+const (
+	CompletionSuccessful CompletionStatus = iota
+	CompletionUnsupportedRequest
+)
+
+type Request struct {
+	Kind         Kind
+	Format       HeaderFormat
+	Address      uint64
+	LengthDW     uint16
+	FirstBE      uint8
+	LastBE       uint8
+	RequesterID  uint16
+	Tag          uint8
+	TrafficClass uint8
+	Attributes   uint8
+	BIR          uint8
+	Malformed    bool
+}
+
+type Limits struct {
+	ReadCompletionBoundary uint16
+	MaxPayloadBytes         uint16
+}
+
+type Completion struct {
+	Status       CompletionStatus
+	HasData      bool
+	Address      uint64
+	LengthDW     uint16
+	ByteCount    uint16
+	LowerAddress uint8
+	RequesterID  uint16
+	Tag          uint8
+	TrafficClass uint8
+	Attributes   uint8
+}
+
+type Plan struct {
+	Decision         Decision
+	Posted           bool
+	EnabledByteCount uint16
+	Completions      []Completion
+	Reason           string
+}
+
+var ErrInvalidLimits = errors.New("invalid PCIe completion limits")
+
+func PlanRequest(req Request, limits Limits) (Plan, error) {
+	if err := validateLimits(limits); err != nil {
+		return Plan{}, err
+	}
+	if reason := malformedReason(req); reason != "" {
+		return Plan{Decision: DecisionMalformedRequest, Reason: reason}, nil
+	}
+
+	switch req.Kind {
+	case MemoryWrite:
+		return Plan{
+			Decision:         DecisionPosted,
+			Posted:           true,
+			EnabledByteCount: enabledByteCount(req),
+		}, nil
+	case MemoryRead:
+	case IORead, IOWrite, Atomic, MemoryReadLocked, ConfigurationRead, ConfigurationWrite:
+		return unsupportedPlan(req, "non-posted request is unsupported"), nil
+	default:
+		return Plan{Decision: DecisionUnsupportedRequest, Reason: "request type is unsupported"}, nil
+	}
+
+	enabledBytes := enabledByteCount(req)
+	remainingBytes := completionByteCount(req)
+	plan := Plan{
+		Decision:         DecisionComplete,
+		EnabledByteCount: enabledBytes,
+		Completions:      make([]Completion, 0, completionCapacity(req, limits)),
+	}
+
+	for dwIndex := uint16(0); dwIndex < req.LengthDW; {
+		address := req.Address + uint64(dwIndex)*4
+		rcbRemainingBytes := uint64(limits.ReadCompletionBoundary) - address%uint64(limits.ReadCompletionBoundary)
+		rcbDW := uint16(rcbRemainingBytes / 4)
+		mpsDW := limits.MaxPayloadBytes / 4
+		chunkDW := min16(req.LengthDW-dwIndex, min16(rcbDW, mpsDW))
+		if chunkDW == 0 {
+			return Plan{}, fmt.Errorf("%w: zero-sized completion", ErrInvalidLimits)
+		}
+
+		startBE := uint8(0xF)
+		if dwIndex == 0 {
+			startBE = req.FirstBE
+		} else if dwIndex == req.LengthDW-1 {
+			startBE = req.LastBE
+		}
+		firstByteOffset := uint8(0)
+		if startBE != 0 {
+			firstByteOffset = uint8(bits.TrailingZeros8(startBE))
+		}
+		plan.Completions = append(plan.Completions, Completion{
+			Status:       CompletionSuccessful,
+			HasData:      true,
+			Address:      address,
+			LengthDW:     chunkDW,
+			ByteCount:    remainingBytes,
+			LowerAddress: uint8((address + uint64(firstByteOffset)) & 0x7F),
+			RequesterID:  req.RequesterID,
+			Tag:          req.Tag,
+			TrafficClass: req.TrafficClass,
+			Attributes:   req.Attributes,
+		})
+
+		remainingBytes -= enabledBytesInRange(req, dwIndex, chunkDW)
+		dwIndex += chunkDW
+	}
+
+	return plan, nil
+}
+
+func PlanCompletions(req Request, limits Limits) (Plan, error) {
+	return PlanRequest(req, limits)
+}
+
+func unsupportedPlan(req Request, reason string) Plan {
+	return Plan{
+		Decision: DecisionUnsupportedRequest,
+		Reason:   reason,
+		Completions: []Completion{{
+			Status:       CompletionUnsupportedRequest,
+			HasData:      false,
+			RequesterID:  req.RequesterID,
+			Tag:          req.Tag,
+			TrafficClass: req.TrafficClass,
+			Attributes:   req.Attributes,
+		}},
+	}
+}
+
+func validateLimits(limits Limits) error {
+	if limits.ReadCompletionBoundary != 64 && limits.ReadCompletionBoundary != 128 {
+		return fmt.Errorf("%w: RCB must be 64 or 128 bytes", ErrInvalidLimits)
+	}
+	mps := limits.MaxPayloadBytes
+	if mps < 128 || mps > 4096 || mps&(mps-1) != 0 {
+		return fmt.Errorf("%w: MPS must be a power of two from 128 through 4096 bytes", ErrInvalidLimits)
+	}
+	return nil
+}
+
+func malformedReason(req Request) string {
+	if req.Malformed {
+		return "request was marked malformed by the wire normalizer"
+	}
+	if req.Format != Header3DW && req.Format != Header4DW {
+		return "header format is neither 3DW nor 4DW"
+	}
+	if req.Format == Header3DW && req.Address > 0xFFFFFFFF {
+		return "3DW request carries an address above 4 GiB"
+	}
+	if req.Address&3 != 0 {
+		return "request address is not DWORD aligned"
+	}
+	if req.LengthDW == 0 || req.LengthDW > 1024 {
+		return "request length is outside 1..1024 DWORDs"
+	}
+	if (req.Address&0xFFF)+uint64(req.LengthDW)*4 > 4096 {
+		return "request crosses a 4 KiB boundary"
+	}
+	if req.FirstBE&0xF != req.FirstBE || req.LastBE&0xF != req.LastBE {
+		return "byte enable uses bits outside a DWORD"
+	}
+	if req.LengthDW == 1 {
+		if req.LastBE != 0 {
+			return "1DW request requires zero LastBE"
+		}
+	} else if req.LengthDW == 2 && req.Address&7 == 0 {
+		if req.FirstBE == 0 || req.LastBE == 0 {
+			return "QW-aligned 2DW request requires nonzero byte enables"
+		}
+	} else if !validFirstEdge(req.FirstBE) || !validLastEdge(req.LastBE) {
+		return "multi-DW request byte enables do not describe contiguous edges"
+	}
+	if req.TrafficClass > 7 || req.Attributes > 7 {
+		return "traffic class or attributes exceed their header width"
+	}
+	if req.BIR > 6 {
+		return "BIR is outside BAR0..BAR6"
+	}
+	return ""
+}
+
+func validFirstEdge(be uint8) bool {
+	return be == 0x8 || be == 0xC || be == 0xE || be == 0xF
+}
+
+func validLastEdge(be uint8) bool {
+	return be == 0x1 || be == 0x3 || be == 0x7 || be == 0xF
+}
+
+func enabledByteCount(req Request) uint16 {
+	if req.LengthDW == 1 {
+		return uint16(bits.OnesCount8(req.FirstBE))
+	}
+	return uint16(bits.OnesCount8(req.FirstBE)+bits.OnesCount8(req.LastBE)) + (req.LengthDW-2)*4
+}
+
+func completionByteCount(req Request) uint16 {
+	if req.Kind == MemoryRead && req.LengthDW == 1 && req.FirstBE == 0 {
+		return 4
+	}
+	return enabledByteCount(req)
+}
+
+func enabledBytesInRange(req Request, first, count uint16) uint16 {
+	var enabled uint16
+	for i := first; i < first+count; i++ {
+		switch {
+		case i == 0:
+			enabled += uint16(bits.OnesCount8(req.FirstBE))
+		case i == req.LengthDW-1:
+			enabled += uint16(bits.OnesCount8(req.LastBE))
+		default:
+			enabled += 4
+		}
+	}
+	return enabled
+}
+
+func completionCapacity(req Request, limits Limits) int {
+	minBoundary := min16(limits.ReadCompletionBoundary, limits.MaxPayloadBytes)
+	return int((req.LengthDW*4 + minBoundary - 1) / minBoundary)
+}
+
+func min16(a, b uint16) uint16 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/firmware/svgen/generator.go
+++ b/internal/firmware/svgen/generator.go
@@ -38,6 +38,23 @@ type SVGeneratorConfig struct {
 	NVMeDiskWords      int                // NVMe disk-cache depth (words), board-scaled
 	NVMeAdvertisedLBAs uint64             // actual NSZE from donor (0 = use default 2000409264)
 	Bar0Size           int
+	ReadCompletionBoundaryBytes int
+	MaxPayloadBytes             int
+}
+
+func (c *SVGeneratorConfig) ResolvedReadCompletionBoundaryBytes() int {
+	if c != nil && (c.ReadCompletionBoundaryBytes == 64 || c.ReadCompletionBoundaryBytes == 128) {
+		return c.ReadCompletionBoundaryBytes
+	}
+	return 64
+}
+
+func (c *SVGeneratorConfig) ResolvedMaxPayloadBytes() int {
+	if c != nil && c.MaxPayloadBytes >= 128 && c.MaxPayloadBytes <= 4096 &&
+		c.MaxPayloadBytes&(c.MaxPayloadBytes-1) == 0 {
+		return c.MaxPayloadBytes
+	}
+	return 128
 }
 
 // NVMeDiskWordsForBRAM36 returns the NVMe disk-cache depth in 32-bit words for
@@ -146,6 +163,18 @@ func GenerateBarImplDeviceSV(cfg *SVGeneratorConfig) (string, error) {
 
 func GenerateBarControllerSV(cfg *SVGeneratorConfig) (string, error) {
 	return renderTemplate("bar_controller", cfg)
+}
+
+func GenerateTransactionNormalizerSV(cfg *SVGeneratorConfig) (string, error) {
+	return renderTemplate("transaction_normalizer", cfg)
+}
+
+func GenerateBarReadEngineSV(cfg *SVGeneratorConfig) (string, error) {
+	return renderTemplate("bar_read_engine", cfg)
+}
+
+func GenerateURCompleterSV(cfg *SVGeneratorConfig) (string, error) {
+	return renderTemplate("transaction_ur_completer", cfg)
 }
 
 func GenerateDeviceConfigSV(cfg *SVGeneratorConfig) (string, error) {

--- a/internal/firmware/svgen/templates/bar_controller.sv.tmpl
+++ b/internal/firmware/svgen/templates/bar_controller.sv.tmpl
@@ -29,13 +29,93 @@ module pcileech_tlps128_bar_controller(
     output                  intr_req
 );
 
-    // TLP receive
+    wire        norm_request_present;
+    wire        norm_request_supported;
+    wire        norm_unsupported_request;
+    wire        norm_ur_required;
+    wire        norm_non_posted_request;
+    wire        norm_malformed_request;
+    wire        norm_posted_write;
+    wire        norm_memory_read;
+    wire        norm_memory_write;
+    wire [2:0]  norm_request_kind;
+    wire        norm_header_4dw;
+    wire [63:0] norm_address;
+    wire [10:0] norm_length_dw;
+    wire [3:0]  norm_first_be;
+    wire [3:0]  norm_last_be;
+    wire [15:0] norm_requester_id;
+    wire [7:0]  norm_tag;
+    wire [2:0]  norm_traffic_class;
+    wire [2:0]  norm_attributes;
+    wire [2:0]  norm_bir;
+    wire [6:0]  norm_bar_mask;
+    wire [12:0] norm_enabled_byte_count;
+    wire [12:0] norm_first_completion_byte_count;
+    wire [10:0] norm_first_completion_dw;
+    wire [6:0]  norm_first_lower_address;
+
+    pcileech_tlp_normalizer #(
+        .READ_COMPLETION_BOUNDARY ( {{ .ResolvedReadCompletionBoundaryBytes }} ),
+        .MAX_PAYLOAD_BYTES         ( {{ .ResolvedMaxPayloadBytes }} )
+    ) i_tlp_normalizer(
+        .tlp_data              ( tlps_in.tdata              ),
+        .tlp_user              ( tlps_in.tuser              ),
+        .tlp_last              ( tlps_in.tlast              ),
+        .request_present       ( norm_request_present       ),
+        .request_supported     ( norm_request_supported     ),
+        .unsupported_request   ( norm_unsupported_request   ),
+        .ur_required           ( norm_ur_required           ),
+        .non_posted_request  ( norm_non_posted_request  ),
+        .malformed_request     ( norm_malformed_request     ),
+        .posted_write          ( norm_posted_write          ),
+        .memory_read           ( norm_memory_read           ),
+        .memory_write          ( norm_memory_write          ),
+        .request_kind          ( norm_request_kind          ),
+        .header_4dw             ( norm_header_4dw             ),
+        .address               ( norm_address               ),
+        .length_dw             ( norm_length_dw             ),
+        .first_be              ( norm_first_be              ),
+        .last_be               ( norm_last_be               ),
+        .requester_id          ( norm_requester_id          ),
+        .tag                   ( norm_tag                   ),
+        .traffic_class         ( norm_traffic_class         ),
+        .attributes            ( norm_attributes            ),
+        .bir                   ( norm_bir                   ),
+        .bar_mask              ( norm_bar_mask              ),
+        .enabled_byte_count    ( norm_enabled_byte_count    ),
+        .first_completion_byte_count ( norm_first_completion_byte_count ),
+        .first_completion_dw   ( norm_first_completion_dw   ),
+        .first_lower_address   ( norm_first_lower_address   )
+    );
+
+    IfAXIS128 tlps_ur();
+    wire ur_request_ready;
+
+    pcileech_tlp_ur_completer i_tlp_ur_completer(
+        .rst            ( rst                           ),
+        .clk            ( clk                           ),
+        .pcie_id        ( pcie_id                       ),
+        .request_valid  ( tlps_in.tvalid && bar_en &&
+                          norm_request_present && norm_ur_required &&
+                          norm_non_posted_request &&
+                          (norm_bar_mask != 7'h00)        ),
+        .request_ready  ( ur_request_ready              ),
+        .requester_id   ( norm_requester_id             ),
+        .tag            ( norm_tag                      ),
+        .traffic_class  ( norm_traffic_class            ),
+        .attributes     ( norm_attributes               ),
+        .tlps_out       ( tlps_ur.source                )
+    );
+
     wire in_is_wr_ready;
     bit  in_is_wr_last;
-    wire in_is_first    = tlps_in.tuser[0];
-    wire in_is_bar      = bar_en && (tlps_in.tuser[8:2] != 0);
-    wire in_is_rd       = (in_is_first && tlps_in.tlast && ((tlps_in.tdata[31:25] == 7'b0000000) || (tlps_in.tdata[31:25] == 7'b0010000) || (tlps_in.tdata[31:24] == 8'b00000010)));
-    wire in_is_wr       = in_is_wr_last || (in_is_first && in_is_wr_ready && ((tlps_in.tdata[31:25] == 7'b0100000) || (tlps_in.tdata[31:25] == 7'b0110000) || (tlps_in.tdata[31:24] == 8'b01000010)));
+    wire in_is_first = tlps_in.tuser[0];
+    wire in_is_bar   = bar_en && (norm_request_supported || in_is_wr_last);
+    wire in_is_rd    = in_is_first && norm_memory_read && norm_request_supported;
+    wire in_is_wr    = in_is_wr_last ||
+                       (in_is_first && in_is_wr_ready && norm_posted_write &&
+                        (norm_enabled_byte_count != 13'd0));
 
     always @ ( posedge clk )
         if ( rst ) begin
@@ -96,45 +176,74 @@ module pcileech_tlps128_bar_controller(
     localparam NVME_TIMING_ENABLED = (`NVME_TIMING_ENABLE != 0);
     localparam integer NVME_TIMING_CLOCK_HZ = `NVME_TIMING_CLK_HZ;
 
-{{ if and (eq .DeviceClass "nvme") .NVMeIdentify }}
-    // rdengine goes to an intermediate bus so we can mux in DMA bridge TLPs
     IfAXIS128 tlps_rdeng();
 
-    pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
-        .rst            ( rst                           ),
-        .clk            ( clk                           ),
-        .pcie_id        ( pcie_id                       ),
-        .tlps_in        ( tlps_in                       ),
-        .tlps_in_valid  ( tlps_in.tvalid && in_is_bar && in_is_rd ),
-        .tlps_out       ( tlps_rdeng.source             ),
-        .rd_req_ctx     ( rd_req_ctx                    ),
-        .rd_req_bar     ( rd_req_bar                    ),
-        .rd_req_addr    ( rd_req_addr                   ),
-        .rd_req_valid   ( rd_req_valid                  ),
-        .rd_rsp_ctx     ( rd_rsp_ctx                    ),
-        .rd_rsp_data    ( rd_rsp_data                   ),
-        .rd_rsp_valid   ( rd_rsp_valid                  )
+    pcileech_tlps128_bar_rdengine #(
+        .READ_COMPLETION_BOUNDARY ( {{ .ResolvedReadCompletionBoundaryBytes }} ),
+        .MAX_PAYLOAD_BYTES         ( {{ .ResolvedMaxPayloadBytes }} )
+    ) i_pcileech_tlps128_bar_rdengine(
+        .rst                       ( rst                         ),
+        .clk                       ( clk                         ),
+        .pcie_id                   ( pcie_id                     ),
+        .tlps_in_valid             ( tlps_in.tvalid && in_is_bar && in_is_rd ),
+        .norm_address              ( norm_address                ),
+        .norm_length_dw            ( norm_length_dw              ),
+        .norm_first_be             ( norm_first_be               ),
+        .norm_last_be              ( norm_last_be                ),
+        .norm_requester_id         ( norm_requester_id           ),
+        .norm_tag                  ( norm_tag                    ),
+        .norm_traffic_class        ( norm_traffic_class          ),
+        .norm_attributes           ( norm_attributes             ),
+        .norm_header_4dw           ( norm_header_4dw             ),
+        .norm_bar_mask             ( norm_bar_mask               ),
+        .norm_enabled_byte_count   ( norm_enabled_byte_count     ),
+        .norm_first_completion_byte_count ( norm_first_completion_byte_count ),
+        .norm_first_completion_dw  ( norm_first_completion_dw    ),
+        .tlps_out                  ( tlps_rdeng.source           ),
+        .rd_req_ctx                ( rd_req_ctx                  ),
+        .rd_req_bar                ( rd_req_bar                  ),
+        .rd_req_addr               ( rd_req_addr                 ),
+        .rd_req_valid              ( rd_req_valid                ),
+        .rd_rsp_ctx                ( rd_rsp_ctx                  ),
+        .rd_rsp_data               ( rd_rsp_data                 ),
+        .rd_rsp_valid              ( rd_rsp_valid                )
     );
-{{ else }}
-    // rdengine output goes to intermediate for DMA bridge TLP muxing
-    IfAXIS128 tlps_rdeng();
 
-    pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
-        .rst            ( rst                           ),
-        .clk            ( clk                           ),
-        .pcie_id        ( pcie_id                       ),
-        .tlps_in        ( tlps_in                       ),
-        .tlps_in_valid  ( tlps_in.tvalid && in_is_bar && in_is_rd ),
-        .tlps_out       ( tlps_rdeng.source             ),
-        .rd_req_ctx     ( rd_req_ctx                    ),
-        .rd_req_bar     ( rd_req_bar                    ),
-        .rd_req_addr    ( rd_req_addr                   ),
-        .rd_req_valid   ( rd_req_valid                  ),
-        .rd_rsp_ctx     ( rd_rsp_ctx                    ),
-        .rd_rsp_data    ( rd_rsp_data                   ),
-        .rd_rsp_valid   ( rd_rsp_valid                  )
-    );
-{{ end }}
+    IfAXIS128 tlps_cpl();
+    reg cpl_grant_active;
+    reg cpl_grant_ur;
+    reg cpl_last_grant_ur;
+    wire cpl_select_ur = cpl_grant_active
+                       ? cpl_grant_ur
+                       : (tlps_ur.tvalid &&
+                          (!tlps_rdeng.tvalid || !cpl_last_grant_ur));
+
+    assign tlps_cpl.tdata    = cpl_select_ur ? tlps_ur.tdata    : tlps_rdeng.tdata;
+    assign tlps_cpl.tkeepdw  = cpl_select_ur ? tlps_ur.tkeepdw  : tlps_rdeng.tkeepdw;
+    assign tlps_cpl.tvalid   = cpl_select_ur ? tlps_ur.tvalid   : tlps_rdeng.tvalid;
+    assign tlps_cpl.tlast    = cpl_select_ur ? tlps_ur.tlast    : tlps_rdeng.tlast;
+    assign tlps_cpl.tuser    = cpl_select_ur ? tlps_ur.tuser    : tlps_rdeng.tuser;
+    assign tlps_cpl.has_data = cpl_select_ur ? tlps_ur.has_data : tlps_rdeng.has_data;
+    assign tlps_ur.tready    = tlps_cpl.tready && cpl_select_ur;
+    assign tlps_rdeng.tready = tlps_cpl.tready && !cpl_select_ur;
+
+    always @(posedge clk) begin
+        if (rst) begin
+            cpl_grant_active <= 1'b0;
+            cpl_grant_ur     <= 1'b0;
+            cpl_last_grant_ur <= 1'b1;
+        end else begin
+            if (!cpl_grant_active && tlps_cpl.tvalid) begin
+                cpl_grant_ur <= cpl_select_ur;
+                if (!(tlps_cpl.tready && tlps_cpl.tlast))
+                    cpl_grant_active <= 1'b1;
+            end
+            if (tlps_cpl.tvalid && tlps_cpl.tready && tlps_cpl.tlast) begin
+                cpl_grant_active <= 1'b0;
+                cpl_last_grant_ur <= cpl_select_ur;
+            end
+        end
+    end
 
     wire        wrengine_ready;
 
@@ -579,6 +688,7 @@ module pcileech_tlps128_bar_controller(
     wire         hda_tlp_tx_tvalid;
     wire         hda_tlp_tx_tlast;
     wire [8:0]   hda_tlp_tx_tuser;
+    wire         hda_tlp_tx_tready;
 
     pcileech_hda_rirb_dma i_hda_rirb_dma(
         .rst            ( rst                           ),
@@ -598,7 +708,7 @@ module pcileech_tlps128_bar_controller(
         .tlp_tx_tvalid  ( hda_tlp_tx_tvalid             ),
         .tlp_tx_tlast   ( hda_tlp_tx_tlast              ),
         .tlp_tx_tuser   ( hda_tlp_tx_tuser              ),
-        .tlp_tx_tready  ( tlps_out.tready && !dma_yield  )
+        .tlp_tx_tready  ( hda_tlp_tx_tready              )
     );
 
     // ========================================================================
@@ -862,52 +972,63 @@ module pcileech_tlps128_bar_controller(
     assign tlps_dma_out.tuser    = {7'h00, nvme_dma_fifo_tlast, nvme_dma_fifo_first};
     assign tlps_dma_out.has_data = (nvme_dma_pkt_count_next != 11'd0);
 
-    assign tlps_out.tdata    = tlps_rdeng.tdata;
-    assign tlps_out.tkeepdw  = tlps_rdeng.tkeepdw;
-    assign tlps_out.tvalid   = tlps_rdeng.tvalid;
-    assign tlps_out.tlast    = tlps_rdeng.tlast;
-    assign tlps_out.tuser    = tlps_rdeng.tuser;
-    assign tlps_out.has_data = tlps_rdeng.has_data;
-    assign tlps_rdeng.tready = tlps_out.tready;
+    assign tlps_out.tdata    = tlps_cpl.tdata;
+    assign tlps_out.tkeepdw  = tlps_cpl.tkeepdw;
+    assign tlps_out.tvalid   = tlps_cpl.tvalid;
+    assign tlps_out.tlast    = tlps_cpl.tlast;
+    assign tlps_out.tuser    = tlps_cpl.tuser;
+    assign tlps_out.has_data = tlps_cpl.has_data;
+    assign tlps_cpl.tready   = tlps_out.tready;
 {{ end }}
 
 {{ if and (eq .DeviceClass "audio") .BARModel }}{{ if not (and (eq .DeviceClass "nvme") .NVMeIdentify) }}
-    // HDA-only build: mux HDA DMA TLPs with rdengine BAR responses
-    //
-    // fairness: after 8 consecutive DMA TLP words a 1-cycle gap is forced so
-    // BAR read completions cannot be starved by sustained DMA bursts
-    reg [2:0] dma_burst_cnt;
-    wire dma_yield = (dma_burst_cnt == 3'd7);
+    reg hda_packet_active;
+    reg hda_packet_select_dma;
+    reg hda_last_grant_dma;
+    wire hda_select_dma = hda_packet_active
+                        ? hda_packet_select_dma
+                        : (hda_tlp_tx_tvalid &&
+                           (!tlps_cpl.tvalid || !hda_last_grant_dma));
+
+    assign tlps_out.tdata    = hda_select_dma ? hda_tlp_tx_tdata   : tlps_cpl.tdata;
+    assign tlps_out.tkeepdw  = hda_select_dma ? hda_tlp_tx_tkeepdw : tlps_cpl.tkeepdw;
+    assign tlps_out.tvalid   = hda_select_dma ? hda_tlp_tx_tvalid  : tlps_cpl.tvalid;
+    assign tlps_out.tlast    = hda_select_dma ? hda_tlp_tx_tlast   : tlps_cpl.tlast;
+    assign tlps_out.tuser    = hda_select_dma ? hda_tlp_tx_tuser   : tlps_cpl.tuser;
+    assign tlps_out.has_data = hda_select_dma ? hda_tlp_tx_tvalid  : tlps_cpl.has_data;
+    assign hda_tlp_tx_tready = tlps_out.tready && hda_select_dma;
+    assign tlps_cpl.tready   = tlps_out.tready && !hda_select_dma;
 
     always @(posedge clk) begin
-        if (dma_yield)
-            dma_burst_cnt <= 3'd0;
-        else if (hda_tlp_tx_tvalid && tlps_out.tready && dma_burst_cnt != 3'd7)
-            dma_burst_cnt <= dma_burst_cnt + 3'd1;
-        else if (!hda_tlp_tx_tvalid)
-            dma_burst_cnt <= 3'd0;
+        if (rst) begin
+            hda_packet_active     <= 1'b0;
+            hda_packet_select_dma <= 1'b0;
+            hda_last_grant_dma    <= 1'b0;
+        end else if (!hda_packet_active) begin
+            if (tlps_out.tvalid) begin
+                hda_packet_select_dma <= hda_select_dma;
+                if (tlps_out.tready && tlps_out.tlast)
+                    hda_last_grant_dma <= hda_select_dma;
+                else
+                    hda_packet_active <= 1'b1;
+            end
+        end else if (tlps_out.tvalid && tlps_out.tready && tlps_out.tlast) begin
+            hda_packet_active  <= 1'b0;
+            hda_last_grant_dma <= hda_select_dma;
+        end
     end
-
-    assign tlps_out.tdata    = (hda_tlp_tx_tvalid && !dma_yield) ? hda_tlp_tx_tdata    : tlps_rdeng.tdata;
-    assign tlps_out.tkeepdw  = (hda_tlp_tx_tvalid && !dma_yield) ? hda_tlp_tx_tkeepdw  : tlps_rdeng.tkeepdw;
-    assign tlps_out.tvalid   = (hda_tlp_tx_tvalid && !dma_yield) || tlps_rdeng.tvalid;
-    assign tlps_out.tlast    = (hda_tlp_tx_tvalid && !dma_yield) ? hda_tlp_tx_tlast    : tlps_rdeng.tlast;
-    assign tlps_out.tuser    = (hda_tlp_tx_tvalid && !dma_yield) ? hda_tlp_tx_tuser    : tlps_rdeng.tuser;
-    assign tlps_out.has_data = (hda_tlp_tx_tvalid && !dma_yield) || tlps_rdeng.has_data;
-    assign tlps_rdeng.tready = tlps_out.tready && (dma_yield || !hda_tlp_tx_tvalid);
 
 {{ end }}{{
  end }}
 
 {{ if not (or (and (eq .DeviceClass "nvme") .NVMeIdentify) (and (eq .DeviceClass "audio") .BARModel)) }}
-    // no DMA bridge: rdengine output goes straight to tlps_out
-    assign tlps_out.tdata    = tlps_rdeng.tdata;
-    assign tlps_out.tkeepdw  = tlps_rdeng.tkeepdw;
-    assign tlps_out.tvalid   = tlps_rdeng.tvalid;
-    assign tlps_out.tlast    = tlps_rdeng.tlast;
-    assign tlps_out.tuser    = tlps_rdeng.tuser;
-    assign tlps_out.has_data = tlps_rdeng.has_data;
-    assign tlps_rdeng.tready = tlps_out.tready;
+    assign tlps_out.tdata    = tlps_cpl.tdata;
+    assign tlps_out.tkeepdw  = tlps_cpl.tkeepdw;
+    assign tlps_out.tvalid   = tlps_cpl.tvalid;
+    assign tlps_out.tlast    = tlps_cpl.tlast;
+    assign tlps_out.tuser    = tlps_cpl.tuser;
+    assign tlps_out.has_data = tlps_cpl.has_data;
+    assign tlps_cpl.tready   = tlps_out.tready;
 {{ end }}
 
     // BAR1: address loopback

--- a/internal/firmware/svgen/templates/bar_read_engine.sv.tmpl
+++ b/internal/firmware/svgen/templates/bar_read_engine.sv.tmpl
@@ -1,0 +1,341 @@
+`timescale 1ns / 1ps
+`include "pcileech_header.svh"
+
+module pcileech_tlps128_bar_rdengine #(
+    parameter integer READ_COMPLETION_BOUNDARY = {{ .ResolvedReadCompletionBoundaryBytes }},
+    parameter integer MAX_PAYLOAD_BYTES         = {{ .ResolvedMaxPayloadBytes }}
+)(
+    input                   rst,
+    input                   clk,
+    input [15:0]            pcie_id,
+    IfAXIS128.source        tlps_out,
+
+    input                   tlps_in_valid,
+    input [63:0]            norm_address,
+    input [10:0]            norm_length_dw,
+    input [3:0]             norm_first_be,
+    input [3:0]             norm_last_be,
+    input [15:0]            norm_requester_id,
+    input [7:0]             norm_tag,
+    input [2:0]             norm_traffic_class,
+    input [2:0]             norm_attributes,
+    input                   norm_header_4dw,
+    input [6:0]             norm_bar_mask,
+    input [12:0]            norm_enabled_byte_count,
+    input [12:0]            norm_first_completion_byte_count,
+    input [10:0]            norm_first_completion_dw,
+
+    output [87:0]           rd_req_ctx,
+    output [6:0]            rd_req_bar,
+    output [31:0]           rd_req_addr,
+    output                  rd_req_valid,
+    input  [87:0]           rd_rsp_ctx,
+    input  [31:0]           rd_rsp_data,
+    input                   rd_rsp_valid
+);
+    localparam integer REQUEST_FIFO_DEPTH = 256;
+    localparam ST_IDLE  = 1'b0;
+    localparam ST_ISSUE = 1'b1;
+
+    reg [63:0] req_addr_fifo [0:REQUEST_FIFO_DEPTH-1];
+    reg [10:0] req_len_fifo  [0:REQUEST_FIFO_DEPTH-1];
+    reg [3:0]  req_fbe_fifo  [0:REQUEST_FIFO_DEPTH-1];
+    reg [3:0]  req_lbe_fifo  [0:REQUEST_FIFO_DEPTH-1];
+    reg [15:0] req_id_fifo   [0:REQUEST_FIFO_DEPTH-1];
+    reg [7:0]  req_tag_fifo  [0:REQUEST_FIFO_DEPTH-1];
+    reg [2:0]  req_tc_fifo   [0:REQUEST_FIFO_DEPTH-1];
+    reg [2:0]  req_attr_fifo [0:REQUEST_FIFO_DEPTH-1];
+    reg        req_4dw_fifo  [0:REQUEST_FIFO_DEPTH-1];
+    reg [6:0]  req_bar_fifo  [0:REQUEST_FIFO_DEPTH-1];
+    reg [12:0] req_bc_fifo   [0:REQUEST_FIFO_DEPTH-1];
+    reg [10:0] req_cpl_fifo  [0:REQUEST_FIFO_DEPTH-1];
+    reg [7:0]  req_wr_ptr;
+    reg [7:0]  req_rd_ptr;
+    reg [8:0]  req_count;
+
+    reg        state;
+    reg [63:0] current_addr;
+    reg [10:0] request_length_dw;
+    reg [10:0] remaining_dw;
+    reg [10:0] packet_length_dw;
+    reg [10:0] packet_remaining_dw;
+    reg [12:0] remaining_byte_count;
+    reg [3:0]  request_first_be;
+    reg [3:0]  request_last_be;
+    reg [15:0] request_id;
+    reg [7:0]  request_tag;
+    reg [2:0]  request_tc;
+    reg [2:0]  request_attr;
+    reg        request_4dw;
+    reg [6:0]  request_bar;
+    reg        request_first_packet;
+    reg        packet_first;
+
+    wire request_fifo_full = (req_count == 9'd256);
+    wire request_pop = (state == ST_IDLE) && (req_count != 0);
+    wire request_can_accept = !request_fifo_full || request_pop;
+    wire request_push = tlps_in_valid && request_can_accept;
+
+    function automatic [2:0] popcount4(input [3:0] value);
+        begin
+            popcount4 = {2'b00, value[0]} + {2'b00, value[1]} +
+                        {2'b00, value[2]} + {2'b00, value[3]};
+        end
+    endfunction
+
+    function automatic [1:0] first_enabled_offset(input [3:0] value);
+        begin
+            if (value[0])      first_enabled_offset = 2'd0;
+            else if (value[1]) first_enabled_offset = 2'd1;
+            else if (value[2]) first_enabled_offset = 2'd2;
+            else if (value[3]) first_enabled_offset = 2'd3;
+            else               first_enabled_offset = 2'd0;
+        end
+    endfunction
+
+    function automatic [10:0] next_completion_dw(
+        input [63:0] address_in,
+        input [10:0] remaining_in
+    );
+        integer rcb_dw;
+        integer mps_dw;
+        integer selected_dw;
+        begin
+            rcb_dw = (READ_COMPLETION_BOUNDARY -
+                      (address_in & (READ_COMPLETION_BOUNDARY - 1))) / 4;
+            mps_dw = MAX_PAYLOAD_BYTES / 4;
+            selected_dw = remaining_in;
+            if (selected_dw > rcb_dw)
+                selected_dw = rcb_dw;
+            if (selected_dw > mps_dw)
+                selected_dw = mps_dw;
+            next_completion_dw = selected_dw[10:0];
+        end
+    endfunction
+
+    function automatic [12:0] completed_enabled_bytes(
+        input [10:0] total_length,
+        input [10:0] remaining_before,
+        input [10:0] completion_length,
+        input [3:0] first_enable,
+        input [3:0] last_enable
+    );
+        reg [12:0] value;
+        begin
+            if (total_length == 11'd1) begin
+                value = popcount4(first_enable);
+            end else begin
+                value = {completion_length, 2'b00};
+                if (remaining_before == total_length)
+                    value = value - (13'd4 - popcount4(first_enable));
+                if (completion_length == remaining_before)
+                    value = value - (13'd4 - popcount4(last_enable));
+            end
+            completed_enabled_bytes = value;
+        end
+    endfunction
+
+    always @(posedge clk) begin
+        if (rst) begin
+            req_wr_ptr <= 8'h00;
+        end else if (request_push) begin
+            req_addr_fifo[req_wr_ptr] <= norm_address;
+            req_len_fifo[req_wr_ptr]  <= norm_length_dw;
+            req_fbe_fifo[req_wr_ptr]  <= norm_first_be;
+            req_lbe_fifo[req_wr_ptr]  <= norm_last_be;
+            req_id_fifo[req_wr_ptr]   <= norm_requester_id;
+            req_tag_fifo[req_wr_ptr]  <= norm_tag;
+            req_tc_fifo[req_wr_ptr]   <= norm_traffic_class;
+            req_attr_fifo[req_wr_ptr] <= norm_attributes;
+            req_4dw_fifo[req_wr_ptr]  <= norm_header_4dw;
+            req_bar_fifo[req_wr_ptr]  <= norm_bar_mask;
+            req_bc_fifo[req_wr_ptr]   <= norm_first_completion_byte_count;
+            req_cpl_fifo[req_wr_ptr]  <= norm_first_completion_dw;
+            req_wr_ptr <= req_wr_ptr + 1'b1;
+        end
+    end
+
+    always @(posedge clk) begin
+        if (rst) begin
+            req_rd_ptr <= 8'h00;
+            req_count  <= 9'h000;
+        end else begin
+            case ({request_push, request_pop})
+                2'b10: req_count <= req_count + 1'b1;
+                2'b01: req_count <= req_count - 1'b1;
+                default: req_count <= req_count;
+            endcase
+            if (request_pop)
+                req_rd_ptr <= req_rd_ptr + 1'b1;
+        end
+    end
+
+    wire rd3_enable;
+    wire issue_dw = (state == ST_ISSUE) && rd3_enable;
+    wire packet_last = (packet_remaining_dw == 11'd1);
+    wire request_last_packet = (packet_length_dw == remaining_dw);
+    wire [3:0] packet_start_be = request_first_packet ? request_first_be :
+                                 ((remaining_dw == 11'd1) ? request_last_be : 4'hF);
+    wire [1:0] packet_first_offset = first_enabled_offset(packet_start_be);
+    wire [31:0] context_address = packet_first
+                                ? {current_addr[31:2], packet_first_offset}
+                                : current_addr[31:0];
+
+    assign rd_req_ctx = {
+        packet_first,
+        packet_last,
+        packet_length_dw,
+        remaining_byte_count[11:0],
+        request_tc,
+        request_attr,
+        request_4dw,
+        request_tag,
+        request_id,
+        context_address
+    };
+    assign rd_req_bar   = request_bar;
+    assign rd_req_addr  = current_addr[31:0];
+    assign rd_req_valid = issue_dw;
+
+    always @(posedge clk) begin
+        if (rst) begin
+            state                 <= ST_IDLE;
+            current_addr          <= 64'h0;
+            request_length_dw     <= 11'h0;
+            remaining_dw          <= 11'h0;
+            packet_length_dw      <= 11'h0;
+            packet_remaining_dw   <= 11'h0;
+            remaining_byte_count  <= 13'h0;
+            request_first_be      <= 4'h0;
+            request_last_be       <= 4'h0;
+            request_id            <= 16'h0;
+            request_tag           <= 8'h0;
+            request_tc            <= 3'h0;
+            request_attr          <= 3'h0;
+            request_4dw           <= 1'b0;
+            request_bar           <= 7'h0;
+            request_first_packet  <= 1'b0;
+            packet_first          <= 1'b0;
+        end else if (state == ST_IDLE) begin
+            if (request_pop) begin
+                current_addr         <= req_addr_fifo[req_rd_ptr];
+                request_length_dw    <= req_len_fifo[req_rd_ptr];
+                remaining_dw         <= req_len_fifo[req_rd_ptr];
+                packet_length_dw     <= req_cpl_fifo[req_rd_ptr];
+                packet_remaining_dw  <= req_cpl_fifo[req_rd_ptr];
+                remaining_byte_count <= req_bc_fifo[req_rd_ptr];
+                request_first_be     <= req_fbe_fifo[req_rd_ptr];
+                request_last_be      <= req_lbe_fifo[req_rd_ptr];
+                request_id           <= req_id_fifo[req_rd_ptr];
+                request_tag          <= req_tag_fifo[req_rd_ptr];
+                request_tc           <= req_tc_fifo[req_rd_ptr];
+                request_attr         <= req_attr_fifo[req_rd_ptr];
+                request_4dw          <= req_4dw_fifo[req_rd_ptr];
+                request_bar          <= req_bar_fifo[req_rd_ptr];
+                request_first_packet <= 1'b1;
+                packet_first         <= 1'b1;
+                state                <= ST_ISSUE;
+            end
+        end else if (issue_dw) begin
+            if (!packet_last) begin
+                current_addr        <= current_addr + 64'd4;
+                packet_remaining_dw <= packet_remaining_dw - 1'b1;
+                packet_first        <= 1'b0;
+            end else if (request_last_packet) begin
+                state        <= ST_IDLE;
+                packet_first <= 1'b0;
+            end else begin
+                current_addr <= current_addr + 64'd4;
+                remaining_dw <= remaining_dw - packet_length_dw;
+                remaining_byte_count <= remaining_byte_count - completed_enabled_bytes(
+                    request_length_dw, remaining_dw, packet_length_dw,
+                    request_first_be, request_last_be);
+                packet_length_dw <= next_completion_dw(
+                    current_addr + 64'd4, remaining_dw - packet_length_dw);
+                packet_remaining_dw <= next_completion_dw(
+                    current_addr + 64'd4, remaining_dw - packet_length_dw);
+                request_first_packet <= 1'b0;
+                packet_first         <= 1'b1;
+            end
+        end
+    end
+
+    wire        rd_rsp_first       = rd_rsp_ctx[87];
+    wire        rd_rsp_last        = rd_rsp_ctx[86];
+    wire [10:0] rd_rsp_dwlen       = rd_rsp_ctx[85:75];
+    wire [11:0] rd_rsp_byte_count  = rd_rsp_ctx[74:63];
+    wire [2:0]  rd_rsp_tc          = rd_rsp_ctx[62:60];
+    wire [2:0]  rd_rsp_attr        = rd_rsp_ctx[59:57];
+    wire        rd_rsp_4dw         = rd_rsp_ctx[56];
+    wire [7:0]  rd_rsp_tag         = rd_rsp_ctx[55:48];
+    wire [15:0] rd_rsp_requester   = rd_rsp_ctx[47:32];
+    wire [6:0]  rd_rsp_lower_addr  = rd_rsp_ctx[6:0];
+    wire [31:0] rd_rsp_data_swapped = {
+        rd_rsp_data[7:0], rd_rsp_data[15:8],
+        rd_rsp_data[23:16], rd_rsp_data[31:24]
+    };
+
+    bit [127:0] tdata;
+    bit [3:0]   tkeepdw;
+    bit         tlast;
+    bit         first;
+    wire        tvalid = tlast || tkeepdw[3];
+
+    always @(posedge clk) begin
+        if (rst) begin
+            tdata   <= 128'h0;
+            tkeepdw <= 4'h0;
+            tlast   <= 1'b0;
+            first   <= 1'b0;
+        end else if (rd_rsp_valid && rd_rsp_first) begin
+            tdata[31:29]      <= 3'b010;
+            tdata[28:24]      <= 5'b01010;
+            tdata[23]         <= 1'b0;
+            tdata[22:20]      <= rd_rsp_tc;
+            tdata[19]         <= 1'b0;
+            tdata[18]         <= rd_rsp_attr[2];
+            tdata[17:14]      <= 4'b0000;
+            tdata[13:12]      <= rd_rsp_attr[1:0];
+            tdata[11:10]      <= 2'b00;
+            tdata[9:0]        <= rd_rsp_dwlen[9:0];
+            tdata[63:32]      <= {pcie_id[7:0], pcie_id[15:8], 4'b0000,
+                                  rd_rsp_byte_count};
+            tdata[95:64]      <= {rd_rsp_requester, rd_rsp_tag, 1'b0,
+                                  rd_rsp_lower_addr};
+            tdata[127:96]     <= rd_rsp_data_swapped;
+            tkeepdw           <= 4'b1111;
+            tlast             <= rd_rsp_last;
+            first             <= 1'b1;
+        end else begin
+            tlast   <= rd_rsp_valid && rd_rsp_last;
+            tkeepdw <= tvalid ? (rd_rsp_valid ? 4'b0001 : 4'b0000) :
+                       (rd_rsp_valid ? ((tkeepdw << 1) | 1'b1) : tkeepdw);
+            first <= 1'b0;
+            if (rd_rsp_valid) begin
+                if (tvalid || !tkeepdw[0]) tdata[31:0]   <= rd_rsp_data_swapped;
+                if (!tkeepdw[1])           tdata[63:32]  <= rd_rsp_data_swapped;
+                if (!tkeepdw[2])           tdata[95:64]  <= rd_rsp_data_swapped;
+                if (!tkeepdw[3])           tdata[127:96] <= rd_rsp_data_swapped;
+            end
+        end
+    end
+
+    wire unused_rd_rsp_4dw = rd_rsp_4dw;
+
+    fifo_134_134_clk1_bar_rdrsp i_fifo_134_134_clk1_bar_rdrsp(
+        .srst       ( rst ),
+        .clk        ( clk ),
+        .din        ( {first, tlast, tkeepdw, tdata} ),
+        .wr_en      ( tvalid ),
+        .rd_en      ( tlps_out.tready ),
+        .dout       ( {tlps_out.tuser[0], tlps_out.tlast,
+                       tlps_out.tkeepdw, tlps_out.tdata} ),
+        .full       ( ),
+        .empty      ( ),
+        .prog_empty ( rd3_enable ),
+        .valid      ( tlps_out.tvalid )
+    );
+    assign tlps_out.tuser[8:2] = 7'h00;
+    assign tlps_out.tuser[1]   = tlps_out.tlast;
+    assign tlps_out.has_data   = tlps_out.tvalid;
+endmodule

--- a/internal/firmware/svgen/templates/transaction_normalizer.sv.tmpl
+++ b/internal/firmware/svgen/templates/transaction_normalizer.sv.tmpl
@@ -1,0 +1,202 @@
+`timescale 1ns / 1ps
+
+module pcileech_tlp_normalizer #(
+    parameter integer READ_COMPLETION_BOUNDARY = {{ .ResolvedReadCompletionBoundaryBytes }},
+    parameter integer MAX_PAYLOAD_BYTES         = {{ .ResolvedMaxPayloadBytes }}
+)(
+    input  wire [127:0] tlp_data,
+    input  wire [8:0]   tlp_user,
+    input  wire         tlp_last,
+
+    output reg          request_present,
+    output reg          request_supported,
+    output reg          unsupported_request,
+    output reg          ur_required,
+    output reg          non_posted_request,
+    output reg          malformed_request,
+    output reg          posted_write,
+    output reg          memory_read,
+    output reg          memory_write,
+    output reg  [2:0]   request_kind,
+    output reg          header_4dw,
+    output reg  [63:0]  address,
+    output reg  [10:0]  length_dw,
+    output reg  [3:0]   first_be,
+    output reg  [3:0]   last_be,
+    output reg  [15:0]  requester_id,
+    output reg  [7:0]   tag,
+    output reg  [2:0]   traffic_class,
+    output reg  [2:0]   attributes,
+    output reg  [2:0]   bir,
+    output reg  [6:0]   bar_mask,
+
+    output reg  [12:0]  enabled_byte_count,
+    output reg  [12:0]  first_completion_byte_count,
+    output reg  [10:0]  first_completion_dw,
+    output reg  [6:0]   first_lower_address
+);
+    localparam [2:0] KIND_UNKNOWN = 3'd0;
+    localparam [2:0] KIND_MRD     = 3'd1;
+    localparam [2:0] KIND_MWR     = 3'd2;
+    localparam [2:0] KIND_IORD    = 3'd3;
+    localparam [2:0] KIND_IOWR    = 3'd4;
+    localparam [2:0] KIND_ATOMIC  = 3'd5;
+    localparam [2:0] KIND_MRDLK   = 3'd6;
+    localparam [2:0] KIND_CONFIG  = 3'd7;
+
+    reg [2:0]  fmt;
+    reg [4:0]  tlp_type;
+    reg [12:0] rcb_bytes_left;
+    reg [10:0] rcb_dw_left;
+    reg [10:0] mps_dw;
+    reg        legal_be;
+    reg        legal_bar;
+    reg        crosses_4k;
+
+    function automatic [2:0] popcount4(input [3:0] value);
+        begin
+            popcount4 = {2'b00, value[0]} + {2'b00, value[1]} +
+                        {2'b00, value[2]} + {2'b00, value[3]};
+        end
+    endfunction
+
+    function automatic [1:0] first_enabled_offset(input [3:0] value);
+        begin
+            if (value[0])      first_enabled_offset = 2'd0;
+            else if (value[1]) first_enabled_offset = 2'd1;
+            else if (value[2]) first_enabled_offset = 2'd2;
+            else if (value[3]) first_enabled_offset = 2'd3;
+            else               first_enabled_offset = 2'd0;
+        end
+    endfunction
+
+    function automatic valid_first_edge(input [3:0] value);
+        begin
+            valid_first_edge = (value == 4'h8) || (value == 4'hC) ||
+                               (value == 4'hE) || (value == 4'hF);
+        end
+    endfunction
+
+    function automatic valid_last_edge(input [3:0] value);
+        begin
+            valid_last_edge = (value == 4'h1) || (value == 4'h3) ||
+                              (value == 4'h7) || (value == 4'hF);
+        end
+    endfunction
+
+    function automatic onehot7(input [6:0] value);
+        begin
+            onehot7 = (value != 7'h00) && ((value & (value - 1'b1)) == 7'h00);
+        end
+    endfunction
+
+    function automatic [2:0] decode_bir(input [6:0] value);
+        begin
+            case (value)
+                7'b0000001: decode_bir = 3'd0;
+                7'b0000010: decode_bir = 3'd1;
+                7'b0000100: decode_bir = 3'd2;
+                7'b0001000: decode_bir = 3'd3;
+                7'b0010000: decode_bir = 3'd4;
+                7'b0100000: decode_bir = 3'd5;
+                7'b1000000: decode_bir = 3'd6;
+                default:    decode_bir = 3'd7;
+            endcase
+        end
+    endfunction
+
+    always @(*) begin
+        fmt               = tlp_data[31:29];
+        tlp_type          = tlp_data[28:24];
+        request_present   = tlp_user[0];
+        request_supported = 1'b0;
+        unsupported_request = 1'b0;
+        ur_required       = 1'b0;
+        non_posted_request = 1'b0;
+        malformed_request = 1'b0;
+        posted_write      = 1'b0;
+        memory_read       = 1'b0;
+        memory_write      = 1'b0;
+        request_kind      = KIND_UNKNOWN;
+        header_4dw        = fmt[0];
+        length_dw         = (tlp_data[9:0] == 10'h000) ? 11'd1024 : {1'b0, tlp_data[9:0]};
+        first_be          = tlp_data[35:32];
+        last_be           = tlp_data[39:36];
+        requester_id      = tlp_data[63:48];
+        tag               = tlp_data[47:40];
+        traffic_class     = tlp_data[22:20];
+        attributes        = {tlp_data[18], tlp_data[13:12]};
+        bar_mask          = tlp_user[8:2];
+        bir               = decode_bir(tlp_user[8:2]);
+        address           = fmt[0]
+                          ? {tlp_data[95:64], tlp_data[127:98], 2'b00}
+                          : {32'h00000000, tlp_data[95:66], 2'b00};
+
+        case ({fmt, tlp_type})
+            8'b000_00000, 8'b001_00000: begin
+                request_kind = KIND_MRD;
+                memory_read  = 1'b1;
+            end
+            8'b010_00000, 8'b011_00000: begin
+                request_kind = KIND_MWR;
+                memory_write = 1'b1;
+            end
+            8'b000_00001, 8'b001_00001: request_kind = KIND_MRDLK;
+            8'b000_00100, 8'b010_00100,
+            8'b000_00101, 8'b010_00101: request_kind = KIND_CONFIG;
+            8'b000_00010: request_kind = KIND_IORD;
+            8'b010_00010: request_kind = KIND_IOWR;
+            8'b010_01100, 8'b011_01100,
+            8'b010_01101, 8'b011_01101,
+            8'b010_01110, 8'b011_01110: request_kind = KIND_ATOMIC;
+            default: request_kind = KIND_UNKNOWN;
+        endcase
+        non_posted_request = (request_kind == KIND_IORD) ||
+                             (request_kind == KIND_IOWR) ||
+                             (request_kind == KIND_ATOMIC) ||
+                             (request_kind == KIND_MRDLK) ||
+                             (request_kind == KIND_CONFIG);
+
+        legal_bar = onehot7(bar_mask);
+        if (length_dw == 11'd1)
+            legal_be = (last_be == 4'h0);
+        else if ((length_dw == 11'd2) && (address[2:0] == 3'b000))
+            legal_be = (first_be != 4'h0) && (last_be != 4'h0);
+        else
+            legal_be = valid_first_edge(first_be) && valid_last_edge(last_be);
+        crosses_4k = ({1'b0, address[11:0]} + ({2'b00, length_dw} << 2)) > 13'd4096;
+
+        if (request_present) begin
+            if (memory_read || memory_write) begin
+                malformed_request = !legal_bar || !legal_be || crosses_4k ||
+                                    (!header_4dw && (address[63:32] != 32'h0)) ||
+                                    (memory_read && !tlp_last);
+                request_supported = !malformed_request;
+                posted_write      = memory_write && !malformed_request;
+            end else begin
+                unsupported_request = 1'b1;
+                ur_required         = 1'b1;
+            end
+        end
+
+        enabled_byte_count = (length_dw == 11'd1)
+                           ? popcount4(first_be)
+                           : ({10'd0, popcount4(first_be)} +
+                              {10'd0, popcount4(last_be)} +
+                              ((length_dw - 11'd2) << 2));
+        first_completion_byte_count =
+            ((length_dw == 11'd1) && (first_be == 4'h0) && memory_read)
+            ? 13'd4 : enabled_byte_count;
+        first_lower_address = address[6:0] + first_enabled_offset(first_be);
+
+        rcb_bytes_left = READ_COMPLETION_BOUNDARY -
+                         (address & (READ_COMPLETION_BOUNDARY - 1));
+        rcb_dw_left = rcb_bytes_left[12:2];
+        mps_dw = MAX_PAYLOAD_BYTES / 4;
+        first_completion_dw = length_dw;
+        if (first_completion_dw > rcb_dw_left)
+            first_completion_dw = rcb_dw_left;
+        if (first_completion_dw > mps_dw)
+            first_completion_dw = mps_dw;
+    end
+endmodule

--- a/internal/firmware/svgen/templates/transaction_ur_completer.sv.tmpl
+++ b/internal/firmware/svgen/templates/transaction_ur_completer.sv.tmpl
@@ -1,0 +1,78 @@
+`timescale 1ns / 1ps
+`include "pcileech_header.svh"
+
+module pcileech_tlp_ur_completer #(
+    parameter integer REQUEST_FIFO_DEPTH = 256
+)(
+    input                   rst,
+    input                   clk,
+    input [15:0]            pcie_id,
+    input                   request_valid,
+    output                  request_ready,
+    input [15:0]            requester_id,
+    input [7:0]             tag,
+    input [2:0]             traffic_class,
+    input [2:0]             attributes,
+    IfAXIS128.source        tlps_out
+);
+    reg [15:0] requester_fifo [0:REQUEST_FIFO_DEPTH-1];
+    reg [7:0]  tag_fifo       [0:REQUEST_FIFO_DEPTH-1];
+    reg [2:0]  tc_fifo        [0:REQUEST_FIFO_DEPTH-1];
+    reg [2:0]  attr_fifo      [0:REQUEST_FIFO_DEPTH-1];
+    reg [7:0]  write_ptr;
+    reg [7:0]  read_ptr;
+    reg [8:0]  request_count;
+    reg [127:0] completion_data;
+
+    wire request_fifo_full = (request_count == REQUEST_FIFO_DEPTH);
+    wire request_pop = tlps_out.tvalid && tlps_out.tready;
+    wire request_can_accept = !request_fifo_full || request_pop;
+    wire request_push = request_valid && request_can_accept;
+
+    assign request_ready = request_can_accept;
+
+    always @(posedge clk) begin
+        if (rst) begin
+            write_ptr <= 8'h00;
+        end else if (request_push) begin
+            requester_fifo[write_ptr] <= requester_id;
+            tag_fifo[write_ptr]       <= tag;
+            tc_fifo[write_ptr]        <= traffic_class;
+            attr_fifo[write_ptr]      <= attributes;
+            write_ptr                 <= write_ptr + 1'b1;
+        end
+    end
+
+    always @(posedge clk) begin
+        if (rst) begin
+            read_ptr      <= 8'h00;
+            request_count <= 9'h000;
+        end else begin
+            case ({request_push, request_pop})
+                2'b10: request_count <= request_count + 1'b1;
+                2'b01: request_count <= request_count - 1'b1;
+                default: request_count <= request_count;
+            endcase
+            if (request_pop)
+                read_ptr <= read_ptr + 1'b1;
+        end
+    end
+
+    always @(*) begin
+        completion_data = 128'h0;
+        completion_data[31:29] = 3'b000;
+        completion_data[28:24] = 5'b01010;
+        completion_data[22:20] = tc_fifo[read_ptr];
+        completion_data[18]    = attr_fifo[read_ptr][2];
+        completion_data[13:12] = attr_fifo[read_ptr][1:0];
+        completion_data[63:32] = {pcie_id[7:0], pcie_id[15:8], 3'b001, 1'b0, 12'h000};
+        completion_data[95:64] = {requester_fifo[read_ptr], tag_fifo[read_ptr], 8'h00};
+    end
+
+    assign tlps_out.tdata    = completion_data;
+    assign tlps_out.tkeepdw  = 4'b0111;
+    assign tlps_out.tvalid   = (request_count != 0);
+    assign tlps_out.tlast    = 1'b1;
+    assign tlps_out.tuser    = 9'b000000011;
+    assign tlps_out.has_data = (request_count != 0);
+endmodule

--- a/internal/firmware/svgen/transaction_normalizer_test.go
+++ b/internal/firmware/svgen/transaction_normalizer_test.go
@@ -1,0 +1,272 @@
+package svgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func compactHDL(source string) string {
+	return strings.Join(strings.Fields(source), "")
+}
+
+func requireHDLFragments(t *testing.T, source string, fragments map[string]string) {
+	t.Helper()
+	compact := compactHDL(source)
+	for name, fragment := range fragments {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(compact, compactHDL(fragment)) {
+				t.Errorf("generated HDL does not contain %s mechanism\nmissing: %s", name, fragment)
+			}
+		})
+	}
+}
+
+func TestGenerateTransactionNormalizerInterfaceAndDecisions(t *testing.T) {
+	sv, err := GenerateTransactionNormalizerSV(testConfig())
+	if err != nil {
+		t.Fatalf("GenerateTransactionNormalizerSV() error = %v", err)
+	}
+
+	requireHDLFragments(t, sv, map[string]string{
+		"module":              "module pcileech_tlp_normalizer",
+		"RCB parameter":       "parameter integer READ_COMPLETION_BOUNDARY = 64",
+		"MPS parameter":       "parameter integer MAX_PAYLOAD_BYTES = 128",
+		"supported decision":  "output reg request_supported",
+		"unsupported decision": "output reg unsupported_request",
+		"UR decision":         "output reg ur_required",
+		"non-posted decision": "output reg non_posted_request",
+		"malformed decision":  "output reg malformed_request",
+		"posted write":        "output reg posted_write",
+		"memory read":         "output reg memory_read",
+		"memory write":        "output reg memory_write",
+		"3DW and 4DW flag":    "output reg header_4dw",
+		"normalized address":  "output reg [63:0] address",
+		"normalized length":   "output reg [10:0] length_dw",
+		"first BE":            "output reg [3:0] first_be",
+		"last BE":             "output reg [3:0] last_be",
+		"requester ID":        "output reg [15:0] requester_id",
+		"tag":                 "output reg [7:0] tag",
+		"traffic class":       "output reg [2:0] traffic_class",
+		"attributes":          "output reg [2:0] attributes",
+		"BIR":                 "output reg [2:0] bir",
+		"enabled byte count":  "output reg [12:0] enabled_byte_count",
+		"completion byte count": "output reg [12:0] first_completion_byte_count",
+		"planned first CplD":  "output reg [10:0] first_completion_dw",
+		"lower address":       "output reg [6:0] first_lower_address",
+	})
+
+	if strings.Contains(sv, "{{") || strings.Contains(sv, "}}") {
+		t.Error("generated normalizer contains unrendered template delimiters")
+	}
+}
+
+func TestGenerateTransactionNormalizerHDLFormulaVectors(t *testing.T) {
+	sv, err := GenerateTransactionNormalizerSV(testConfig())
+	if err != nil {
+		t.Fatalf("GenerateTransactionNormalizerSV() error = %v", err)
+	}
+
+	requireHDLFragments(t, sv, map[string]string{
+		"wire length 0 means 1024 DW": "length_dw = (tlp_data[9:0] == 10'h000) ? 11'd1024 : {1'b0, tlp_data[9:0]}",
+		"3DW and 4DW decode":          "header_4dw = fmt[0]",
+		"3DW and 4DW MRd":             "8'b000_00000, 8'b001_00000",
+		"3DW and 4DW MWr":             "8'b010_00000, 8'b011_00000",
+		"3DW and 4DW MRdLk":           "8'b000_00001, 8'b001_00001: request_kind = KIND_MRDLK",
+		"I/O read classification":     "8'b000_00010: request_kind = KIND_IORD",
+		"I/O write classification":    "8'b010_00010: request_kind = KIND_IOWR",
+		"Atomic classification":       "8'b010_01100, 8'b011_01100",
+		"3DW address":                 "{32'h00000000, tlp_data[95:66], 2'b00}",
+		"4DW address":                 "{tlp_data[95:64], tlp_data[127:98], 2'b00}",
+		"first BE decode":             "first_be = tlp_data[35:32]",
+		"last BE decode":              "last_be = tlp_data[39:36]",
+		"requester preservation":      "requester_id = tlp_data[63:48]",
+		"tag preservation":            "tag = tlp_data[47:40]",
+		"TC preservation":             "traffic_class = tlp_data[22:20]",
+		"attribute preservation":      "attributes = {tlp_data[18], tlp_data[13:12]}",
+		"all 1DW first BE patterns":    "popcount4(first_be)",
+		"zero-length 1DW BE legality":  "if (length_dw == 11'd1) legal_be = (last_be == 4'h0)",
+		"QW-aligned 2DW BE exception":  "else if ((length_dw == 11'd2) && (address[2:0] == 3'b000)) legal_be = (first_be != 4'h0) && (last_be != 4'h0)",
+		"zero-length CplD byte count":  "((length_dw == 11'd1) && (first_be == 4'h0) && memory_read) ? 13'd4",
+		"actual zero-byte count":        "enabled_byte_count = (length_dw == 11'd1) ? popcount4(first_be)",
+		"completion byte count source":  "? 13'd4 : enabled_byte_count",
+		"legal multi-DW first BEs":     "(value == 4'h8) || (value == 4'hC) || (value == 4'hE) || (value == 4'hF)",
+		"legal multi-DW last BEs":      "(value == 4'h1) || (value == 4'h3) || (value == 4'h7) || (value == 4'hF)",
+		"multi-DW interior bytes":     "((length_dw - 11'd2) << 2)",
+		"first enabled byte":          "first_lower_address = address[6:0] + first_enabled_offset(first_be)",
+		"64 or 128 byte RCB split":    "rcb_bytes_left = READ_COMPLETION_BOUNDARY - (address & (READ_COMPLETION_BOUNDARY - 1))",
+		"MPS split":                   "mps_dw = MAX_PAYLOAD_BYTES / 4",
+		"RCB minimum":                 "if (first_completion_dw > rcb_dw_left) first_completion_dw = rcb_dw_left",
+		"MPS minimum":                 "if (first_completion_dw > mps_dw) first_completion_dw = mps_dw",
+		"posted MWr has no completion": "posted_write = memory_write && !malformed_request",
+		"unsupported needs UR":        "unsupported_request = 1'b1; ur_required = 1'b1",
+		"I/O Atomic non-posted":      "non_posted_request = (request_kind == KIND_IORD) || (request_kind == KIND_IOWR) || (request_kind == KIND_ATOMIC)",
+		"MRdLk non-posted":           "(request_kind == KIND_MRDLK)",
+		"malformed BE decision":       "malformed_request = !legal_bar || !legal_be || crosses_4k",
+	})
+}
+
+func TestGenerateURCompleterPreservesMetadataWithoutData(t *testing.T) {
+	sv, err := GenerateURCompleterSV(testConfig())
+	if err != nil {
+		t.Fatalf("GenerateURCompleterSV() error = %v", err)
+	}
+
+	requireHDLFragments(t, sv, map[string]string{
+		"module":                    "module pcileech_tlp_ur_completer",
+		"request valid":             "input request_valid",
+		"request ready":             "output request_ready",
+		"requester input":           "input [15:0] requester_id",
+		"tag input":                 "input [7:0] tag",
+		"TC input":                  "input [2:0] traffic_class",
+		"attributes input":          "input [2:0] attributes",
+		"full tag-space depth":      "parameter integer REQUEST_FIFO_DEPTH = 256",
+		"full and pop admission":    "request_can_accept = !request_fifo_full || request_pop",
+		"request handshake":         "request_push = request_valid && request_can_accept",
+		"no-data Cpl format":        "completion_data[31:29] = 3'b000",
+		"completion type":           "completion_data[28:24] = 5'b01010",
+		"TC preservation":           "completion_data[22:20] = tc_fifo[read_ptr]",
+		"attribute preservation":    "completion_data[18] = attr_fifo[read_ptr][2]",
+		"UR completion status":      "3'b001, 1'b0, 12'h000",
+		"requester tag preservation": "{requester_fifo[read_ptr], tag_fifo[read_ptr], 8'h00}",
+		"no-data Cpl width":         "assign tlps_out.tkeepdw = 4'b0111",
+		"queued stream availability": "assign tlps_out.has_data = (request_count != 0)",
+	})
+}
+
+func TestGenerateBarReadEngineUsesNormalizedVectors(t *testing.T) {
+	sv, err := GenerateBarReadEngineSV(testConfig())
+	if err != nil {
+		t.Fatalf("GenerateBarReadEngineSV() error = %v", err)
+	}
+
+	requireHDLFragments(t, sv, map[string]string{
+		"normalized address input":   "input [63:0] norm_address",
+		"normalized length input":    "input [10:0] norm_length_dw",
+		"first BE input":             "input [3:0] norm_first_be",
+		"last BE input":              "input [3:0] norm_last_be",
+		"requester input":            "input [15:0] norm_requester_id",
+		"tag input":                  "input [7:0] norm_tag",
+		"TC input":                   "input [2:0] norm_traffic_class",
+		"attributes input":           "input [2:0] norm_attributes",
+		"enabled bytes input":        "input [12:0] norm_enabled_byte_count",
+		"completion bytes input":       "input [12:0] norm_first_completion_byte_count",
+		"completion bytes FIFO":        "req_bc_fifo[req_wr_ptr] <= norm_first_completion_byte_count",
+		"first completion input":     "input [10:0] norm_first_completion_dw",
+		"full tag-space depth":       "localparam integer REQUEST_FIFO_DEPTH = 256",
+		"tag descriptor storage":     "reg [7:0] req_tag_fifo [0:REQUEST_FIFO_DEPTH-1]",
+		"full descriptor count":      "reg [8:0] req_count",
+		"full and pop admission":     "wire request_can_accept = !request_fifo_full || request_pop",
+		"lossless request push":      "wire request_push = tlps_in_valid && request_can_accept",
+		"simultaneous pop push hold": "case ({request_push, request_pop})",
+		"simultaneous count stable":  "default: req_count <= req_count",
+		"partial first decrement":    "value = value - (13'd4 - popcount4(first_enable))",
+		"partial last decrement":     "value = value - (13'd4 - popcount4(last_enable))",
+		"remaining byte count update": "remaining_byte_count <= remaining_byte_count - completed_enabled_bytes(",
+		"next RCB/MPS split":         "packet_length_dw <= next_completion_dw(",
+		"requester context":          "request_id",
+		"tag context":                "request_tag",
+		"TC completion header":       "tdata[22:20] <= rd_rsp_tc",
+		"attribute completion header": "tdata[18] <= rd_rsp_attr[2]",
+		"byte count completion header": "rd_rsp_byte_count",
+		"lower address header":       "rd_rsp_lower_addr",
+		"tuser BAR bits driven":      "assign tlps_out.tuser[8:2] = 7'h00",
+		"tuser last bit driven":      "assign tlps_out.tuser[1] = tlps_out.tlast",
+		"stream has data contract":   "assign tlps_out.has_data = tlps_out.tvalid",
+	})
+
+	for _, legacy := range []string{
+		"IfAXIS128.sink_lite tlps_in",
+		"tlps_in.tdata",
+		"tlps_in.tuser",
+		"tlps_in.tlast",
+	} {
+		if strings.Contains(compactHDL(sv), compactHDL(legacy)) {
+			t.Errorf("generated read engine still consumes legacy raw request expression %q", legacy)
+		}
+	}
+}
+
+func TestGenerateTransactionLimitsAreSharedAcrossRTL(t *testing.T) {
+	cfg := testConfig()
+	cfg.ReadCompletionBoundaryBytes = 128
+	cfg.MaxPayloadBytes = 256
+
+	normalizer, err := GenerateTransactionNormalizerSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateTransactionNormalizerSV() error = %v", err)
+	}
+	readEngine, err := GenerateBarReadEngineSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarReadEngineSV() error = %v", err)
+	}
+	controller, err := GenerateBarControllerSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarControllerSV() error = %v", err)
+	}
+
+	for name, source := range map[string]string{
+		"normalizer": normalizer,
+		"read_engine": readEngine,
+	} {
+		compact := compactHDL(source)
+		if !strings.Contains(compact, "parameterintegerREAD_COMPLETION_BOUNDARY=128") {
+			t.Errorf("%s RCB parameter does not resolve to 128 bytes", name)
+		}
+		if !strings.Contains(compact, "parameterintegerMAX_PAYLOAD_BYTES=256") {
+			t.Errorf("%s MPS parameter does not resolve to 256 bytes", name)
+		}
+	}
+
+	compactController := compactHDL(controller)
+	if got := strings.Count(compactController, ".READ_COMPLETION_BOUNDARY(128)"); got != 2 {
+		t.Errorf("controller RCB override count = %d, want 2", got)
+	}
+	if got := strings.Count(compactController, ".MAX_PAYLOAD_BYTES(256)"); got != 2 {
+		t.Errorf("controller MPS override count = %d, want 2", got)
+	}
+}
+
+func TestGeneratedBarControllerIntegratesTransactionNormalizer(t *testing.T) {
+	sv, err := GenerateBarControllerSV(testConfig())
+	if err != nil {
+		t.Fatalf("GenerateBarControllerSV() error = %v", err)
+	}
+
+	requireHDLFragments(t, sv, map[string]string{
+		"normalizer instance":       ") i_tlp_normalizer(",
+		"UR stream":                 "IfAXIS128 tlps_ur()",
+		"UR completer instance":     "pcileech_tlp_ur_completer i_tlp_ur_completer",
+		"UR non-posted gate":        "norm_request_present && norm_ur_required && norm_non_posted_request",
+		"UR requester connection":   ".requester_id ( norm_requester_id )",
+		"UR tag connection":         ".tag ( norm_tag )",
+		"UR TC connection":          ".traffic_class ( norm_traffic_class )",
+		"UR attribute connection":   ".attributes ( norm_attributes )",
+		"UR output stream":          ".tlps_out ( tlps_ur.source )",
+		"UR completion mux":         "cpl_select_ur ? tlps_ur.tdata : tlps_rdeng.tdata",
+		"normalized read gate":      "norm_memory_read && norm_request_supported",
+		"posted write first beat":    "in_is_first && in_is_wr_ready && norm_posted_write",
+		"posted write continuation":  "norm_request_supported || in_is_wr_last",
+		"zero-byte write suppression": "norm_enabled_byte_count != 13'd0",
+		"read address connection":   ".norm_address ( norm_address )",
+		"read length connection":    ".norm_length_dw ( norm_length_dw )",
+		"first BE connection":       ".norm_first_be ( norm_first_be )",
+		"last BE connection":        ".norm_last_be ( norm_last_be )",
+		"requester connection":      ".norm_requester_id ( norm_requester_id )",
+		"tag connection":            ".norm_tag ( norm_tag )",
+		"TC connection":             ".norm_traffic_class ( norm_traffic_class )",
+		"attribute connection":      ".norm_attributes ( norm_attributes )",
+		"enabled bytes connection":  ".norm_enabled_byte_count ( norm_enabled_byte_count )",
+		"completion bytes connection": ".norm_first_completion_byte_count ( norm_first_completion_byte_count )",
+		"completion plan connection": ".norm_first_completion_dw ( norm_first_completion_dw )",
+	})
+
+	for _, legacy := range []string{
+		"tlps_in.tdata[31:25] == 7'b0000000",
+		"tlps_in.tdata[31:25] == 7'b0010000",
+		"tlps_in.tdata[31:24] == 8'b00000010",
+	} {
+		if strings.Contains(compactHDL(sv), compactHDL(legacy)) {
+			t.Errorf("generated controller still uses legacy hardcoded transaction formula %q", legacy)
+		}
+	}
+}

--- a/internal/firmware/svgen/transaction_verilator_test.go
+++ b/internal/firmware/svgen/transaction_verilator_test.go
@@ -1,0 +1,522 @@
+package svgen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const axis128Header = "`ifndef _pcileech_header_svh_\n`define _pcileech_header_svh_\ninterface IfAXIS128;\nwire [127:0] tdata;\nwire [3:0] tkeepdw;\nwire tvalid;\nwire tlast;\nwire [8:0] tuser;\nwire tready;\nwire has_data;\nmodport source(input tready, output tdata, tkeepdw, tvalid, tlast, tuser, has_data);\nmodport sink(output tready, input tdata, tkeepdw, tvalid, tlast, tuser, has_data);\nmodport source_lite(output tdata, tkeepdw, tvalid, tlast, tuser);\nmodport sink_lite(input tdata, tkeepdw, tvalid, tlast, tuser);\nendinterface\n`endif\n"
+
+func runVerilatorBinary(t *testing.T, dut, bench string) {
+	t.Helper()
+	verilator, err := exec.LookPath("verilator")
+	if err != nil {
+		t.Skip("verilator not installed")
+	}
+	dir := t.TempDir()
+	for name, content := range map[string]string{
+		"pcileech_header.svh": axis128Header,
+		"dut.sv":              dut,
+		"tb.sv":               bench,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cmd := exec.Command(verilator, "--binary", "--timing", "-Wno-fatal", "--top-module", "tb", "--Mdir", "obj", "-I"+dir, "dut.sv", "tb.sv")
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("verilator build failed: %v\n%s", err, output)
+	}
+	binary := filepath.Join(dir, "obj", "Vtb")
+	if output, err := exec.Command(binary).CombinedOutput(); err != nil {
+		t.Fatalf("verilator simulation failed: %v\n%s", err, output)
+	}
+}
+
+func TestVerilatorURCompletionStableWhileStalled(t *testing.T) {
+	dut, err := GenerateURCompleterSV(testConfig())
+	if err != nil {
+		t.Fatalf("GenerateURCompleterSV() error = %v", err)
+	}
+	bench := "`timescale 1ns/1ps\n`include \"pcileech_header.svh\"\nmodule tb;\nbit clk = 0;\nalways #5 clk = ~clk;\nbit rst = 1;\nbit ready = 0;\nbit request_valid = 0;\nwire request_ready;\nIfAXIS128 out();\nassign out.tready = ready;\npcileech_tlp_ur_completer dut(.rst(rst), .clk(clk), .pcie_id(16'h1234), .request_valid(request_valid), .request_ready(request_ready), .requester_id(16'hA15E), .tag(8'hD3), .traffic_class(3'h5), .attributes(3'h3), .tlps_out(out.source));\nreg [142:0] held;\ninitial begin\nrepeat (2) @(posedge clk);\n@(negedge clk); rst = 0; request_valid = 1;\n@(posedge clk);\n@(negedge clk); request_valid = 0;\nwait (out.tvalid);\nheld = {out.has_data, out.tuser, out.tlast, out.tkeepdw, out.tdata};\nif (out.tdata[31:29] !== 3'b000) $fatal(1, \"fmt\");\nif (out.tdata[28:24] !== 5'b01010) $fatal(1, \"type\");\nif (out.tdata[22:20] !== 3'h5) $fatal(1, \"tc\");\nif ({out.tdata[18], out.tdata[13:12]} !== 3'h3) $fatal(1, \"attr\");\nif (out.tdata[47:45] !== 3'b001) $fatal(1, \"status\");\nif (out.tdata[95:80] !== 16'hA15E) $fatal(1, \"requester\");\nif (out.tdata[79:72] !== 8'hD3) $fatal(1, \"tag\");\nif (out.tdata[9:0] !== 10'h000) $fatal(1, \"length\");\nif (out.tkeepdw !== 4'b0111) $fatal(1, \"keep\");\nrepeat (4) begin\n@(posedge clk);\n#1;\nif ({out.has_data, out.tuser, out.tlast, out.tkeepdw, out.tdata} !== held) $fatal(1, \"stability\");\nend\n@(negedge clk); ready = 1;\n@(posedge clk);\n@(negedge clk);\nif (out.tvalid !== 1'b0) $fatal(1, \"drain\");\n$finish;\nend\nendmodule\n"
+	runVerilatorBinary(t, dut, bench)
+}
+
+func TestVerilatorCompletionArbiterLocksStalledPacket(t *testing.T) {
+	controller, err := GenerateBarControllerSV(testConfig())
+	if err != nil {
+		t.Fatalf("GenerateBarControllerSV() error = %v", err)
+	}
+	block := extractHDLBlock(t, controller, "    reg cpl_grant_active;", "    wire        wrengine_ready;")
+	dut := "`timescale 1ns/1ps\n`include \"pcileech_header.svh\"\nmodule cpl_arb(input clk, input rst, IfAXIS128.sink tlps_ur, IfAXIS128.sink tlps_rdeng, IfAXIS128.source tlps_cpl);\n" + block + "endmodule\n"
+	bench := `
+module tb;
+timeunit 1ns;
+timeprecision 1ps;
+bit clk = 0;
+always #5 clk = ~clk;
+bit rst = 1;
+bit ready = 0;
+bit ur_valid = 0;
+bit ur_last = 1;
+bit [127:0] ur_data = 128'hA1;
+bit rd_valid = 0;
+bit rd_last = 0;
+bit [127:0] rd_data = 128'hB1;
+IfAXIS128 ur();
+IfAXIS128 rd();
+IfAXIS128 cpl();
+assign ur.tdata = ur_data;
+assign ur.tkeepdw = 4'h7;
+assign ur.tvalid = ur_valid;
+assign ur.tlast = ur_last;
+assign ur.tuser = 9'h003;
+assign ur.has_data = ur_valid;
+assign rd.tdata = rd_data;
+assign rd.tkeepdw = 4'hF;
+assign rd.tvalid = rd_valid;
+assign rd.tlast = rd_last;
+assign rd.tuser = {7'h00, rd_last, 1'b1};
+assign rd.has_data = rd_valid;
+assign cpl.tready = ready;
+cpl_arb dut(.clk(clk), .rst(rst), .tlps_ur(ur.sink), .tlps_rdeng(rd.sink), .tlps_cpl(cpl.source));
+reg [142:0] held;
+initial begin
+repeat (2) @(posedge clk);
+@(negedge clk); rst = 0; ur_valid = 1; rd_valid = 1;
+@(posedge clk);
+@(negedge clk);
+if (!dut.cpl_grant_active || dut.cpl_grant_ur) $fatal(1, "grant");
+if (cpl.tdata !== 128'hB1) $fatal(1, "read_select");
+held = {cpl.has_data, cpl.tuser, cpl.tlast, cpl.tkeepdw, cpl.tdata};
+ur_data = 128'hA2;
+repeat (3) begin
+@(posedge clk);
+#1;
+if ({cpl.has_data, cpl.tuser, cpl.tlast, cpl.tkeepdw, cpl.tdata} !== held) $fatal(1, "first_stall");
+end
+@(negedge clk); ready = 1;
+@(posedge clk);
+@(negedge clk); ready = 0; rd_data = 128'hB2; rd_last = 1;
+#1;
+held = {cpl.has_data, cpl.tuser, cpl.tlast, cpl.tkeepdw, cpl.tdata};
+ur_data = 128'hA3;
+repeat (3) begin
+@(posedge clk);
+#1;
+if ({cpl.has_data, cpl.tuser, cpl.tlast, cpl.tkeepdw, cpl.tdata} !== held) $fatal(1, "last_stall");
+end
+@(negedge clk); ready = 1;
+@(posedge clk);
+@(negedge clk); rd_valid = 0;
+#1;
+if (dut.cpl_grant_active) $fatal(1, "release");
+if (!cpl.tvalid || cpl.tdata !== 128'hA3) $fatal(1, "ur_after_read");
+$finish;
+end
+endmodule
+`
+	runVerilatorBinary(t, dut, bench)
+}
+
+func TestVerilatorCompletionArbiterServicesQueuedURUnderContinuousReads(t *testing.T) {
+	controller, err := GenerateBarControllerSV(testConfig())
+	if err != nil {
+		t.Fatalf("GenerateBarControllerSV() error = %v", err)
+	}
+	block := extractHDLBlock(t, controller, "    reg cpl_grant_active;", "    wire        wrengine_ready;")
+	dut := "`timescale 1ns/1ps\n`include \"pcileech_header.svh\"\nmodule cpl_arb(input clk, input rst, IfAXIS128.sink tlps_ur, IfAXIS128.sink tlps_rdeng, IfAXIS128.source tlps_cpl);\n" + block + "endmodule\n"
+	bench := `
+module tb;
+timeunit 1ns;
+timeprecision 1ps;
+bit clk = 0;
+always #5 clk = ~clk;
+bit rst = 1;
+bit ready = 0;
+bit [15:0] lfsr = 16'hACE1;
+bit ur_valid = 0;
+bit ur_queued = 0;
+bit ur_seen = 0;
+integer rd_beat = 0;
+integer rd_packet = 0;
+integer rd_boundaries_after_ur = 0;
+bit monitor_active = 0;
+bit monitor_ur = 0;
+bit stalled = 0;
+reg [142:0] stalled_value;
+IfAXIS128 ur();
+IfAXIS128 rd();
+IfAXIS128 out();
+wire [127:0] rd_data = {8'hB0, rd_packet[7:0], rd_beat[7:0], 104'h0};
+wire rd_last = (rd_beat == 2);
+assign ur.tdata = 128'hA50000000000000000000000000000D3;
+assign ur.tkeepdw = 4'h7;
+assign ur.tvalid = ur_valid;
+assign ur.tlast = 1'b1;
+assign ur.tuser = 9'h003;
+assign ur.has_data = ur_valid;
+assign rd.tdata = rd_data;
+assign rd.tkeepdw = 4'hF;
+assign rd.tvalid = !rst;
+assign rd.tlast = rd_last;
+assign rd.tuser = {7'h00, rd_last, 1'b1};
+assign rd.has_data = !rst;
+assign out.tready = ready;
+cpl_arb dut(.clk(clk), .rst(rst), .tlps_ur(ur.sink), .tlps_rdeng(rd.sink), .tlps_cpl(out.source));
+always @(negedge clk) begin
+if (rst) begin
+lfsr = 16'hACE1;
+ready = 0;
+end else begin
+lfsr = {lfsr[14:0], lfsr[15] ^ lfsr[13] ^ lfsr[12] ^ lfsr[10]};
+ready = lfsr[0] | lfsr[3];
+end
+end
+always @(posedge clk) begin
+if (rst) begin
+rd_beat <= 0;
+rd_packet <= 0;
+ur_valid <= 0;
+ur_queued <= 0;
+end else begin
+if (rd.tvalid && rd.tready) begin
+if (!ur_queued) begin
+ur_valid <= 1;
+ur_queued <= 1;
+end
+if (rd_last) begin
+rd_beat <= 0;
+rd_packet <= rd_packet + 1;
+end else begin
+rd_beat <= rd_beat + 1;
+end
+end
+if (ur_valid && ur.tready) begin
+ur_valid <= 0;
+ur_seen <= 1;
+end
+end
+end
+always @(posedge clk) begin
+bit source_ur;
+if (!rst && out.tvalid && out.tready) begin
+source_ur = (out.tdata[127:120] == 8'hA5);
+if (monitor_active && source_ur != monitor_ur) $fatal(1, "interleave");
+if (!monitor_active) monitor_ur <= source_ur;
+monitor_active <= !out.tlast;
+if (ur_queued && !ur_seen && !source_ur && out.tlast) begin
+if (rd_boundaries_after_ur >= 1) $fatal(1, "starvation");
+rd_boundaries_after_ur <= rd_boundaries_after_ur + 1;
+end
+end
+if (!rst && stalled) begin
+if ({out.has_data, out.tuser, out.tlast, out.tkeepdw, out.tdata} !== stalled_value) $fatal(1, "stall_stability");
+if (out.tvalid && out.tready) stalled <= 0;
+end else if (!rst && out.tvalid && !out.tready) begin
+stalled <= 1;
+stalled_value <= {out.has_data, out.tuser, out.tlast, out.tkeepdw, out.tdata};
+end
+if (ur_seen) begin
+if (rd_boundaries_after_ur > 1) $fatal(1, "bound");
+$finish;
+end
+end
+initial begin
+repeat (2) @(posedge clk);
+@(negedge clk); rst = 0;
+repeat (1000) @(posedge clk);
+$fatal(1, "timeout");
+end
+endmodule
+`
+	runVerilatorBinary(t, dut, bench)
+}
+
+func TestVerilatorHDAArbiterLocksPacketsUnderBackpressure(t *testing.T) {
+	controller, err := GenerateBarControllerSV(audioConfig())
+	if err != nil {
+		t.Fatalf("GenerateBarControllerSV() error = %v", err)
+	}
+	block := extractHDLThroughAlways(t, controller, "    reg hda_packet_active;", "    always @(posedge clk) begin")
+	dut := "`timescale 1ns/1ps\n`include \"pcileech_header.svh\"\nmodule hda_arb(input clk, input rst, input [127:0] hda_tlp_tx_tdata, input [3:0] hda_tlp_tx_tkeepdw, input hda_tlp_tx_tvalid, input hda_tlp_tx_tlast, input [8:0] hda_tlp_tx_tuser, output hda_tlp_tx_tready, IfAXIS128.sink tlps_cpl, IfAXIS128.source tlps_out);\n" + block + "endmodule\n"
+	bench := `
+module tb;
+timeunit 1ns;
+timeprecision 1ps;
+bit clk = 0;
+always #5 clk = ~clk;
+bit rst = 1;
+bit ready = 0;
+bit dma_valid = 0;
+bit dma_last = 0;
+bit [127:0] dma_data = 128'hD1;
+bit cpl_valid = 0;
+bit cpl_last = 0;
+bit [127:0] cpl_data = 128'hC1;
+wire dma_ready;
+IfAXIS128 cpl();
+IfAXIS128 out();
+assign cpl.tdata = cpl_data;
+assign cpl.tkeepdw = 4'hF;
+assign cpl.tvalid = cpl_valid;
+assign cpl.tlast = cpl_last;
+assign cpl.tuser = {7'h00, cpl_last, 1'b1};
+assign cpl.has_data = cpl_valid;
+assign out.tready = ready;
+hda_arb dut(.clk(clk), .rst(rst), .hda_tlp_tx_tdata(dma_data), .hda_tlp_tx_tkeepdw(4'hF), .hda_tlp_tx_tvalid(dma_valid), .hda_tlp_tx_tlast(dma_last), .hda_tlp_tx_tuser({7'h00, dma_last, 1'b1}), .hda_tlp_tx_tready(dma_ready), .tlps_cpl(cpl.sink), .tlps_out(out.source));
+reg [142:0] held;
+initial begin
+repeat (2) @(posedge clk);
+@(negedge clk); rst = 0; dma_valid = 1; cpl_valid = 1;
+@(posedge clk);
+@(negedge clk);
+if (!dut.hda_packet_active || !dut.hda_packet_select_dma) $fatal(1, "dma_grant");
+if (out.tdata !== 128'hD1 || dma_ready || cpl.tready) $fatal(1, "dma_stall");
+held = {out.has_data, out.tuser, out.tlast, out.tkeepdw, out.tdata};
+cpl_data = 128'hC9;
+repeat (2) begin
+@(posedge clk);
+#1;
+if ({out.has_data, out.tuser, out.tlast, out.tkeepdw, out.tdata} !== held) $fatal(1, "dma_stability");
+end
+@(negedge clk); ready = 1;
+@(posedge clk);
+@(negedge clk); ready = 0; dma_data = 128'hD2; dma_last = 1;
+#1;
+if (out.tdata !== 128'hD2 || dma_ready || cpl.tready) $fatal(1, "dma_last_stall");
+@(negedge clk); ready = 1;
+@(posedge clk);
+@(negedge clk); ready = 0; dma_data = 128'hD3; dma_last = 1; cpl_data = 128'hC1; cpl_last = 0;
+@(posedge clk);
+@(negedge clk);
+if (!dut.hda_packet_active || dut.hda_packet_select_dma) $fatal(1, "cpl_grant");
+if (out.tdata !== 128'hC1 || dma_ready || cpl.tready) $fatal(1, "cpl_stall");
+held = {out.has_data, out.tuser, out.tlast, out.tkeepdw, out.tdata};
+dma_data = 128'hD9;
+repeat (2) begin
+@(posedge clk);
+#1;
+if ({out.has_data, out.tuser, out.tlast, out.tkeepdw, out.tdata} !== held) $fatal(1, "cpl_stability");
+end
+@(negedge clk); ready = 1;
+@(posedge clk);
+@(negedge clk); ready = 0; cpl_data = 128'hC2; cpl_last = 1;
+#1;
+if (out.tdata !== 128'hC2 || dma_ready || cpl.tready) $fatal(1, "cpl_last_stall");
+@(negedge clk); ready = 1;
+@(posedge clk);
+@(negedge clk); cpl_valid = 0; ready = 0;
+#1;
+if (dut.hda_packet_active) $fatal(1, "release");
+if (!out.tvalid || out.tdata !== 128'hD9) $fatal(1, "dma_after_cpl");
+$finish;
+end
+endmodule
+`
+	runVerilatorBinary(t, dut, bench)
+}
+
+func TestVerilatorReadEngineDrivesCompleteStreamContract(t *testing.T) {
+	engine, err := GenerateBarReadEngineSV(testConfig())
+	if err != nil {
+		t.Fatalf("GenerateBarReadEngineSV() error = %v", err)
+	}
+	stub := `
+module fifo_134_134_clk1_bar_rdrsp(input srst, input clk, input [133:0] din, input wr_en, input rd_en, output [133:0] dout, output full, output empty, output prog_empty, output valid);
+reg [133:0] value;
+reg occupied;
+assign dout = value;
+assign full = 1'b0;
+assign empty = !occupied;
+assign prog_empty = 1'b1;
+assign valid = occupied;
+always @(posedge clk) begin
+if (srst) begin
+value <= 134'h0;
+occupied <= 1'b0;
+end else if (wr_en) begin
+value <= din;
+occupied <= 1'b1;
+end else if (rd_en) begin
+occupied <= 1'b0;
+end
+end
+endmodule
+`
+	bench := `
+module tb;
+timeunit 1ns;
+timeprecision 1ps;
+bit clk = 0;
+always #5 clk = ~clk;
+bit rst = 1;
+bit ready = 0;
+bit rsp_valid = 0;
+bit [87:0] rsp_ctx;
+IfAXIS128 out();
+assign out.tready = ready;
+wire [87:0] req_ctx;
+wire [6:0] req_bar;
+wire [31:0] req_addr;
+wire req_valid;
+pcileech_tlps128_bar_rdengine dut(.rst(rst), .clk(clk), .pcie_id(16'h1234), .tlps_out(out.source), .tlps_in_valid(1'b0), .norm_address(64'h0), .norm_length_dw(11'd1), .norm_first_be(4'hF), .norm_last_be(4'h0), .norm_requester_id(16'h0), .norm_tag(8'h0), .norm_traffic_class(3'h0), .norm_attributes(3'h0), .norm_header_4dw(1'b0), .norm_bar_mask(7'h1), .norm_enabled_byte_count(13'd4), .norm_first_completion_byte_count(13'd4), .norm_first_completion_dw(11'd1), .rd_req_ctx(req_ctx), .rd_req_bar(req_bar), .rd_req_addr(req_addr), .rd_req_valid(req_valid), .rd_rsp_ctx(rsp_ctx), .rd_rsp_data(32'hDEADBEEF), .rd_rsp_valid(rsp_valid));
+reg [142:0] held;
+initial begin
+rsp_ctx = {1'b1, 1'b1, 11'd1, 12'd4, 3'h5, 3'h3, 1'b0, 8'hD3, 16'hA15E, 32'h00000040};
+repeat (2) @(posedge clk);
+@(negedge clk); rst = 0; rsp_valid = 1;
+@(posedge clk);
+@(negedge clk); rsp_valid = 0;
+wait (out.tvalid);
+#1;
+if (out.tuser !== 9'b000000011) $fatal(1, "tuser");
+if (out.has_data !== out.tvalid) $fatal(1, "has_data");
+held = {out.has_data, out.tuser, out.tlast, out.tkeepdw, out.tdata};
+repeat (3) begin
+@(posedge clk);
+#1;
+if ({out.has_data, out.tuser, out.tlast, out.tkeepdw, out.tdata} !== held) $fatal(1, "stall");
+end
+@(negedge clk); ready = 1;
+@(posedge clk);
+@(negedge clk);
+if (out.tvalid) $fatal(1, "drain");
+$finish;
+end
+endmodule
+`
+	runVerilatorBinary(t, engine+stub, bench)
+}
+
+func TestVerilatorLockedReadsEmitURFor3DWAnd4DW(t *testing.T) {
+	normalizer, err := GenerateTransactionNormalizerSV(testConfig())
+	if err != nil {
+		t.Fatalf("GenerateTransactionNormalizerSV() error = %v", err)
+	}
+	completer, err := GenerateURCompleterSV(testConfig())
+	if err != nil {
+		t.Fatalf("GenerateURCompleterSV() error = %v", err)
+	}
+	bench := `
+module tb;
+timeunit 1ns;
+timeprecision 1ps;
+bit clk = 0;
+always #5 clk = ~clk;
+bit rst = 1;
+bit ready = 0;
+bit [127:0] tlp_data;
+bit [8:0] tlp_user = 0;
+wire request_present;
+wire ur_required;
+wire non_posted_request;
+wire posted_write;
+wire [15:0] requester_id;
+wire [7:0] tag;
+wire [2:0] traffic_class;
+wire [2:0] attributes;
+wire request_ready;
+IfAXIS128 out();
+assign out.tready = ready;
+pcileech_tlp_normalizer norm(.tlp_data(tlp_data), .tlp_user(tlp_user), .tlp_last(1'b1), .request_present(request_present), .ur_required(ur_required), .non_posted_request(non_posted_request), .posted_write(posted_write), .requester_id(requester_id), .tag(tag), .traffic_class(traffic_class), .attributes(attributes));
+pcileech_tlp_ur_completer ur(.rst(rst), .clk(clk), .pcie_id(16'h1234), .request_valid(request_present && ur_required && non_posted_request), .request_ready(request_ready), .requester_id(requester_id), .tag(tag), .traffic_class(traffic_class), .attributes(attributes), .tlps_out(out.source));
+task automatic send_locked(input [2:0] fmt);
+begin
+@(negedge clk);
+tlp_data = 128'h0;
+tlp_data[31:29] = fmt;
+tlp_data[28:24] = 5'b00001;
+tlp_data[22:20] = 3'h5;
+tlp_data[18] = 1'b0;
+tlp_data[13:12] = 2'b11;
+tlp_data[9:0] = 10'd1;
+tlp_data[35:32] = 4'hF;
+tlp_data[39:36] = 4'h0;
+tlp_data[63:48] = 16'hA15E;
+tlp_data[47:40] = 8'hD3;
+tlp_user = 9'b000000101;
+#1;
+if (!ur_required || !non_posted_request || posted_write) $fatal(1, "classification");
+@(posedge clk);
+@(negedge clk);
+tlp_user = 0;
+wait (out.tvalid);
+#1;
+if (out.tdata[47:45] !== 3'b001) $fatal(1, "status");
+if (out.tdata[95:80] !== 16'hA15E || out.tdata[79:72] !== 8'hD3) $fatal(1, "identity");
+if (out.tdata[22:20] !== 3'h5 || {out.tdata[18], out.tdata[13:12]} !== 3'h3) $fatal(1, "metadata");
+@(negedge clk);
+ready = 1;
+@(posedge clk);
+@(negedge clk);
+ready = 0;
+end
+endtask
+initial begin
+tlp_data = 0;
+repeat (2) @(posedge clk);
+@(negedge clk); rst = 0;
+send_locked(3'b000);
+send_locked(3'b001);
+$finish;
+end
+endmodule
+`
+	runVerilatorBinary(t, normalizer+completer, bench)
+}
+
+func extractHDLThroughAlways(t *testing.T, source, start, always string) string {
+	t.Helper()
+	startIndex := strings.Index(source, start)
+	if startIndex < 0 {
+		t.Fatalf("start marker missing: %s", start)
+	}
+	alwaysIndex := strings.Index(source[startIndex:], always)
+	if alwaysIndex < 0 {
+		t.Fatalf("always marker missing: %s", always)
+	}
+	cursor := startIndex + alwaysIndex
+	depth := 0
+	seen := false
+	for cursor < len(source) {
+		lineEnd := strings.IndexByte(source[cursor:], '\n')
+		if lineEnd < 0 {
+			lineEnd = len(source) - cursor
+		}
+		lineEnd += cursor
+		for _, token := range strings.Fields(source[cursor:lineEnd]) {
+			token = strings.Trim(token, "()@:;")
+			if token == "begin" {
+				depth++
+				seen = true
+			}
+			if token == "end" {
+				depth--
+			}
+		}
+		if seen && depth == 0 {
+			return source[startIndex : lineEnd+1]
+		}
+		cursor = lineEnd + 1
+	}
+	t.Fatalf("balanced always block missing after: %s", always)
+	return ""
+}
+
+func extractHDLBlock(t *testing.T, source, start, end string) string {
+	t.Helper()
+	startIndex := strings.Index(source, start)
+	if startIndex < 0 {
+		t.Fatalf("start marker missing: %s", start)
+	}
+	endIndex := strings.Index(source[startIndex:], end)
+	if endIndex < 0 {
+		t.Fatalf("end marker missing: %s\n%.1200s", end, source[startIndex:])
+	}
+	return source[startIndex : startIndex+endIndex]
+}


### PR DESCRIPTION
## Summary

Adds a board-independent normalized PCIe request/completion layer and replaces ad-hoc raw-header handling in the generated BAR controller.

- decodes 3DW/4DW MRd/MWr with 64-bit addresses, raw First/Last BE, requester ID, tag, TC, attributes, and validation decisions
- implements byte-enable-aware software planning and completion metadata
- generates a normalized request module, completion read engine, and no-data UR completer
- emits UR for unsupported non-posted I/O, Configuration, Atomic, MRdLk, and unmapped requests while never responding to posted writes
- preserves requester/tag/TC/attribute context in completions
- uses a lossless 256-entry request queue with full+pop admission
- splits completions conservatively at 64-byte RCB and 128-byte MPS boundaries by default
- packet-locks and fairly arbitrates read, UR, and HDA transmit sources under backpressure

## Correctness details

- output payload and sidebands remain stable while `valid && !ready`
- UR/read arbitration is packet-level round-robin, so continuous reads cannot starve an error completion
- HDA traffic cannot be interleaved mid-packet by a completion
- generated read sidebands drive all `tuser`, `tlast`, and `has_data` fields
- malformed and unsupported requests cannot mutate BAR state
- Completion Byte Count and Lower Address are derived byte-accurately from request BE/length

## Verification

- `go test -race -count=1 ./...` under Ubuntu WSL2
- executable Verilator simulations for stalled UR stability, UR/read packet lock and fairness, HDA packet arbitration, read-engine sidebands, MRdLk UR dispatch, and randomized backpressure
- software planner coverage for 3DW/4DW requests, 225 nonzero two-DWORD BE combinations, 4 KiB boundaries, malformed requests, and conservative RCB/MPS splitting
- independent protocol review and final closure review
- zero comments added to production or test code

## Research references

Design and review were checked against cocotbext-pcie TLP packing/validation, LitePCIe streaming/backpressure patterns, Linux MMIO ordering guidance, and public AMD/Xilinx endpoint interface behavior. Member-only PCI-SIG requirements are not guessed; unsupported policy remains conservative.