### PR TITLE
feat: add lifecycle DMA tag and interrupt services

### DIFF
--- a/internal/firmware/output/writer.go
+++ b/internal/firmware/output/writer.go
@@ -233,8 +233,12 @@ func (ow *OutputWriter) patchSVSources(b *board.Board, ids firmware.DeviceIDs) e
 	// generated version, so we exclude the original file and split it.
 	if !ow.StockBar {
 		ctrlSrc := filepath.Join(srcDir, "pcileech_tlps128_bar_controller.sv")
-		if err := extractSubModules(ctrlSrc, dstDir, barControllerSubModules); err != nil {
-			slog.Warn("could not extract BAR controller sub-modules, board source may be incompatible", "error", err)
+		if _, err := os.Stat(ctrlSrc); err == nil {
+			if err := extractSubModules(ctrlSrc, dstDir, barControllerSubModules); err != nil {
+				return fmt.Errorf("failed to extract BAR controller sub-modules: %w", err)
+			}
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to inspect BAR controller: %w", err)
 		}
 	} else {
 		slog.Info("stock-bar mode: keeping stock bar controller")
@@ -344,6 +348,9 @@ func ListOutputFiles() []string {
 		"vivado_generate_project.tcl",
 		"vivado_build.tcl",
 		"src/",
+		"pcileech_lifecycle_service.sv",
+		"pcileech_dma_tag_service.sv",
+		"pcileech_interrupt_service.sv",
 		"pcileech_bar_impl_device.sv",
 		"pcileech_tlps128_bar_controller.sv",
 		"pcileech_bar_impl_msi.sv",
@@ -368,6 +375,9 @@ type svArtifact struct {
 
 // coreSVArtifacts are always generated.
 var coreSVArtifacts = []svArtifact{
+	{"pcileech_lifecycle_service.sv", svgen.GenerateLifecycleServiceSV},
+	{"pcileech_dma_tag_service.sv", svgen.GenerateDMATagServiceSV},
+	{"pcileech_interrupt_service.sv", svgen.GenerateInterruptServiceSV},
 	{"pcileech_bar_impl_device.sv", svgen.GenerateBarImplDeviceSV},
 	{"pcileech_tlps128_bar_controller.sv", svgen.GenerateBarControllerSV},
 	{"pcileech_bar_impl_msi.sv", svgen.GenerateBarImplMSISV},

--- a/internal/firmware/services/interrupts.go
+++ b/internal/firmware/services/interrupts.go
@@ -1,0 +1,106 @@
+package services
+
+type Delivery struct {
+	Valid  bool
+	Vector int
+}
+
+type InterruptController struct {
+	enabled      bool
+	functionMask bool
+	vectorMask   []bool
+	pending      []bool
+}
+
+func NewInterruptController(vectors int) *InterruptController {
+	if vectors < 0 {
+		vectors = 0
+	}
+	return &InterruptController{
+		vectorMask: make([]bool, vectors),
+		pending:    make([]bool, vectors),
+	}
+}
+
+func (c *InterruptController) Request(vector int) Delivery {
+	if !c.valid(vector) {
+		return Delivery{}
+	}
+	if c.deliverable(vector) {
+		return Delivery{Valid: true, Vector: vector}
+	}
+	c.pending[vector] = true
+	return Delivery{}
+}
+
+func (c *InterruptController) SetEnabled(enabled bool) []Delivery {
+	if c == nil {
+		return nil
+	}
+	c.enabled = enabled
+	return c.drainOne()
+}
+
+func (c *InterruptController) SetFunctionMask(masked bool) []Delivery {
+	if c == nil {
+		return nil
+	}
+	c.functionMask = masked
+	return c.drainOne()
+}
+
+func (c *InterruptController) SetVectorMask(vector int, masked bool) []Delivery {
+	if !c.valid(vector) {
+		return nil
+	}
+	c.vectorMask[vector] = masked
+	if !masked && c.pending[vector] && c.deliverable(vector) {
+		c.pending[vector] = false
+		return []Delivery{{Valid: true, Vector: vector}}
+	}
+	return nil
+}
+
+func (c *InterruptController) Drain() Delivery {
+	if deliveries := c.drainOne(); len(deliveries) != 0 {
+		return deliveries[0]
+	}
+	return Delivery{}
+}
+
+func (c *InterruptController) Pending(vector int) bool {
+	return c.valid(vector) && c.pending[vector]
+}
+
+func (c *InterruptController) Reset() {
+	if c == nil {
+		return
+	}
+	c.enabled = false
+	c.functionMask = false
+	for i := range c.vectorMask {
+		c.vectorMask[i] = false
+		c.pending[i] = false
+	}
+}
+
+func (c *InterruptController) valid(vector int) bool {
+	return c != nil && vector >= 0 && vector < len(c.pending)
+}
+
+func (c *InterruptController) deliverable(vector int) bool {
+	return c.enabled && !c.functionMask && !c.vectorMask[vector]
+}
+
+func (c *InterruptController) drainOne() []Delivery {
+	if c == nil || !c.enabled || c.functionMask {
+		return nil
+	}
+	for vector := range c.pending {
+		if c.pending[vector] && !c.vectorMask[vector] {
+			c.pending[vector] = false
+			return []Delivery{{Valid: true, Vector: vector}}
+		}
+	}
+	return nil
+}

--- a/internal/firmware/services/lifecycle.go
+++ b/internal/firmware/services/lifecycle.go
@@ -1,0 +1,54 @@
+package services
+
+type PowerState uint8
+
+const (
+	D0 PowerState = iota
+	D1
+	D2
+	D3Hot
+)
+
+const D3 = D3Hot
+
+type Inputs struct {
+	Reset    bool
+	FLR      bool
+	DState   PowerState
+	MSE      bool
+	BME      bool
+	Turnoff  bool
+	LinkDown bool
+}
+
+type Outputs struct {
+	DeviceReset bool
+	IOEnabled   bool
+	DMAEnabled  bool
+	Quiesce     bool
+	Generation  uint32
+}
+
+type Lifecycle struct {
+	generation uint32
+	inReset    bool
+}
+
+func (l *Lifecycle) Apply(in Inputs) Outputs {
+	deviceReset := in.Reset || in.FLR
+	if deviceReset && !l.inReset {
+		l.generation++
+	}
+	l.inReset = deviceReset
+
+	active := !deviceReset && in.DState == D0 && !in.Turnoff && !in.LinkDown
+	ioEnabled := active && in.MSE
+	dmaEnabled := active && in.BME
+	return Outputs{
+		DeviceReset: deviceReset,
+		IOEnabled:   ioEnabled,
+		DMAEnabled:  dmaEnabled,
+		Quiesce:     !dmaEnabled,
+		Generation:  l.generation,
+	}
+}

--- a/internal/firmware/services/services_test.go
+++ b/internal/firmware/services/services_test.go
@@ -1,0 +1,339 @@
+package services
+
+import "testing"
+
+func TestLifecycleResetFLRD3MSEBMETransitions(t *testing.T) {
+	var lifecycle Lifecycle
+
+	out := lifecycle.Apply(Inputs{DState: 0, MSE: true, BME: true})
+	if out.DeviceReset || !out.IOEnabled || !out.DMAEnabled || out.Quiesce {
+		t.Fatalf("D0 with MSE+BME should be fully enabled, got %+v", out)
+	}
+	initialGeneration := out.Generation
+
+	out = lifecycle.Apply(Inputs{DState: 0, MSE: false, BME: true})
+	if out.IOEnabled || !out.DMAEnabled {
+		t.Fatalf("MSE must gate only MMIO, got %+v", out)
+	}
+	if out.Generation != initialGeneration {
+		t.Fatalf("ordinary MSE gating reset state: generation %d -> %d", initialGeneration, out.Generation)
+	}
+
+	out = lifecycle.Apply(Inputs{DState: 0, MSE: true, BME: false})
+	if !out.IOEnabled || out.DMAEnabled {
+		t.Fatalf("BME must gate only DMA, got %+v", out)
+	}
+	if out.Generation != initialGeneration {
+		t.Fatalf("ordinary BME gating reset state: generation %d -> %d", initialGeneration, out.Generation)
+	}
+
+	out = lifecycle.Apply(Inputs{DState: 3, MSE: true, BME: true})
+	if out.IOEnabled || out.DMAEnabled || !out.Quiesce {
+		t.Fatalf("D3 must quiesce both MMIO and DMA, got %+v", out)
+	}
+	if out.Generation != initialGeneration {
+		t.Fatalf("D3 transition must retain function state: generation %d -> %d", initialGeneration, out.Generation)
+	}
+
+	out = lifecycle.Apply(Inputs{DState: 0, MSE: true, BME: true})
+	if !out.IOEnabled || !out.DMAEnabled || out.Quiesce || out.Generation != initialGeneration {
+		t.Fatalf("D0 resume should restore gates without resetting retained state, got %+v", out)
+	}
+
+	out = lifecycle.Apply(Inputs{Reset: true, DState: 0, MSE: true, BME: true})
+	if !out.DeviceReset || out.IOEnabled || out.DMAEnabled || !out.Quiesce {
+		t.Fatalf("reset must quiesce all activity, got %+v", out)
+	}
+	if out.Generation != initialGeneration+1 {
+		t.Fatalf("reset rising edge generation = %d, want %d", out.Generation, initialGeneration+1)
+	}
+	resetGeneration := out.Generation
+
+	out = lifecycle.Apply(Inputs{Reset: true, DState: 0, MSE: true, BME: true})
+	if out.Generation != resetGeneration {
+		t.Fatalf("held reset incremented generation again: got %d, want %d", out.Generation, resetGeneration)
+	}
+	lifecycle.Apply(Inputs{DState: 0, MSE: true, BME: true})
+
+	out = lifecycle.Apply(Inputs{FLR: true, DState: 0, MSE: true, BME: true})
+	if !out.DeviceReset || out.IOEnabled || out.DMAEnabled || !out.Quiesce {
+		t.Fatalf("FLR must quiesce all activity, got %+v", out)
+	}
+	if out.Generation != resetGeneration+1 {
+		t.Fatalf("FLR rising edge generation = %d, want %d", out.Generation, resetGeneration+1)
+	}
+	flrGeneration := out.Generation
+	out = lifecycle.Apply(Inputs{FLR: true, DState: 0, MSE: true, BME: true})
+	if out.Generation != flrGeneration {
+		t.Fatalf("held FLR incremented generation again: got %d, want %d", out.Generation, flrGeneration)
+	}
+}
+
+func TestLifecycleTurnoffAndLinkDownQuiesceWithoutReset(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   Inputs
+	}{
+		{name: "turnoff", in: Inputs{DState: 0, MSE: true, BME: true, Turnoff: true}},
+		{name: "link_down", in: Inputs{DState: 0, MSE: true, BME: true, LinkDown: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var lifecycle Lifecycle
+			before := lifecycle.Apply(Inputs{DState: 0, MSE: true, BME: true})
+			after := lifecycle.Apply(tc.in)
+			if !after.Quiesce || after.IOEnabled || after.DMAEnabled {
+				t.Fatalf("transition should quiesce traffic, got %+v", after)
+			}
+			if after.DeviceReset || after.Generation != before.Generation {
+				t.Fatalf("traffic quiesce must not reset retained state: before=%+v after=%+v", before, after)
+			}
+		})
+	}
+}
+
+func TestTagAllocatorAllocationWrapCompletionAndError(t *testing.T) {
+	allocator := NewTagAllocator(30, 4, 100)
+
+	var tags []uint8
+	for range 4 {
+		tag, ok := allocator.Allocate(10)
+		if !ok {
+			t.Fatal("allocator exhausted before all configured tags were allocated")
+		}
+		tags = append(tags, tag)
+	}
+	want := []uint8{30, 31, 32, 33}
+	for i := range want {
+		if tags[i] != want[i] {
+			t.Fatalf("tag[%d] = %d, want %d (all tags %v)", i, tags[i], want[i], tags)
+		}
+	}
+	if tag, ok := allocator.Allocate(10); ok {
+		t.Fatalf("exhausted allocator returned tag %d", tag)
+	}
+
+	completed, ok := allocator.Complete(tags[1])
+	if !ok || completed.Tag != tags[1] || completed.Kind != Completed {
+		t.Fatalf("completion mismatch: outcome=%+v ok=%v", completed, ok)
+	}
+	if _, ok := allocator.Complete(tags[1]); ok {
+		t.Fatal("duplicate completion was accepted")
+	}
+
+	reused, ok := allocator.Allocate(20)
+	if !ok {
+		t.Fatal("completed tag was not returned to the free pool")
+	}
+	if reused != tags[1] {
+		t.Fatalf("allocation cursor did not wrap to the freed tag: got %d, want %d", reused, tags[1])
+	}
+	failed, ok := allocator.Fail(reused)
+	if !ok || failed.Tag != reused || failed.Kind != Error {
+		t.Fatalf("error completion mismatch: outcome=%+v ok=%v", failed, ok)
+	}
+	if _, ok := allocator.Fail(reused); ok {
+		t.Fatal("duplicate error completion was accepted")
+	}
+	if _, ok := allocator.Complete(200); ok {
+		t.Fatal("completion for an unallocated tag was accepted")
+	}
+}
+
+func TestTagAllocatorTimeoutCancelAndNoStaleActivity(t *testing.T) {
+	allocator := NewTagAllocator(7, 3, 10)
+	tag0, ok := allocator.Allocate(100)
+	if !ok {
+		t.Fatal("first allocation failed")
+	}
+	tag1, ok := allocator.Allocate(105)
+	if !ok {
+		t.Fatal("second allocation failed")
+	}
+
+	if outcomes := allocator.Tick(109); len(outcomes) != 0 {
+		t.Fatalf("tag timed out early: %+v", outcomes)
+	}
+	outcomes := allocator.Tick(110)
+	if len(outcomes) != 1 || outcomes[0].Tag != tag0 || outcomes[0].Kind != Timeout {
+		t.Fatalf("deadline should time out only tag %d, got %+v", tag0, outcomes)
+	}
+	if _, ok := allocator.Complete(tag0); ok {
+		t.Fatal("late completion after timeout was accepted")
+	}
+	if outcomes := allocator.Tick(114); len(outcomes) != 0 {
+		t.Fatalf("second tag timed out early: %+v", outcomes)
+	}
+
+	cancelled := allocator.CancelAll()
+	if len(cancelled) != 1 || cancelled[0].Tag != tag1 || cancelled[0].Kind != Cancelled {
+		t.Fatalf("cancel should report the sole outstanding tag, got %+v", cancelled)
+	}
+	if again := allocator.CancelAll(); len(again) != 0 {
+		t.Fatalf("repeated cancel produced stale outcomes: %+v", again)
+	}
+	if _, ok := allocator.Complete(tag1); ok {
+		t.Fatal("late completion after reset/cancel was accepted")
+	}
+	if outcomes := allocator.Tick(1_000); len(outcomes) != 0 {
+		t.Fatalf("cancelled tags produced stale timeout activity: %+v", outcomes)
+	}
+
+	for i := range 3 {
+		if _, ok := allocator.Allocate(2_000); !ok {
+			t.Fatalf("allocator did not recover all capacity after timeout/cancel at allocation %d", i)
+		}
+	}
+}
+
+func TestInterruptControllerMSIEnableMasking(t *testing.T) {
+	interrupts := NewInterruptController(1)
+
+	if delivery := interrupts.Request(0); delivery.Valid {
+		t.Fatalf("disabled MSI delivered immediately: %+v", delivery)
+	}
+	if !interrupts.Pending(0) {
+		t.Fatal("disabled MSI request was not retained pending")
+	}
+	deliveries := interrupts.SetEnabled(true)
+	assertSingleDelivery(t, deliveries, 0)
+	if interrupts.Pending(0) {
+		t.Fatal("MSI pending bit remained set after delivery")
+	}
+	if deliveries := interrupts.SetEnabled(true); len(deliveries) != 0 {
+		t.Fatalf("re-enabling MSI redelivered an already consumed request: %+v", deliveries)
+	}
+
+	if delivery := interrupts.Request(0); !delivery.Valid || delivery.Vector != 0 {
+		t.Fatalf("enabled MSI did not deliver immediately: %+v", delivery)
+	}
+	if interrupts.Pending(0) {
+		t.Fatal("immediately delivered MSI incorrectly set pending")
+	}
+}
+
+func TestInterruptControllerMSIXMasksPBARetentionAndExactlyOnceUnmask(t *testing.T) {
+	interrupts := NewInterruptController(4)
+	if deliveries := interrupts.SetEnabled(true); len(deliveries) != 0 {
+		t.Fatalf("enabling idle controller delivered interrupts: %+v", deliveries)
+	}
+
+	interrupts.SetVectorMask(2, true)
+	if delivery := interrupts.Request(2); delivery.Valid {
+		t.Fatalf("vector-masked request delivered immediately: %+v", delivery)
+	}
+	if delivery := interrupts.Request(2); delivery.Valid {
+		t.Fatalf("duplicate masked request delivered immediately: %+v", delivery)
+	}
+	if !interrupts.Pending(2) {
+		t.Fatal("masked vector did not set its pending bit")
+	}
+	deliveries := interrupts.SetVectorMask(2, false)
+	assertSingleDelivery(t, deliveries, 2)
+	if interrupts.Pending(2) {
+		t.Fatal("pending bit was not cleared by unmask delivery")
+	}
+	if deliveries := interrupts.SetVectorMask(2, false); len(deliveries) != 0 {
+		t.Fatalf("repeated vector unmask redelivered consumed request: %+v", deliveries)
+	}
+
+	interrupts.SetFunctionMask(true)
+	interrupts.SetVectorMask(1, true)
+	if delivery := interrupts.Request(1); delivery.Valid {
+		t.Fatalf("function/vector-masked request delivered immediately: %+v", delivery)
+	}
+	if delivery := interrupts.Request(3); delivery.Valid {
+		t.Fatalf("second function-masked request delivered immediately: %+v", delivery)
+	}
+	if deliveries := interrupts.SetVectorMask(1, false); len(deliveries) != 0 {
+		t.Fatalf("vector unmask bypassed function mask: %+v", deliveries)
+	}
+	if !interrupts.Pending(1) || !interrupts.Pending(3) {
+		t.Fatal("PBA was lost while the function mask remained asserted")
+	}
+	deliveries = interrupts.SetFunctionMask(false)
+	assertSingleDelivery(t, deliveries, 1)
+	if interrupts.Pending(1) {
+		t.Fatal("PBA was not cleared after function-unmask delivery")
+	}
+	if !interrupts.Pending(3) {
+		t.Fatal("function unmask dropped a second pending vector instead of retaining it for drain")
+	}
+	if delivery := interrupts.Drain(); !delivery.Valid || delivery.Vector != 3 {
+		t.Fatalf("drain did not deliver the second pending vector exactly once: %+v", delivery)
+	}
+	if delivery := interrupts.Drain(); delivery.Valid {
+		t.Fatalf("drain redelivered consumed pending activity: %+v", delivery)
+	}
+	if deliveries := interrupts.SetFunctionMask(false); len(deliveries) != 0 {
+		t.Fatalf("repeated function unmask redelivered consumed request: %+v", deliveries)
+	}
+}
+
+func TestInterruptControllerResetDropsPendingWithoutStaleDelivery(t *testing.T) {
+	interrupts := NewInterruptController(3)
+	interrupts.SetEnabled(true)
+	interrupts.SetFunctionMask(true)
+	interrupts.Request(0)
+	interrupts.Request(2)
+	if !interrupts.Pending(0) || !interrupts.Pending(2) {
+		t.Fatal("test setup failed to create pending vectors")
+	}
+
+	interrupts.Reset()
+	for vector := range 3 {
+		if interrupts.Pending(vector) {
+			t.Fatalf("reset retained stale pending vector %d", vector)
+		}
+	}
+	if deliveries := interrupts.SetFunctionMask(false); len(deliveries) != 0 {
+		t.Fatalf("unmask after reset emitted stale interrupts: %+v", deliveries)
+	}
+	if deliveries := interrupts.SetEnabled(true); len(deliveries) != 0 {
+		t.Fatalf("re-enable after reset emitted stale interrupts: %+v", deliveries)
+	}
+}
+
+func TestDeviceResetCancelsOutstandingServicesWithoutStaleActivity(t *testing.T) {
+	var lifecycle Lifecycle
+	tags := NewTagAllocator(8, 2, 10)
+	interrupts := NewInterruptController(2)
+
+	lifecycle.Apply(Inputs{DState: D0, MSE: true, BME: true})
+	tag, ok := tags.Allocate(100)
+	if !ok {
+		t.Fatal("test setup could not allocate a DMA tag")
+	}
+	interrupts.SetEnabled(true)
+	interrupts.SetFunctionMask(true)
+	interrupts.Request(1)
+
+	reset := lifecycle.Apply(Inputs{Reset: true, DState: D0, MSE: true, BME: true})
+	if !reset.DeviceReset {
+		t.Fatal("test setup did not enter device reset")
+	}
+	cancelled := tags.CancelAll()
+	interrupts.Reset()
+	if len(cancelled) != 1 || cancelled[0].Tag != tag || cancelled[0].Kind != Cancelled {
+		t.Fatalf("device reset did not cancel the outstanding tag: %+v", cancelled)
+	}
+
+	if _, ok := tags.Complete(tag); ok {
+		t.Fatal("pre-reset completion was accepted after device reset")
+	}
+	if outcomes := tags.Tick(1_000); len(outcomes) != 0 {
+		t.Fatalf("pre-reset tag generated stale timeout activity: %+v", outcomes)
+	}
+	if deliveries := interrupts.SetFunctionMask(false); len(deliveries) != 0 {
+		t.Fatalf("pre-reset interrupt escaped after unmask: %+v", deliveries)
+	}
+	if deliveries := interrupts.SetEnabled(true); len(deliveries) != 0 {
+		t.Fatalf("pre-reset interrupt escaped after re-enable: %+v", deliveries)
+	}
+}
+
+func assertSingleDelivery(t *testing.T, deliveries []Delivery, vector int) {
+	t.Helper()
+	if len(deliveries) != 1 || !deliveries[0].Valid || deliveries[0].Vector != vector {
+		t.Fatalf("deliveries = %+v, want one valid delivery for vector %d", deliveries, vector)
+	}
+}

--- a/internal/firmware/services/tags.go
+++ b/internal/firmware/services/tags.go
@@ -1,0 +1,133 @@
+package services
+
+type OutcomeKind uint8
+
+const (
+	Completed OutcomeKind = iota + 1
+	Error
+	Timeout
+	Cancelled
+)
+
+type Outcome struct {
+	Tag  uint8
+	Kind OutcomeKind
+}
+
+type tagRequest struct {
+	tag       uint8
+	deadline  uint64
+	cancelled bool
+}
+
+type TagAllocator struct {
+	first       uint8
+	count       int
+	timeout     uint64
+	outstanding map[uint8]tagRequest
+	next        int
+}
+
+func NewTagAllocator(first uint8, count int, timeout uint64) *TagAllocator {
+	if count < 0 {
+		count = 0
+	}
+	if max := 256 - int(first); count > max {
+		count = max
+	}
+	return &TagAllocator{
+		first:       first,
+		count:       count,
+		timeout:     timeout,
+		outstanding: make(map[uint8]tagRequest, count),
+	}
+}
+
+func (a *TagAllocator) Allocate(now uint64) (uint8, bool) {
+	if a == nil || a.count == 0 || len(a.outstanding) >= a.count {
+		return 0, false
+	}
+	for offset := range a.count {
+		index := (a.next + offset) % a.count
+		tag := uint8(int(a.first) + index)
+		if _, busy := a.outstanding[tag]; busy {
+			continue
+		}
+		deadline := uint64(0)
+		if a.timeout != 0 {
+			deadline = now + a.timeout
+			if deadline < now {
+				deadline = ^uint64(0)
+			}
+		}
+		a.outstanding[tag] = tagRequest{tag: tag, deadline: deadline}
+		a.next = (index + 1) % a.count
+		return tag, true
+	}
+	return 0, false
+}
+
+func (a *TagAllocator) Complete(tag uint8) (Outcome, bool) {
+	return a.finish(tag, Completed)
+}
+
+func (a *TagAllocator) Fail(tag uint8) (Outcome, bool) {
+	return a.finish(tag, Error)
+}
+
+func (a *TagAllocator) finish(tag uint8, kind OutcomeKind) (Outcome, bool) {
+	if a == nil {
+		return Outcome{}, false
+	}
+	req, ok := a.outstanding[tag]
+	if !ok {
+		return Outcome{}, false
+	}
+	delete(a.outstanding, tag)
+	if req.cancelled {
+		return Outcome{}, false
+	}
+	return Outcome{Tag: tag, Kind: kind}, true
+}
+
+func (a *TagAllocator) Tick(now uint64) []Outcome {
+	if a == nil || a.timeout == 0 {
+		return nil
+	}
+	out := make([]Outcome, 0)
+	for index := range a.count {
+		tag := uint8(int(a.first) + index)
+		req, ok := a.outstanding[tag]
+		if ok && req.deadline != 0 && now >= req.deadline {
+			delete(a.outstanding, tag)
+			if !req.cancelled {
+				out = append(out, Outcome{Tag: tag, Kind: Timeout})
+			}
+		}
+	}
+	return out
+}
+
+func (a *TagAllocator) CancelAll() []Outcome {
+	if a == nil {
+		return nil
+	}
+	out := make([]Outcome, 0, len(a.outstanding))
+	for index := range a.count {
+		tag := uint8(int(a.first) + index)
+		req, ok := a.outstanding[tag]
+		if ok && !req.cancelled {
+			req.cancelled = true
+			a.outstanding[tag] = req
+			out = append(out, Outcome{Tag: tag, Kind: Cancelled})
+		}
+	}
+	return out
+}
+
+func (a *TagAllocator) Outstanding() int {
+	if a == nil {
+		return 0
+	}
+	return len(a.outstanding)
+}

--- a/internal/firmware/svgen/generator.go
+++ b/internal/firmware/svgen/generator.go
@@ -140,6 +140,18 @@ func renderTemplateDelim(name, leftDelim, rightDelim string, data any) (string, 
 	return buf.String(), nil
 }
 
+func GenerateLifecycleServiceSV(cfg *SVGeneratorConfig) (string, error) {
+	return renderTemplate("lifecycle_service", cfg)
+}
+
+func GenerateDMATagServiceSV(cfg *SVGeneratorConfig) (string, error) {
+	return renderTemplate("dma_tag_service", cfg)
+}
+
+func GenerateInterruptServiceSV(cfg *SVGeneratorConfig) (string, error) {
+	return renderTemplate("interrupt_service", cfg)
+}
+
 func GenerateBarImplDeviceSV(cfg *SVGeneratorConfig) (string, error) {
 	return renderTemplate("bar_impl_device", cfg)
 }

--- a/internal/firmware/svgen/patcher.go
+++ b/internal/firmware/svgen/patcher.go
@@ -38,6 +38,29 @@ func (p *SVPatcher) PatchAll() error {
 	if err := p.patchCfgSV(); err != nil {
 		return fmt.Errorf("patching pcileech_pcie_cfg_a7.sv: %w", err)
 	}
+	tlpData, err := os.ReadFile(filepath.Join(p.srcDir, "pcileech_pcie_tlp_a7.sv"))
+	if err == nil {
+		modern, classifyErr := classifyServiceTLP(string(tlpData))
+		if classifyErr != nil {
+			return fmt.Errorf("patching pcileech_pcie_tlp_a7.sv services: %w", classifyErr)
+		}
+		if modern {
+			if err := p.patchCfgInterruptHandshake(); err != nil {
+				return fmt.Errorf("patching pcileech_pcie_cfg_a7.sv interrupt handshake: %w", err)
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := p.patchTLPServiceWiring(); err != nil {
+		return fmt.Errorf("patching pcileech_pcie_tlp_a7.sv services: %w", err)
+	}
+	if err := p.patchPCIeWrapperServiceWiring(); err != nil {
+		return fmt.Errorf("patching PCIe wrapper services: %w", err)
+	}
+	if err := p.validateServiceWiring(); err != nil {
+		return err
+	}
 
 	if err := p.patchFifoSV(); err != nil {
 		return fmt.Errorf("patching pcileech_fifo.sv: %w", err)
@@ -178,28 +201,6 @@ func (p *SVPatcher) patchCfgSV() error {
 		label:       "PM: halt ASPM L1 (cfg_pm_halt_aspm_l1 -> 1)",
 	})
 
-	// force IP core to stay in D0 power state. without this, Windows
-	// can write D3 to PMCSR which the IP core processes internally
-	// before the shadow BRAM even sees it. once in D3, the IP core
-	// stops processing memory/IO TLPs -> DPC_WATCHDOG_VIOLATION BSOD.
-	// cfg_pm_force_state = 00 (D0) is already the default, we just
-	// need to enable the force mechanism.
-	patches = append(patches, svRegexPatch{
-		pattern:     `(rw\[210\]\s*<=\s*)0(\s*;\s*//\s*cfg_pm_force_state_en)`,
-		replacement: "${1}1${2}",
-		label:       "PM: force D0 state (cfg_pm_force_state_en -> 1)",
-	})
-
-	// enable periodic command register auto-set. every ~1ms this
-	// writes 0x0007 (BME+MSE+IOSE) to the IP core's command register
-	// via cfg_mgmt. without this, Windows clearing Bus Master Enable
-	// during Code 10 restart attempts permanently kills DMA.
-	patches = append(patches, svRegexPatch{
-		pattern:     `(rw\[21\]\s*<=\s*)0(\s*;\s*//\s*CFGSPACE_COMMAND_REGISTER_AUTO_SET)`,
-		replacement: "${1}1${2}",
-		label:       "CMD: auto-set BME+MSE+IOSE (CFGSPACE_COMMAND_REGISTER_AUTO_SET -> 1)",
-	})
-
 	// enable periodic status register error bit clearing. every ~1ms
 	// this clears W1C error bits (master abort, target abort, parity)
 	// in the status register. prevents error accumulation that would
@@ -211,6 +212,299 @@ func (p *SVPatcher) patchCfgSV() error {
 	})
 
 	return p.patchFile("pcileech_pcie_cfg_a7.sv", patches)
+}
+
+func (p *SVPatcher) patchCfgInterruptHandshake() error {
+	path := filepath.Join(p.srcDir, "pcileech_pcie_cfg_a7.sv")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	content := string(data)
+	requestPort := interruptRequestPort(content)
+	if requestPort == "" {
+		requestPort = "generated_bar_intr_req"
+	}
+	var patches []svRegexPatch
+	if interruptRequestPort(content) == "" {
+		patches = append(patches, svRegexPatch{
+			pattern:     `(module\s+pcileech_pcie_cfg_a7\s*\(\s*\r?\n)`,
+			replacement: "${1}    input                   " + requestPort + ",\n",
+			label:       "services: accept interrupt request",
+		})
+	}
+	if !strings.Contains(content, "intr_req_pending") {
+		patches = append(patches, svRegexPatch{
+			pattern: `(assign\s+ctx\.cfg_interrupt\s*=\s*)rw\[206\](\s*;)`,
+			replacement: "reg intr_req_pending = 1'b0;\n" +
+				"    always @(posedge clk_pcie) begin\n" +
+				"        if (rst)\n" +
+				"            intr_req_pending <= 1'b0;\n" +
+				"        else if (" + requestPort + ")\n" +
+				"            intr_req_pending <= 1'b1;\n" +
+				"        else if (intr_req_pending && ctx.cfg_interrupt_rdy)\n" +
+				"            intr_req_pending <= 1'b0;\n" +
+				"    end\n\n" +
+				"    ${1}rw[206] | intr_req_pending${2}",
+			label: "services: hold interrupt request until ready",
+		})
+	}
+	escapedPort := regexp.QuoteMeta(requestPort)
+	patches = append(patches,
+		svRegexPatch{
+			pattern:     `(assign\s+ctx\.cfg_interrupt_assert\s*=\s*)rw\[205\](\s*;)`,
+			replacement: "${1}rw[205] | intr_req_pending${2}",
+			label:       "services: route held interrupt assertion",
+		},
+		svRegexPatch{
+			pattern: `(else\s+if\s*\(\s*intr_req_pending\s*&&\s*ctx\.cfg_interrupt_rdy\s*\)\s*begin\s*\r?\n\s*intr_req_pending\s*<=\s*1'b0;\s*\r?\n\s*end\s+else\s+if\s*\(\s*` + escapedPort + `\s*\)\s*begin\s*\r?\n\s*intr_req_pending\s*<=\s*1'b1;\s*\r?\n\s*end)`,
+			replacement: "else if (" + requestPort + ") begin\n" +
+				"            intr_req_pending <= 1'b1;\n" +
+				"        end else if (intr_req_pending && ctx.cfg_interrupt_rdy) begin\n" +
+				"            intr_req_pending <= 1'b0;\n" +
+				"        end",
+			label: "services: preserve interrupt arriving with acknowledgement",
+		},
+	)
+	return p.patchFile("pcileech_pcie_cfg_a7.sv", patches)
+}
+
+func classifyServiceTLP(content string) (bool, error) {
+	if strings.Contains(content, "pcileech_tlps128_bar_controller") {
+		return true, nil
+	}
+	if strings.Contains(content, "IfTlp64") || strings.Contains(content, "IfPCIeTlpRxTx") {
+		return false, nil
+	}
+	return false, fmt.Errorf("unsupported TLP service architecture")
+}
+
+func interruptRequestPort(content string) string {
+	for _, name := range []string{"generated_bar_intr_req", "intr_req"} {
+		re := regexp.MustCompile(`\b(?:input|output)\s+(?:wire\s+)?` + regexp.QuoteMeta(name) + `\b`)
+		if re.MatchString(content) {
+			return name
+		}
+	}
+	return ""
+}
+
+func instanceHasPort(content, moduleName, portName string) bool {
+	re := regexp.MustCompile(`(?s)\b` + regexp.QuoteMeta(moduleName) + `\s+\w+\s*\((.*?)\);`)
+	match := re.FindStringSubmatch(content)
+	return len(match) == 2 && strings.Contains(match[1], "."+portName)
+}
+
+func instancePortPatch(moduleName, portName, connection, label string) svRegexPatch {
+	return svRegexPatch{
+		pattern:     `(` + regexp.QuoteMeta(moduleName) + `\s+\w+\s*\(\s*\r?\n)`,
+		replacement: "${1}        ." + portName + connection + ",\n",
+		label:       label,
+	}
+}
+
+func (p *SVPatcher) patchTLPServiceWiring() error {
+	path := filepath.Join(p.srcDir, "pcileech_pcie_tlp_a7.sv")
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	content := string(data)
+	modern, err := classifyServiceTLP(content)
+	if err != nil {
+		return err
+	}
+	if !modern {
+		return nil
+	}
+
+	var patches []svRegexPatch
+	if !regexp.MustCompile(`\bIfPCIeSignals(?:\.\w+)?\s+ctx\b`).MatchString(content) {
+		patches = append(patches, svRegexPatch{
+			pattern:     `(module\s+pcileech_pcie_tlp_a7\s*\(\s*\r?\n)`,
+			replacement: "${1}    IfPCIeSignals           ctx,\n",
+			label:       "services: add PCIe context port",
+		})
+	}
+	requestPort := interruptRequestPort(content)
+	if requestPort == "" {
+		requestPort = "generated_bar_intr_req"
+		patches = append(patches, svRegexPatch{
+			pattern:     `(module\s+pcileech_pcie_tlp_a7\s*\(\s*\r?\n)`,
+			replacement: "${1}    output wire             " + requestPort + ",\n",
+			label:       "services: add interrupt request port",
+		})
+	}
+	if !instanceHasPort(content, "pcileech_tlps128_bar_controller", "cfg_command") {
+		ports := "        .cfg_command     ( ctx.cfg_command                ),\n" +
+			"        .cfg_power_state ( ctx.cfg_pmcsr_powerstate       ),\n" +
+			"        .cfg_flr_in_process( ctx.cfg_received_func_lvl_rst ),\n" +
+			"        .cfg_to_turnoff  ( ctx.cfg_to_turnoff             ),\n" +
+			"        .cfg_link_up     ( ctx.pl_phy_lnk_up               ),\n" +
+			"        .cfg_msi_enable  ( ctx.cfg_interrupt_msienable     ),\n" +
+			"        .cfg_msix_enable ( ctx.cfg_interrupt_msixenable    ),\n" +
+			"        .cfg_msix_function_mask( ctx.cfg_interrupt_msixfm  ),\n"
+		if !instanceHasPort(content, "pcileech_tlps128_bar_controller", "intr_req") {
+			ports += "        .intr_req        ( " + requestPort + "          ),\n"
+		}
+		patches = append(patches, svRegexPatch{
+			pattern:     `(pcileech_tlps128_bar_controller\s+\w+\s*\(\s*\r?\n)`,
+			replacement: "${1}" + ports,
+			label:       "services: wire lifecycle and interrupt BAR ports",
+		})
+	}
+	return p.patchFile("pcileech_pcie_tlp_a7.sv", patches)
+}
+
+func (p *SVPatcher) patchPCIeWrapperServiceWiring() error {
+	tlpData, err := os.ReadFile(filepath.Join(p.srcDir, "pcileech_pcie_tlp_a7.sv"))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	modern, err := classifyServiceTLP(string(tlpData))
+	if err != nil {
+		return err
+	}
+	if !modern {
+		return nil
+	}
+	requestPort := interruptRequestPort(string(tlpData))
+	if requestPort == "" {
+		return fmt.Errorf("modern TLP wrapper has no interrupt request port")
+	}
+
+	for _, filename := range []string{"pcileech_pcie_a7.sv", "pcileech_pcie_a7x4.sv"} {
+		path := filepath.Join(p.srcDir, filename)
+		data, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		content := string(data)
+		var patches []svRegexPatch
+		wirePattern := regexp.MustCompile(`\bwire\s+` + regexp.QuoteMeta(requestPort) + `\b`)
+		if !wirePattern.MatchString(content) {
+			patches = append(patches, svRegexPatch{
+				pattern:     `(IfPCIeSignals\s+ctx\(\);\s*\r?\n)`,
+				replacement: "${1}    wire                    " + requestPort + ";\n",
+				label:       "services: declare interrupt wire",
+			})
+		}
+		if !instanceHasPort(content, "pcileech_pcie_cfg_a7", requestPort) {
+			patches = append(patches, instancePortPatch(
+				"pcileech_pcie_cfg_a7", requestPort, "   ( "+requestPort+"    )",
+				"services: connect interrupt to cfg wrapper",
+			))
+		}
+		if !instanceHasPort(content, "pcileech_pcie_tlp_a7", "ctx") {
+			patches = append(patches, instancePortPatch(
+				"pcileech_pcie_tlp_a7", "ctx", "                        ( ctx                       )",
+				"services: connect lifecycle context to TLP wrapper",
+			))
+		}
+		if !instanceHasPort(content, "pcileech_pcie_tlp_a7", requestPort) {
+			patches = append(patches, instancePortPatch(
+				"pcileech_pcie_tlp_a7", requestPort, "   ( "+requestPort+"    )",
+				"services: connect interrupt from TLP wrapper",
+			))
+		}
+		if err := p.patchFile(filename, patches); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *SVPatcher) validateServiceWiring() error {
+	tlpPath := filepath.Join(p.srcDir, "pcileech_pcie_tlp_a7.sv")
+	tlpData, err := os.ReadFile(tlpPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	tlpContent := string(tlpData)
+	modern, err := classifyServiceTLP(tlpContent)
+	if err != nil {
+		return fmt.Errorf("pcileech_pcie_tlp_a7.sv: %w", err)
+	}
+	requestPort := interruptRequestPort(tlpContent)
+
+	if modern {
+		cfgData, err := os.ReadFile(filepath.Join(p.srcDir, "pcileech_pcie_cfg_a7.sv"))
+		if err != nil {
+			return err
+		}
+		cfgContent := string(cfgData)
+		cfgChecks := []*regexp.Regexp{
+			regexp.MustCompile(`\binput\s+(?:wire\s+)?` + regexp.QuoteMeta(requestPort) + `\b`),
+			regexp.MustCompile(`\bintr_req_pending\b`),
+			regexp.MustCompile(`intr_req_pending\s*&&\s*ctx\.cfg_interrupt_rdy`),
+			regexp.MustCompile(`ctx\.cfg_interrupt\s*=\s*rw\[206\]\s*\|\s*intr_req_pending`),
+		}
+		for _, check := range cfgChecks {
+			if !check.MatchString(cfgContent) {
+				return fmt.Errorf("pcileech_pcie_cfg_a7.sv: required interrupt handshake %q not applied", check.String())
+			}
+		}
+		required := []string{
+			".cfg_command",
+			".cfg_power_state",
+			".cfg_flr_in_process",
+			".cfg_to_turnoff",
+			".cfg_link_up",
+			".cfg_msi_enable",
+			".cfg_msix_enable",
+			".cfg_msix_function_mask",
+			".intr_req",
+		}
+		if requestPort == "" {
+			return fmt.Errorf("pcileech_pcie_tlp_a7.sv: interrupt request port not applied")
+		}
+		if !regexp.MustCompile(`\bIfPCIeSignals(?:\.\w+)?\s+ctx\b`).MatchString(tlpContent) {
+			return fmt.Errorf("pcileech_pcie_tlp_a7.sv: required service context not applied")
+		}
+		for _, token := range required {
+			if !strings.Contains(tlpContent, token) {
+				return fmt.Errorf("pcileech_pcie_tlp_a7.sv: required service wiring %q not applied", token)
+			}
+		}
+	}
+
+	foundWrapper := false
+	for _, filename := range []string{"pcileech_pcie_a7.sv", "pcileech_pcie_a7x4.sv"} {
+		data, err := os.ReadFile(filepath.Join(p.srcDir, filename))
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		foundWrapper = true
+		if modern {
+			content := string(data)
+			if !instanceHasPort(content, "pcileech_pcie_cfg_a7", requestPort) ||
+				!instanceHasPort(content, "pcileech_pcie_tlp_a7", requestPort) {
+				return fmt.Errorf("%s: interrupt request path not connected", filename)
+			}
+			if !instanceHasPort(content, "pcileech_pcie_tlp_a7", "ctx") {
+				return fmt.Errorf("%s: lifecycle context not connected", filename)
+			}
+		}
+	}
+	if !foundWrapper {
+		return fmt.Errorf("no supported Xilinx PCIe wrapper found")
+	}
+	return nil
 }
 
 // patchFifoSV patches pcileech_fifo.sv with donor device identity.

--- a/internal/firmware/svgen/patcher.go
+++ b/internal/firmware/svgen/patcher.go
@@ -45,7 +45,11 @@ func (p *SVPatcher) PatchAll() error {
 			return fmt.Errorf("patching pcileech_pcie_tlp_a7.sv services: %w", classifyErr)
 		}
 		if modern {
-			if err := p.patchCfgInterruptHandshake(); err != nil {
+			requestPort := interruptRequestPort(string(tlpData))
+			if requestPort == "" {
+				requestPort = "generated_bar_intr_req"
+			}
+			if err := p.patchCfgInterruptHandshake(requestPort); err != nil {
 				return fmt.Errorf("patching pcileech_pcie_cfg_a7.sv interrupt handshake: %w", err)
 			}
 		}
@@ -201,6 +205,18 @@ func (p *SVPatcher) patchCfgSV() error {
 		label:       "PM: halt ASPM L1 (cfg_pm_halt_aspm_l1 -> 1)",
 	})
 
+	patches = append(patches, svRegexPatch{
+		pattern:     `(rw\[210\]\s*<=\s*)0(\s*;\s*//\s*cfg_pm_force_state_en)`,
+		replacement: "${1}1${2}",
+		label:       "PM: force D0 state (cfg_pm_force_state_en -> 1)",
+	})
+
+	patches = append(patches, svRegexPatch{
+		pattern:     `(rw\[21\]\s*<=\s*)0(\s*;\s*//\s*CFGSPACE_COMMAND_REGISTER_AUTO_SET)`,
+		replacement: "${1}1${2}",
+		label:       "CMD: auto-set BME+MSE+IOSE (CFGSPACE_COMMAND_REGISTER_AUTO_SET -> 1)",
+	})
+
 	// enable periodic status register error bit clearing. every ~1ms
 	// this clears W1C error bits (master abort, target abort, parity)
 	// in the status register. prevents error accumulation that would
@@ -214,19 +230,18 @@ func (p *SVPatcher) patchCfgSV() error {
 	return p.patchFile("pcileech_pcie_cfg_a7.sv", patches)
 }
 
-func (p *SVPatcher) patchCfgInterruptHandshake() error {
+func (p *SVPatcher) patchCfgInterruptHandshake(requestPort string) error {
 	path := filepath.Join(p.srcDir, "pcileech_pcie_cfg_a7.sv")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 	content := string(data)
-	requestPort := interruptRequestPort(content)
 	if requestPort == "" {
-		requestPort = "generated_bar_intr_req"
+		return fmt.Errorf("interrupt request port is empty")
 	}
 	var patches []svRegexPatch
-	if interruptRequestPort(content) == "" {
+	if !hasInterruptRequestPort(content, requestPort) {
 		patches = append(patches, svRegexPatch{
 			pattern:     `(module\s+pcileech_pcie_cfg_a7\s*\(\s*\r?\n)`,
 			replacement: "${1}    input                   " + requestPort + ",\n",
@@ -281,12 +296,16 @@ func classifyServiceTLP(content string) (bool, error) {
 
 func interruptRequestPort(content string) string {
 	for _, name := range []string{"generated_bar_intr_req", "intr_req"} {
-		re := regexp.MustCompile(`\b(?:input|output)\s+(?:wire\s+)?` + regexp.QuoteMeta(name) + `\b`)
-		if re.MatchString(content) {
+		if hasInterruptRequestPort(content, name) {
 			return name
 		}
 	}
 	return ""
+}
+
+func hasInterruptRequestPort(content, name string) bool {
+	re := regexp.MustCompile(`\b(?:input|output)\s+(?:wire\s+)?` + regexp.QuoteMeta(name) + `\b`)
+	return re.MatchString(content)
 }
 
 func instanceHasPort(content, moduleName, portName string) bool {

--- a/internal/firmware/svgen/patcher_services_regression_test.go
+++ b/internal/firmware/svgen/patcher_services_regression_test.go
@@ -131,7 +131,7 @@ endmodule
 `
 	runVerilatorSimulation(t, map[string]string{
 		"pcileech_pcie_cfg_a7.sv": string(cfg),
-		"tb.sv":                    testbench,
+		"tb.sv":                   testbench,
 	})
 }
 
@@ -809,9 +809,9 @@ end
 endmodule
 `
 	runVerilatorSimulation(t, map[string]string{
-		"msix_table_init.hex":     strings.Repeat("00000000\n", 16),
+		"msix_table_init.hex":    strings.Repeat("00000000\n", 16),
 		"pcileech_msix_table.sv": sv,
-		"tb.sv":                   testbench,
+		"tb.sv":                  testbench,
 	})
 }
 
@@ -1018,10 +1018,10 @@ end
 endmodule
 `
 	runVerilatorSimulation(t, map[string]string{
-		"msix_table_init.hex":            strings.Repeat("00000000\n", 16),
+		"msix_table_init.hex":           strings.Repeat("00000000\n", 16),
 		"pcileech_interrupt_service.sv": interruptSV,
 		"pcileech_msix_table.sv":        tableSV,
-		"tb.sv":                          testbench,
+		"tb.sv":                         testbench,
 	})
 }
 
@@ -1062,6 +1062,7 @@ wire [15:0] vector_select;
 wire irq_delivery_valid;
 wire [15:0] irq_delivery_vector;
 wire irq_delivery_ready;
+wire irq_delivery_done;
 wire msi_pulse;
 wire pba_set_valid;
 wire pba_clear_valid;
@@ -1096,7 +1097,8 @@ integer i;
 reg found = 0;
 
 pcileech_interrupt_service #(
-    .NUM_VECTORS(4)
+    .NUM_VECTORS(4),
+    .DEFER_MSIX_CLEAR(1)
 ) interrupts (
     .clk(clk),
     .rst(rst),
@@ -1109,6 +1111,7 @@ pcileech_interrupt_service #(
     .vector_select(vector_select),
     .vector_masked(1'b0),
     .delivery_ready(irq_delivery_ready),
+    .delivery_done(irq_delivery_done),
     .delivery_valid(irq_delivery_valid),
     .delivery_vector(irq_delivery_vector),
     .msi_pulse(msi_pulse),
@@ -1157,11 +1160,11 @@ pcileech_nvme_admin_responder responder (
     .doorbell_is_cq(1'b0),
     .doorbell_qid(16'd0),
     .doorbell_val(16'd0),
-    .msix_vector_select(),
     .msix_vector_addr(64'h00000000FEE00000),
     .msix_vector_data(32'h00000044),
     .irq_delivery_valid(irq_delivery_valid),
     .irq_delivery_ready(irq_delivery_ready),
+    .irq_delivery_done(irq_delivery_done),
     .dma_rd_req(dma_rd_req),
     .dma_rd_addr(dma_rd_addr),
     .dma_rd_len(dma_rd_len),
@@ -1273,12 +1276,14 @@ initial begin
     if (!found || responder_state !== 8'd0 || msix_writes !== 0)
         $fatal(1, "test did not reach ready-high held delivery");
 
-    @(negedge clk);
+    cycle();
+    if (responder_state === 8'd0 || !dma_wr_valid)
+        $fatal(1, "ready delivery was not accepted by the responder");
     quiesce = 1;
     dma_enabled = 0;
     cycle();
     if (irq_delivery_valid || irq_delivery_ready || dma_wr_valid || responder_state !== 8'd0 || msix_writes !== 0)
-        $fatal(1, "BME drop accepted delivery or stranded responder");
+        $fatal(1, "BME drop failed to reset the accepted delivery");
     for (i = 0; i < 3; i = i + 1) begin
         cycle();
         if (dma_wr_valid || responder_state !== 8'd0 || msix_writes !== 0)
@@ -1305,6 +1310,8 @@ initial begin
             i = 16;
     end
     if (responder_state !== 8'd0 || dma_wr_valid) $fatal(1, "responder remained stuck waiting for DMA write");
+    cycle();
+    cycle();
     read_pba();
     if (rd_rsp_data[0] !== 1'b0) $fatal(1, "completed resumed MSI-X write did not clear PBA");
     for (i = 0; i < 16; i = i + 1) begin
@@ -1316,12 +1323,12 @@ end
 endmodule
 `
 	runVerilatorSimulation(t, map[string]string{
-		"msix_table_init.hex":             strings.Repeat("00000000\n", 16),
-		"pcileech_dma_tag_service.sv":     tagSV,
-		"pcileech_interrupt_service.sv":   interruptSV,
-		"pcileech_msix_table.sv":          tableSV,
+		"msix_table_init.hex":              strings.Repeat("00000000\n", 16),
+		"pcileech_dma_tag_service.sv":      tagSV,
+		"pcileech_interrupt_service.sv":    interruptSV,
+		"pcileech_msix_table.sv":           tableSV,
 		"pcileech_nvme_admin_responder.sv": responderSV,
-		"pcileech_nvme_dma_bridge.sv":     bridgeSV,
+		"pcileech_nvme_dma_bridge.sv":      bridgeSV,
 		"tb.sv":                            testbench,
 	})
 }

--- a/internal/firmware/svgen/patcher_services_regression_test.go
+++ b/internal/firmware/svgen/patcher_services_regression_test.go
@@ -1,0 +1,1455 @@
+package svgen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/firmware"
+)
+
+func TestPatchAllAcceptsNeTV2AcornAndPCIeScreamerLegacyWrappers(t *testing.T) {
+	dir := t.TempDir()
+	writeLegacyWrapperFixture(t, dir)
+
+	ids := firmware.DeviceIDs{
+		VendorID:       0x144D,
+		DeviceID:       0xA808,
+		SubsysVendorID: 0x144D,
+		SubsysDeviceID: 0xA801,
+		RevisionID:     0x01,
+	}
+	if err := NewSVPatcher(ids, dir).PatchAll(); err != nil {
+		t.Fatalf("legacy 64-bit wrapper generation failed: %v", err)
+	}
+}
+
+func TestPatchedCfgInterruptRequestPersistsUntilReadyAndAcknowledgesOnce(t *testing.T) {
+	dir := t.TempDir()
+	writeModernInterruptWrapperFixture(t, dir)
+	patcher := NewSVPatcher(firmware.DeviceIDs{}, dir)
+	if err := patcher.PatchAll(); err != nil {
+		t.Fatalf("PatchAll: %v", err)
+	}
+	cfg, err := os.ReadFile(filepath.Join(dir, "pcileech_pcie_cfg_a7.sv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	testbench := "`timescale 1ns/1ps\n" + `module tb;
+reg clk = 0;
+always #1 clk = ~clk;
+reg rst = 1;
+reg generated_bar_intr_req = 0;
+integer accepted = 0;
+IfPCIeSignals ctx();
+
+pcileech_pcie_cfg_a7 dut (
+    .generated_bar_intr_req(generated_bar_intr_req),
+    .rst(rst),
+    .clk(clk),
+    .clk_100(clk),
+    .clk_pcie(clk),
+    .ctx(ctx)
+);
+
+always @(posedge clk) begin
+    if (!rst && ctx.cfg_interrupt && ctx.cfg_interrupt_rdy)
+        accepted <= accepted + 1;
+end
+
+task cycle;
+begin
+    @(posedge clk);
+    #1ps;
+end
+endtask
+
+initial begin
+    ctx.cfg_interrupt_rdy = 0;
+    cycle();
+    cycle();
+    @(negedge clk);
+    rst = 0;
+    generated_bar_intr_req = 1;
+    cycle();
+    @(negedge clk);
+    generated_bar_intr_req = 0;
+    cycle();
+    if (!ctx.cfg_interrupt || accepted !== 0) $fatal(1, "request was lost while ready was low");
+    cycle();
+    cycle();
+    if (!ctx.cfg_interrupt || accepted !== 0) $fatal(1, "request did not remain pending");
+    @(negedge clk);
+    ctx.cfg_interrupt_rdy = 1;
+    cycle();
+    if (ctx.cfg_interrupt || accepted !== 1) $fatal(1, "acknowledgment did not consume exactly one request");
+    cycle();
+    cycle();
+    if (ctx.cfg_interrupt || accepted !== 1) $fatal(1, "consumed request was emitted more than once");
+    @(negedge clk);
+    ctx.cfg_interrupt_rdy = 0;
+    generated_bar_intr_req = 1;
+    cycle();
+    @(negedge clk);
+    generated_bar_intr_req = 0;
+    cycle();
+    if (!ctx.cfg_interrupt) $fatal(1, "second request was not retained");
+    @(negedge clk);
+    ctx.cfg_interrupt_rdy = 1;
+    generated_bar_intr_req = 1;
+    cycle();
+    if (!ctx.cfg_interrupt || accepted !== 2) $fatal(1, "request arriving with acknowledgment was lost");
+    @(negedge clk);
+    generated_bar_intr_req = 0;
+    cycle();
+    if (ctx.cfg_interrupt || accepted !== 3) $fatal(1, "overlapping requests did not complete exactly once");
+    cycle();
+    if (ctx.cfg_interrupt || accepted !== 3) $fatal(1, "overlapping request was emitted more than once");
+    @(negedge clk);
+    ctx.cfg_interrupt_rdy = 0;
+    generated_bar_intr_req = 1;
+    cycle();
+    @(negedge clk);
+    generated_bar_intr_req = 0;
+    cycle();
+    if (!ctx.cfg_interrupt) $fatal(1, "reset test request was not retained");
+    @(negedge clk);
+    rst = 1;
+    cycle();
+    if (ctx.cfg_interrupt || accepted !== 3) $fatal(1, "reset did not cancel pending request");
+    @(negedge clk);
+    rst = 0;
+    ctx.cfg_interrupt_rdy = 1;
+    cycle();
+    if (ctx.cfg_interrupt || accepted !== 3) $fatal(1, "cancelled request reappeared after reset");
+    $finish;
+end
+endmodule
+`
+	runVerilatorSimulation(t, map[string]string{
+		"pcileech_pcie_cfg_a7.sv": string(cfg),
+		"tb.sv":                    testbench,
+	})
+}
+
+func TestGeneratedInterruptServiceHoldsValidAndVectorUntilReady(t *testing.T) {
+	sv, err := GenerateInterruptServiceSV(&SVGeneratorConfig{})
+	if err != nil {
+		t.Fatalf("GenerateInterruptServiceSV: %v", err)
+	}
+	testbench := "`timescale 1ns/1ps\n" + `module tb;
+reg clk = 0;
+always #1 clk = ~clk;
+reg rst = 1;
+reg quiesce = 0;
+reg msix_mode = 1;
+reg function_enable = 1;
+reg function_mask = 0;
+reg event_valid = 0;
+reg [15:0] event_vector = 0;
+wire [15:0] vector_select;
+reg vector_masked = 0;
+reg delivery_ready = 0;
+wire delivery_valid;
+wire [15:0] delivery_vector;
+wire msi_pulse;
+wire pba_set_valid;
+wire pba_clear_valid;
+wire [15:0] pba_vector;
+integer accepted = 0;
+integer msi_accepted = 0;
+integer i;
+reg found = 0;
+
+pcileech_interrupt_service #(
+    .NUM_VECTORS(4)
+) dut (
+    .clk(clk),
+    .rst(rst),
+    .quiesce(quiesce),
+    .msix_mode(msix_mode),
+    .function_enable(function_enable),
+    .function_mask(function_mask),
+    .event_valid(event_valid),
+    .event_vector(event_vector),
+    .vector_select(vector_select),
+    .vector_masked(vector_masked),
+    .delivery_ready(delivery_ready),
+    .delivery_valid(delivery_valid),
+    .delivery_vector(delivery_vector),
+    .msi_pulse(msi_pulse),
+    .pba_set_valid(pba_set_valid),
+    .pba_clear_valid(pba_clear_valid),
+    .pba_vector(pba_vector)
+);
+
+always @(posedge clk) begin
+    if (!rst && delivery_valid && delivery_ready)
+        accepted <= accepted + 1;
+    if (!rst && msi_pulse && delivery_ready)
+        msi_accepted <= msi_accepted + 1;
+end
+
+task cycle;
+begin
+    @(posedge clk);
+    #1ps;
+end
+endtask
+
+task wait_for_delivery;
+begin
+    found = 0;
+    for (i = 0; i < 32; i = i + 1) begin
+        cycle();
+        if (delivery_valid) begin
+            found = 1;
+            i = 32;
+        end
+    end
+    if (!found) $fatal(1, "interrupt never asserted valid under backpressure");
+end
+endtask
+
+initial begin
+    cycle();
+    cycle();
+    @(negedge clk);
+    rst = 0;
+    event_valid = 1;
+    event_vector = 16'd2;
+    cycle();
+    @(negedge clk);
+    event_valid = 0;
+    wait_for_delivery();
+    if (delivery_vector !== 16'd2 || accepted !== 0) $fatal(1, "first delivery payload mismatch");
+    for (i = 0; i < 4; i = i + 1) begin
+        cycle();
+        if (!delivery_valid || delivery_vector !== 16'd2 || accepted !== 0)
+            $fatal(1, "valid or payload changed while ready was low");
+    end
+
+    @(negedge clk);
+    delivery_ready = 1;
+    event_valid = 1;
+    event_vector = 16'd2;
+    cycle();
+    if (accepted !== 1 || !pba_set_valid || pba_vector !== 16'd2)
+        $fatal(1, "acknowledgment collision did not preserve the new event");
+    @(negedge clk);
+    delivery_ready = 0;
+    event_valid = 0;
+    wait_for_delivery();
+    if (delivery_vector !== 16'd2 || accepted !== 1) $fatal(1, "replacement delivery payload mismatch");
+    for (i = 0; i < 3; i = i + 1) begin
+        cycle();
+        if (!delivery_valid || delivery_vector !== 16'd2 || accepted !== 1)
+            $fatal(1, "replacement delivery did not remain stable");
+    end
+    @(negedge clk);
+    delivery_ready = 1;
+    cycle();
+    if (accepted !== 2) $fatal(1, "replacement event was not delivered exactly once");
+    @(negedge clk);
+    delivery_ready = 0;
+    cycle();
+    cycle();
+    if (delivery_valid || accepted !== 2) $fatal(1, "acknowledged event was redelivered");
+
+    @(negedge clk);
+    event_valid = 1;
+    event_vector = 16'd1;
+    cycle();
+    @(negedge clk);
+    event_valid = 0;
+    wait_for_delivery();
+    @(negedge clk);
+    rst = 1;
+    cycle();
+    if (delivery_valid || accepted !== 2) $fatal(1, "reset did not cancel backpressured delivery");
+    @(negedge clk);
+    rst = 0;
+    cycle();
+    if (delivery_valid || accepted !== 2) $fatal(1, "cancelled delivery reappeared after reset");
+    @(negedge clk);
+    event_valid = 1;
+    event_vector = 16'd3;
+    cycle();
+    @(negedge clk);
+    event_valid = 0;
+    wait_for_delivery();
+    @(negedge clk);
+    quiesce = 1;
+    cycle();
+    if (delivery_valid || accepted !== 2) $fatal(1, "quiesce exposed held MSI-X delivery");
+    cycle();
+    if (delivery_valid || accepted !== 2) $fatal(1, "quiesced MSI-X request was accepted");
+    @(negedge clk);
+    quiesce = 0;
+    wait_for_delivery();
+    if (delivery_vector !== 16'd3 || accepted !== 2) $fatal(1, "quiesced MSI-X request was not reissued");
+    @(negedge clk);
+    delivery_ready = 1;
+    cycle();
+    if (delivery_valid || accepted !== 3) $fatal(1, "resumed MSI-X request was not accepted exactly once");
+    @(negedge clk);
+    delivery_ready = 0;
+    cycle();
+    if (delivery_valid || accepted !== 3) $fatal(1, "resumed MSI-X request was redelivered");
+
+    @(negedge clk);
+    msix_mode = 0;
+    event_valid = 1;
+    event_vector = 0;
+    cycle();
+    @(negedge clk);
+    event_valid = 0;
+    found = 0;
+    for (i = 0; i < 32; i = i + 1) begin
+        cycle();
+        if (msi_pulse) begin
+            found = 1;
+            i = 32;
+        end
+    end
+    if (!found) $fatal(1, "MSI request never asserted under backpressure");
+    for (i = 0; i < 3; i = i + 1) begin
+        cycle();
+        if (!msi_pulse || msi_accepted !== 0) $fatal(1, "MSI request did not remain held");
+    end
+    @(negedge clk);
+    quiesce = 1;
+    cycle();
+    if (msi_pulse || msi_accepted !== 0) $fatal(1, "quiesce exposed held MSI request");
+    cycle();
+    if (msi_pulse || msi_accepted !== 0) $fatal(1, "quiesced MSI request was accepted");
+    @(negedge clk);
+    quiesce = 0;
+    found = 0;
+    for (i = 0; i < 32; i = i + 1) begin
+        cycle();
+        if (msi_pulse) begin
+            found = 1;
+            i = 32;
+        end
+    end
+    if (!found || msi_accepted !== 0) $fatal(1, "quiesced MSI request was not reissued");
+    @(negedge clk);
+    delivery_ready = 1;
+    cycle();
+    if (msi_pulse || msi_accepted !== 1) $fatal(1, "resumed MSI request was not consumed exactly once");
+    cycle();
+    if (msi_pulse || msi_accepted !== 1) $fatal(1, "consumed MSI request was redelivered");
+    @(negedge clk);
+    delivery_ready = 0;
+    event_valid = 1;
+    cycle();
+    @(negedge clk);
+    event_valid = 0;
+    found = 0;
+    for (i = 0; i < 32; i = i + 1) begin
+        cycle();
+        if (msi_pulse) begin
+            found = 1;
+            i = 32;
+        end
+    end
+    if (!found) $fatal(1, "reset test MSI was not pending");
+    @(negedge clk);
+    rst = 1;
+    cycle();
+    if (msi_pulse || msi_accepted !== 1) $fatal(1, "device reset did not clear held MSI");
+    @(negedge clk);
+    rst = 0;
+    cycle();
+    if (msi_pulse || msi_accepted !== 1) $fatal(1, "reset MSI reappeared");
+    $finish;
+end
+endmodule
+`
+	runVerilatorSimulation(t, map[string]string{
+		"pcileech_interrupt_service.sv": sv,
+		"tb.sv":                         testbench,
+	})
+}
+
+func TestGeneratedNVMeDMACancelledCompletionDoesNotPublishData(t *testing.T) {
+	bridgeSV, err := GenerateNVMeDMABridgeSV(&SVGeneratorConfig{})
+	if err != nil {
+		t.Fatalf("GenerateNVMeDMABridgeSV: %v", err)
+	}
+	tagSV, err := GenerateDMATagServiceSV(&SVGeneratorConfig{})
+	if err != nil {
+		t.Fatalf("GenerateDMATagServiceSV: %v", err)
+	}
+	testbench := "`timescale 1ns/1ps\n" + `module tb;
+reg clk = 0;
+always #1 clk = ~clk;
+reg rst = 1;
+reg dma_enabled = 1;
+reg [15:0] pcie_id = 0;
+reg dma_wr_req = 0;
+reg [63:0] dma_wr_addr = 0;
+reg [31:0] dma_wr_data = 0;
+reg [3:0] dma_wr_be = 0;
+reg dma_wr_valid = 0;
+wire dma_wr_done;
+reg dma_rd_req = 0;
+reg [63:0] dma_rd_addr = 64'h1000;
+reg [9:0] dma_rd_len = 1;
+wire dma_rd_valid;
+wire [31:0] dma_rd_data;
+wire dma_rd_done;
+wire [127:0] tlp_tx_tdata;
+wire [3:0] tlp_tx_tkeepdw;
+wire tlp_tx_tvalid;
+wire tlp_tx_tlast;
+wire [8:0] tlp_tx_tuser;
+reg tlp_tx_tready = 1;
+reg [127:0] tlp_rx_tdata = 0;
+reg [3:0] tlp_rx_tkeepdw = 0;
+reg tlp_rx_tvalid = 0;
+reg [8:0] tlp_rx_tuser = 0;
+wire [31:0] dbg_status;
+integer i;
+reg cancelled = 0;
+
+pcileech_nvme_dma_bridge dut (
+    .rst(rst),
+    .clk(clk),
+    .dma_enabled(dma_enabled),
+    .pcie_id(pcie_id),
+    .dma_wr_req(dma_wr_req),
+    .dma_wr_addr(dma_wr_addr),
+    .dma_wr_data(dma_wr_data),
+    .dma_wr_be(dma_wr_be),
+    .dma_wr_valid(dma_wr_valid),
+    .dma_wr_done(dma_wr_done),
+    .dma_rd_req(dma_rd_req),
+    .dma_rd_addr(dma_rd_addr),
+    .dma_rd_len(dma_rd_len),
+    .dma_rd_valid(dma_rd_valid),
+    .dma_rd_data(dma_rd_data),
+    .dma_rd_done(dma_rd_done),
+    .tlp_tx_tdata(tlp_tx_tdata),
+    .tlp_tx_tkeepdw(tlp_tx_tkeepdw),
+    .tlp_tx_tvalid(tlp_tx_tvalid),
+    .tlp_tx_tlast(tlp_tx_tlast),
+    .tlp_tx_tuser(tlp_tx_tuser),
+    .tlp_tx_tready(tlp_tx_tready),
+    .tlp_rx_tdata(tlp_rx_tdata),
+    .tlp_rx_tkeepdw(tlp_rx_tkeepdw),
+    .tlp_rx_tvalid(tlp_rx_tvalid),
+    .tlp_rx_tuser(tlp_rx_tuser),
+    .dbg_status(dbg_status)
+);
+
+task cycle;
+begin
+    @(posedge clk);
+    #1ps;
+end
+endtask
+
+initial begin
+    cycle();
+    cycle();
+    @(negedge clk);
+    rst = 0;
+    dma_rd_req = 1;
+    cycle();
+    if (!tlp_tx_tvalid) $fatal(1, "DMA read did not issue a PCIe request");
+    @(negedge clk);
+    dma_rd_req = 0;
+    cycle();
+    @(negedge clk);
+    dma_enabled = 0;
+    cycle();
+    for (i = 0; i < 12; i = i + 1) begin
+        cycle();
+        if (dma_rd_valid) $fatal(1, "cancel published user data");
+        if (dma_rd_done) begin
+            cancelled = 1;
+            i = 12;
+        end
+    end
+    if (!cancelled) $fatal(1, "cancel did not notify the DMA owner");
+
+    @(negedge clk);
+    tlp_rx_tdata = 0;
+    tlp_rx_tdata[31:25] = 7'b0100101;
+    tlp_rx_tdata[47:45] = 3'b000;
+    tlp_rx_tdata[79:72] = 8'h10;
+    tlp_rx_tdata[127:96] = 32'hA5C35A7E;
+    tlp_rx_tuser[0] = 1;
+    tlp_rx_tkeepdw = 4'hF;
+    tlp_rx_tvalid = 1;
+    cycle();
+    if (dma_rd_valid) $fatal(1, "tombstoned completion published user data");
+    @(negedge clk);
+    tlp_rx_tvalid = 0;
+    tlp_rx_tuser = 0;
+    for (i = 0; i < 4; i = i + 1) begin
+        cycle();
+        if (dma_rd_valid) $fatal(1, "retired tombstone published delayed user data");
+    end
+    $finish;
+end
+endmodule
+`
+	runVerilatorSimulation(t, map[string]string{
+		"pcileech_dma_tag_service.sv": tagSV,
+		"pcileech_nvme_dma_bridge.sv": bridgeSV,
+		"tb.sv":                       testbench,
+	})
+}
+
+func TestGeneratedDMATagServiceCancelRetiresTagsExactlyOnce(t *testing.T) {
+	sv, err := GenerateDMATagServiceSV(&SVGeneratorConfig{})
+	if err != nil {
+		t.Fatalf("GenerateDMATagServiceSV: %v", err)
+	}
+	testbench := "`timescale 1ns/1ps\n" + `module tb;
+reg clk = 0;
+always #1 clk = ~clk;
+reg rst = 1;
+reg alloc_valid = 0;
+wire alloc_ready;
+wire [7:0] alloc_tag;
+reg completion_valid = 0;
+reg [7:0] completion_tag = 0;
+reg completion_error = 0;
+reg cancel_all = 0;
+wire outcome_valid;
+wire [7:0] outcome_tag;
+wire [1:0] outcome_status;
+reg outcome_ready = 1;
+wire [1:0] active_tags;
+wire [1:0] outstanding_count;
+integer cancel_count = 0;
+reg [1:0] cancel_seen = 0;
+integer i;
+reg retired = 0;
+reg [7:0] held_outcome_tag = 0;
+reg [1:0] held_outcome_status = 0;
+
+pcileech_dma_tag_service #(
+    .TAG_FIRST(8'h10),
+    .TAG_COUNT(2),
+    .TIMEOUT_WIDTH(8),
+    .TIMEOUT_CYCLES(32)
+) dut (
+    .clk(clk),
+    .rst(rst),
+    .alloc_valid(alloc_valid),
+    .alloc_ready(alloc_ready),
+    .alloc_tag(alloc_tag),
+    .completion_valid(completion_valid),
+    .completion_tag(completion_tag),
+    .completion_error(completion_error),
+    .cancel_all(cancel_all),
+    .outcome_valid(outcome_valid),
+    .outcome_tag(outcome_tag),
+    .outcome_status(outcome_status),
+    .outcome_ready(outcome_ready),
+    .active_tags(active_tags),
+    .outstanding_count(outstanding_count)
+);
+
+task cycle;
+begin
+    @(posedge clk);
+    #1ps;
+end
+endtask
+
+always @(posedge clk) begin
+    if (!rst && outcome_valid && outcome_ready) begin
+        if (outcome_status !== 2'd3) $fatal(1, "cancel surfaced a non-cancelled owner status");
+        if (outcome_tag === 8'h10) begin
+            if (cancel_seen[0]) $fatal(1, "tag 10 cancellation repeated");
+            cancel_seen[0] = 1;
+        end else if (outcome_tag === 8'h11) begin
+            if (cancel_seen[1]) $fatal(1, "tag 11 cancellation repeated");
+            cancel_seen[1] = 1;
+        end else begin
+            $fatal(1, "cancellation reported an unowned tag");
+        end
+        cancel_count = cancel_count + 1;
+    end
+end
+
+initial begin
+    cycle();
+    cycle();
+    @(negedge clk);
+    rst = 0;
+    alloc_valid = 1;
+    cycle();
+    if (active_tags !== 2'b01 || outstanding_count !== 1) $fatal(1, "first allocation failed");
+    @(negedge clk);
+    alloc_valid = 0;
+    cycle();
+    @(negedge clk);
+    alloc_valid = 1;
+    cycle();
+    if (active_tags !== 2'b11 || outstanding_count !== 2) $fatal(1, "second allocation failed");
+    @(negedge clk);
+    alloc_valid = 0;
+    outcome_ready = 0;
+    cancel_all = 1;
+    cycle();
+    @(negedge clk);
+    cancel_all = 0;
+    for (i = 0; i < 4; i = i + 1) begin
+        cycle();
+        if (outcome_valid)
+            i = 4;
+    end
+    if (!outcome_valid || outcome_status !== 2'd3) $fatal(1, "cancel status was not presented under backpressure");
+    held_outcome_tag = outcome_tag;
+    held_outcome_status = outcome_status;
+    for (i = 0; i < 4; i = i + 1) begin
+        cycle();
+        if (!outcome_valid || outcome_tag !== held_outcome_tag || outcome_status !== held_outcome_status)
+            $fatal(1, "cancel status changed while outcome_ready was low");
+        if (active_tags !== 2'b11 || outstanding_count !== 2 || alloc_ready)
+            $fatal(1, "cancel freed an issued PCIe tag before retirement");
+    end
+    @(negedge clk);
+    outcome_ready = 1;
+    for (i = 0; i < 8; i = i + 1) begin
+        cycle();
+        if (active_tags !== 2'b11 || outstanding_count !== 2 || alloc_ready)
+            $fatal(1, "accepted cancel status freed an issued PCIe tag");
+        if (cancel_count == 2)
+            i = 8;
+    end
+    if (cancel_count !== 2 || cancel_seen !== 2'b11) $fatal(1, "cancel did not report each owner exactly once");
+    @(negedge clk);
+    outcome_ready = 0;
+    cycle();
+    if (outcome_valid) $fatal(1, "cancel owner status repeated after drain");
+
+    @(negedge clk);
+    completion_valid = 1;
+    completion_tag = 8'h10;
+    cycle();
+    if (outcome_valid) $fatal(1, "late completion emitted a second owner status");
+    if (active_tags !== 2'b10 || outstanding_count !== 1) $fatal(1, "matching late completion did not retire only its tombstone");
+    if (!alloc_ready || alloc_tag !== 8'h10) $fatal(1, "retired numeric tag did not return to the allocator");
+    @(negedge clk);
+    completion_valid = 0;
+
+    for (i = 0; i < 40; i = i + 1) begin
+        cycle();
+        if (outcome_valid) $fatal(1, "cancelled timeout emitted a second owner status");
+        if (!active_tags[1]) begin
+            retired = 1;
+            i = 40;
+        end
+    end
+    if (!retired || active_tags !== 2'b00 || outstanding_count !== 0) $fatal(1, "timeout did not retire the remaining tombstone");
+    if (!alloc_ready) $fatal(1, "timeout-retired tag remained unavailable");
+    @(negedge clk);
+    completion_valid = 1;
+    completion_tag = 8'h11;
+    cycle();
+    if (outcome_valid || active_tags !== 2'b00) $fatal(1, "completion after timeout changed retired state");
+    @(negedge clk);
+    completion_valid = 0;
+    alloc_valid = 1;
+    cycle();
+    if (active_tags !== 2'b01) $fatal(1, "post-retirement allocation failed");
+    @(negedge clk);
+    alloc_valid = 0;
+    cancel_count = 0;
+    cancel_seen = 0;
+    outcome_ready = 1;
+    cancel_all = 1;
+    cycle();
+    @(negedge clk);
+    cancel_all = 0;
+    for (i = 0; i < 6; i = i + 1) begin
+        cycle();
+        if (cancel_count == 1)
+            i = 6;
+    end
+    if (cancel_count !== 1 || cancel_seen !== 2'b01 || active_tags !== 2'b01)
+        $fatal(1, "single-tag cancel did not leave one tombstone");
+    @(negedge clk);
+    rst = 1;
+    cycle();
+    if (outcome_valid || active_tags !== 2'b00 || outstanding_count !== 0) $fatal(1, "FLR/reset retirement left stale owner state");
+    @(negedge clk);
+    rst = 0;
+    cycle();
+    if (outcome_valid || active_tags !== 2'b00 || outstanding_count !== 0) $fatal(1, "FLR/reset emitted a second owner status");
+    $finish;
+end
+endmodule
+`
+	runVerilatorSimulation(t, map[string]string{
+		"pcileech_dma_tag_service.sv": sv,
+		"tb.sv":                       testbench,
+	})
+}
+
+func TestGeneratedMSIXPBANewEventDominatesSameCycleDispatchClear(t *testing.T) {
+	cfg := &SVGeneratorConfig{
+		Bar0Size: 4096,
+		HasMSIX:  true,
+		MSIXConfig: &MSIXConfig{
+			NumVectors:  4,
+			TableOffset: 0x100,
+			PBAOffset:   0x200,
+		},
+	}
+	sv, err := GenerateMSIXTableSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateMSIXTableSV: %v", err)
+	}
+	testbench := "`timescale 1ns/1ps\n" + `module tb;
+reg clk = 0;
+always #1 clk = ~clk;
+reg rst = 1;
+reg [31:0] wr_addr = 0;
+reg [31:0] wr_data = 0;
+reg [3:0] wr_be = 0;
+reg wr_valid = 0;
+reg [87:0] rd_req_ctx = 0;
+reg [31:0] rd_req_addr = 0;
+reg rd_req_valid = 0;
+wire [87:0] rd_rsp_ctx;
+wire [31:0] rd_rsp_data;
+wire rd_rsp_valid;
+reg [15:0] vector_select = 0;
+wire [63:0] vector_addr;
+wire [31:0] vector_data;
+wire vector_masked;
+reg pba_set_valid = 0;
+reg [15:0] pba_set_vector = 0;
+reg pba_clear_valid = 0;
+reg [15:0] pba_clear_vector = 0;
+wire addr_hit;
+
+pcileech_msix_table dut (
+    .rst(rst),
+    .clk(clk),
+    .wr_addr(wr_addr),
+    .wr_data(wr_data),
+    .wr_be(wr_be),
+    .wr_valid(wr_valid),
+    .rd_req_ctx(rd_req_ctx),
+    .rd_req_addr(rd_req_addr),
+    .rd_req_valid(rd_req_valid),
+    .rd_rsp_ctx(rd_rsp_ctx),
+    .rd_rsp_data(rd_rsp_data),
+    .rd_rsp_valid(rd_rsp_valid),
+    .vector_select(vector_select),
+    .vector_addr(vector_addr),
+    .vector_data(vector_data),
+    .vector_masked(vector_masked),
+    .pba_set_valid(pba_set_valid),
+    .pba_set_vector(pba_set_vector),
+    .pba_clear_valid(pba_clear_valid),
+    .pba_clear_vector(pba_clear_vector),
+    .addr_hit(addr_hit)
+);
+
+task cycle;
+begin
+    @(posedge clk);
+    #1ps;
+end
+endtask
+
+task start_pba_read;
+begin
+    @(negedge clk);
+    rd_req_addr = 32'h00000200;
+    rd_req_valid = 1;
+    cycle();
+    @(negedge clk);
+    rd_req_valid = 0;
+    cycle();
+    if (!rd_rsp_valid) $fatal(1, "PBA read response was not produced");
+end
+endtask
+
+initial begin
+    cycle();
+    cycle();
+    @(negedge clk);
+    rst = 0;
+    pba_set_valid = 1;
+    pba_set_vector = 16'd2;
+    pba_clear_valid = 1;
+    pba_clear_vector = 16'd2;
+    cycle();
+    @(negedge clk);
+    pba_set_valid = 0;
+    pba_clear_valid = 0;
+    start_pba_read();
+    if (rd_rsp_data[2] !== 1'b1) $fatal(1, "same-cycle clear erased the newly pending event");
+
+    @(negedge clk);
+    pba_clear_valid = 1;
+    pba_clear_vector = 16'd2;
+    cycle();
+    @(negedge clk);
+    pba_clear_valid = 0;
+    start_pba_read();
+    if (rd_rsp_data[2] !== 1'b0) $fatal(1, "standalone dispatch clear did not clear PBA");
+    $finish;
+end
+endmodule
+`
+	runVerilatorSimulation(t, map[string]string{
+		"msix_table_init.hex":     strings.Repeat("00000000\n", 16),
+		"pcileech_msix_table.sv": sv,
+		"tb.sv":                   testbench,
+	})
+}
+
+func TestGeneratedMSIXMaskedPendingSurvivesQuiesceAndClearsAfterResume(t *testing.T) {
+	cfg := &SVGeneratorConfig{
+		Bar0Size: 4096,
+		HasMSIX:  true,
+		MSIXConfig: &MSIXConfig{
+			NumVectors:  4,
+			TableOffset: 0x100,
+			PBAOffset:   0x200,
+		},
+	}
+	tableSV, err := GenerateMSIXTableSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateMSIXTableSV: %v", err)
+	}
+	interruptSV, err := GenerateInterruptServiceSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateInterruptServiceSV: %v", err)
+	}
+	testbench := "`timescale 1ns/1ps\n" + `module tb;
+reg clk = 0;
+always #1 clk = ~clk;
+reg rst = 1;
+reg quiesce = 0;
+reg event_valid = 0;
+reg [15:0] event_vector = 0;
+wire [15:0] vector_select;
+reg vector_masked = 1;
+reg delivery_ready = 0;
+wire delivery_valid;
+wire [15:0] delivery_vector;
+wire msi_pulse;
+wire pba_set_valid;
+wire pba_clear_valid;
+wire [15:0] pba_vector;
+reg [31:0] rd_req_addr = 0;
+reg rd_req_valid = 0;
+wire [31:0] rd_rsp_data;
+wire rd_rsp_valid;
+wire [63:0] vector_addr;
+wire [31:0] vector_data;
+wire table_vector_masked;
+wire addr_hit;
+integer accepted = 0;
+integer i;
+reg found = 0;
+
+pcileech_interrupt_service #(
+    .NUM_VECTORS(4)
+) interrupts (
+    .clk(clk),
+    .rst(rst),
+    .quiesce(quiesce),
+    .msix_mode(1'b1),
+    .function_enable(1'b1),
+    .function_mask(1'b0),
+    .event_valid(event_valid),
+    .event_vector(event_vector),
+    .vector_select(vector_select),
+    .vector_masked(vector_masked),
+    .delivery_ready(delivery_ready),
+    .delivery_valid(delivery_valid),
+    .delivery_vector(delivery_vector),
+    .msi_pulse(msi_pulse),
+    .pba_set_valid(pba_set_valid),
+    .pba_clear_valid(pba_clear_valid),
+    .pba_vector(pba_vector)
+);
+
+pcileech_msix_table msix_table_i (
+    .rst(rst),
+    .clk(clk),
+    .wr_addr(32'd0),
+    .wr_data(32'd0),
+    .wr_be(4'd0),
+    .wr_valid(1'b0),
+    .rd_req_ctx(88'd0),
+    .rd_req_addr(rd_req_addr),
+    .rd_req_valid(rd_req_valid),
+    .rd_rsp_ctx(),
+    .rd_rsp_data(rd_rsp_data),
+    .rd_rsp_valid(rd_rsp_valid),
+    .vector_select(vector_select),
+    .vector_addr(vector_addr),
+    .vector_data(vector_data),
+    .vector_masked(table_vector_masked),
+    .pba_set_valid(pba_set_valid),
+    .pba_set_vector(pba_vector),
+    .pba_clear_valid(pba_clear_valid),
+    .pba_clear_vector(pba_vector),
+    .addr_hit(addr_hit)
+);
+
+always @(posedge clk) begin
+    if (!rst && !quiesce && delivery_valid && delivery_ready)
+        accepted <= accepted + 1;
+end
+
+task cycle;
+begin
+    @(posedge clk);
+    #1ps;
+end
+endtask
+
+task read_pba;
+begin
+    @(negedge clk);
+    rd_req_addr = 32'h00000200;
+    rd_req_valid = 1;
+    cycle();
+    @(negedge clk);
+    rd_req_valid = 0;
+    cycle();
+    if (!rd_rsp_valid) $fatal(1, "PBA read response was not produced");
+end
+endtask
+
+task wait_for_delivery;
+begin
+    found = 0;
+    for (i = 0; i < 32; i = i + 1) begin
+        cycle();
+        if (delivery_valid) begin
+            found = 1;
+            i = 32;
+        end
+    end
+    if (!found) $fatal(1, "queued MSI-X event did not resume");
+end
+endtask
+
+initial begin
+    cycle();
+    cycle();
+    @(negedge clk);
+    rst = 0;
+    event_valid = 1;
+    event_vector = 16'd2;
+    cycle();
+    @(negedge clk);
+    event_valid = 0;
+    cycle();
+    read_pba();
+    if (rd_rsp_data[2] !== 1'b1 || accepted !== 0) $fatal(1, "masked event did not set PBA");
+
+    @(negedge clk);
+    quiesce = 1;
+    for (i = 0; i < 4; i = i + 1) begin
+        cycle();
+        if (delivery_valid || accepted !== 0) $fatal(1, "quiesced masked event was delivered");
+    end
+    read_pba();
+    if (rd_rsp_data[2] !== 1'b1) $fatal(1, "transient quiesce orphaned or cleared PBA");
+
+    @(negedge clk);
+    quiesce = 0;
+    vector_masked = 0;
+    wait_for_delivery();
+    if (delivery_vector !== 16'd2 || accepted !== 0) $fatal(1, "resumed MSI-X payload mismatch");
+    read_pba();
+    if (rd_rsp_data[2] !== 1'b1) $fatal(1, "PBA cleared before resumed delivery was accepted");
+    @(negedge clk);
+    delivery_ready = 1;
+    cycle();
+    if (accepted !== 1) $fatal(1, "resumed MSI-X event was not accepted exactly once");
+    @(negedge clk);
+    delivery_ready = 0;
+    cycle();
+    read_pba();
+    if (rd_rsp_data[2] !== 1'b0) $fatal(1, "accepted resumed delivery did not clear PBA");
+    for (i = 0; i < 8; i = i + 1) begin
+        cycle();
+        if (delivery_valid || accepted !== 1) $fatal(1, "resumed MSI-X event was redelivered");
+    end
+
+    @(negedge clk);
+    vector_masked = 1;
+    event_valid = 1;
+    event_vector = 16'd1;
+    cycle();
+    @(negedge clk);
+    event_valid = 0;
+    cycle();
+    read_pba();
+    if (rd_rsp_data[1] !== 1'b1) $fatal(1, "device-reset test event did not set PBA");
+    @(negedge clk);
+    rst = 1;
+    cycle();
+    @(negedge clk);
+    rst = 0;
+    vector_masked = 0;
+    cycle();
+    read_pba();
+    if (rd_rsp_data[1] !== 1'b0) $fatal(1, "device reset did not clear PBA");
+    for (i = 0; i < 12; i = i + 1) begin
+        cycle();
+        if (delivery_valid || accepted !== 1) $fatal(1, "device-reset event reappeared without PBA");
+    end
+    $finish;
+end
+endmodule
+`
+	runVerilatorSimulation(t, map[string]string{
+		"msix_table_init.hex":            strings.Repeat("00000000\n", 16),
+		"pcileech_interrupt_service.sv": interruptSV,
+		"pcileech_msix_table.sv":        tableSV,
+		"tb.sv":                          testbench,
+	})
+}
+
+func TestGeneratedNVMeMSIXReadyQuiesceEdgeReissuesWithoutResponderHang(t *testing.T) {
+	cfg := testConfig()
+	cfg.Bar0Size = 4096
+	cfg.HasMSIX = true
+	cfg.MSIXConfig = &MSIXConfig{NumVectors: 4, TableOffset: 0x100, PBAOffset: 0x200}
+	responderSV, err := GenerateNVMeResponderSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateNVMeResponderSV: %v", err)
+	}
+	bridgeSV, err := GenerateNVMeDMABridgeSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateNVMeDMABridgeSV: %v", err)
+	}
+	tagSV, err := GenerateDMATagServiceSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateDMATagServiceSV: %v", err)
+	}
+	interruptSV, err := GenerateInterruptServiceSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateInterruptServiceSV: %v", err)
+	}
+	tableSV, err := GenerateMSIXTableSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateMSIXTableSV: %v", err)
+	}
+	testbench := "`timescale 1ns/1ps\n" + `module tb;
+reg clk = 0;
+always #1 clk = ~clk;
+reg rst = 1;
+reg dma_enabled = 1;
+reg quiesce = 0;
+reg event_valid = 0;
+reg [15:0] event_vector = 0;
+wire [15:0] vector_select;
+wire irq_delivery_valid;
+wire [15:0] irq_delivery_vector;
+wire irq_delivery_ready;
+wire msi_pulse;
+wire pba_set_valid;
+wire pba_clear_valid;
+wire [15:0] pba_vector;
+reg [31:0] rd_req_addr = 0;
+reg rd_req_valid = 0;
+wire [31:0] rd_rsp_data;
+wire rd_rsp_valid;
+wire [63:0] table_vector_addr;
+wire [31:0] table_vector_data;
+wire table_vector_masked;
+wire dma_rd_req;
+wire [63:0] dma_rd_addr;
+wire [9:0] dma_rd_len;
+wire dma_rd_valid;
+wire [31:0] dma_rd_data;
+wire dma_rd_done;
+wire dma_wr_req;
+wire [63:0] dma_wr_addr;
+wire [31:0] dma_wr_data;
+wire [3:0] dma_wr_be;
+wire dma_wr_valid;
+wire dma_wr_done;
+wire [127:0] tlp_tx_tdata;
+wire [3:0] tlp_tx_tkeepdw;
+wire tlp_tx_tvalid;
+wire tlp_tx_tlast;
+wire [8:0] tlp_tx_tuser;
+wire [7:0] responder_state;
+integer msix_writes = 0;
+integer i;
+reg found = 0;
+
+pcileech_interrupt_service #(
+    .NUM_VECTORS(4)
+) interrupts (
+    .clk(clk),
+    .rst(rst),
+    .quiesce(quiesce),
+    .msix_mode(1'b1),
+    .function_enable(1'b1),
+    .function_mask(1'b0),
+    .event_valid(event_valid),
+    .event_vector(event_vector),
+    .vector_select(vector_select),
+    .vector_masked(1'b0),
+    .delivery_ready(irq_delivery_ready),
+    .delivery_valid(irq_delivery_valid),
+    .delivery_vector(irq_delivery_vector),
+    .msi_pulse(msi_pulse),
+    .pba_set_valid(pba_set_valid),
+    .pba_clear_valid(pba_clear_valid),
+    .pba_vector(pba_vector)
+);
+
+pcileech_msix_table msix_table_i (
+    .rst(rst),
+    .clk(clk),
+    .wr_addr(32'd0),
+    .wr_data(32'd0),
+    .wr_be(4'd0),
+    .wr_valid(1'b0),
+    .rd_req_ctx(88'd0),
+    .rd_req_addr(rd_req_addr),
+    .rd_req_valid(rd_req_valid),
+    .rd_rsp_ctx(),
+    .rd_rsp_data(rd_rsp_data),
+    .rd_rsp_valid(rd_rsp_valid),
+    .vector_select(vector_select),
+    .vector_addr(table_vector_addr),
+    .vector_data(table_vector_data),
+    .vector_masked(table_vector_masked),
+    .pba_set_valid(pba_set_valid),
+    .pba_set_vector(pba_vector),
+    .pba_clear_valid(pba_clear_valid),
+    .pba_clear_vector(pba_vector),
+    .addr_hit()
+);
+
+pcileech_nvme_admin_responder responder (
+    .rst(rst),
+    .clk(clk),
+    .dma_enabled(dma_enabled),
+    .cc_en(1'b1),
+    .cc_enable_wr(1'b0),
+    .cc_disable_wr(1'b0),
+    .asq_lo(32'd0),
+    .asq_hi(32'd0),
+    .acq_lo(32'd0),
+    .acq_hi(32'd0),
+    .aqa(32'd0),
+    .doorbell_wr(1'b0),
+    .doorbell_is_cq(1'b0),
+    .doorbell_qid(16'd0),
+    .doorbell_val(16'd0),
+    .msix_vector_select(),
+    .msix_vector_addr(64'h00000000FEE00000),
+    .msix_vector_data(32'h00000044),
+    .irq_delivery_valid(irq_delivery_valid),
+    .irq_delivery_ready(irq_delivery_ready),
+    .dma_rd_req(dma_rd_req),
+    .dma_rd_addr(dma_rd_addr),
+    .dma_rd_len(dma_rd_len),
+    .dma_rd_valid(dma_rd_valid),
+    .dma_rd_data(dma_rd_data),
+    .dma_rd_done(dma_rd_done),
+    .dma_wr_req(dma_wr_req),
+    .dma_wr_addr(dma_wr_addr),
+    .dma_wr_data(dma_wr_data),
+    .dma_wr_be(dma_wr_be),
+    .dma_wr_valid(dma_wr_valid),
+    .dma_wr_done(dma_wr_done),
+    .disk_req_valid(),
+    .disk_req_write(),
+    .disk_req_flush(),
+    .disk_req_lba(),
+    .disk_req_word(),
+    .disk_req_wdata(),
+    .disk_req_done(1'b0),
+    .disk_req_rdata(32'd0),
+    .disk_req_hit(1'b0),
+    .disk_busy(1'b0),
+    .disk_error(1'b0),
+    .msix_trigger(),
+    .pba_set_valid(),
+    .pba_set_vector(),
+    .id_rom_addr(),
+    .id_rom_data(32'd0),
+    .dbg_state(responder_state),
+    .dbg_active_qid(),
+    .dbg_opcode(),
+    .dbg_admin_queues(),
+    .dbg_cmd_info()
+);
+
+pcileech_nvme_dma_bridge bridge (
+    .rst(rst),
+    .clk(clk),
+    .dma_enabled(dma_enabled),
+    .pcie_id(16'd0),
+    .dma_wr_req(dma_wr_req),
+    .dma_wr_addr(dma_wr_addr),
+    .dma_wr_data(dma_wr_data),
+    .dma_wr_be(dma_wr_be),
+    .dma_wr_valid(dma_wr_valid),
+    .dma_wr_done(dma_wr_done),
+    .dma_rd_req(dma_rd_req),
+    .dma_rd_addr(dma_rd_addr),
+    .dma_rd_len(dma_rd_len),
+    .dma_rd_valid(dma_rd_valid),
+    .dma_rd_data(dma_rd_data),
+    .dma_rd_done(dma_rd_done),
+    .tlp_tx_tdata(tlp_tx_tdata),
+    .tlp_tx_tkeepdw(tlp_tx_tkeepdw),
+    .tlp_tx_tvalid(tlp_tx_tvalid),
+    .tlp_tx_tlast(tlp_tx_tlast),
+    .tlp_tx_tuser(tlp_tx_tuser),
+    .tlp_tx_tready(1'b1),
+    .tlp_rx_tdata(128'd0),
+    .tlp_rx_tkeepdw(4'd0),
+    .tlp_rx_tvalid(1'b0),
+    .tlp_rx_tuser(9'd0),
+    .dbg_status()
+);
+
+always @(posedge clk) begin
+    if (!rst && tlp_tx_tvalid && tlp_tx_tlast)
+        msix_writes <= msix_writes + 1;
+end
+
+task cycle;
+begin
+    @(posedge clk);
+    #1ps;
+end
+endtask
+
+task read_pba;
+begin
+    @(negedge clk);
+    rd_req_addr = 32'h00000200;
+    rd_req_valid = 1;
+    cycle();
+    @(negedge clk);
+    rd_req_valid = 0;
+    cycle();
+    if (!rd_rsp_valid) $fatal(1, "PBA read response was not produced");
+end
+endtask
+
+initial begin
+    cycle();
+    cycle();
+    @(negedge clk);
+    rst = 0;
+    event_valid = 1;
+    event_vector = 0;
+    cycle();
+    @(negedge clk);
+    event_valid = 0;
+    found = 0;
+    for (i = 0; i < 32; i = i + 1) begin
+        cycle();
+        if (irq_delivery_valid && irq_delivery_ready) begin
+            found = 1;
+            i = 32;
+        end
+    end
+    if (!found || responder_state !== 8'd0 || msix_writes !== 0)
+        $fatal(1, "test did not reach ready-high held delivery");
+
+    @(negedge clk);
+    quiesce = 1;
+    dma_enabled = 0;
+    cycle();
+    if (irq_delivery_valid || irq_delivery_ready || dma_wr_valid || responder_state !== 8'd0 || msix_writes !== 0)
+        $fatal(1, "BME drop accepted delivery or stranded responder");
+    for (i = 0; i < 3; i = i + 1) begin
+        cycle();
+        if (dma_wr_valid || responder_state !== 8'd0 || msix_writes !== 0)
+            $fatal(1, "disabled DMA bridge/responder did not remain idle");
+    end
+    read_pba();
+    if (rd_rsp_data[0] !== 1'b1) $fatal(1, "quiesce edge lost pending PBA");
+
+    @(negedge clk);
+    quiesce = 0;
+    dma_enabled = 1;
+    found = 0;
+    for (i = 0; i < 64; i = i + 1) begin
+        cycle();
+        if (msix_writes == 1) begin
+            found = 1;
+            i = 64;
+        end
+    end
+    if (!found) $fatal(1, "resumed event did not complete an MSI-X write");
+    for (i = 0; i < 16; i = i + 1) begin
+        cycle();
+        if (responder_state === 8'd0 && !dma_wr_valid)
+            i = 16;
+    end
+    if (responder_state !== 8'd0 || dma_wr_valid) $fatal(1, "responder remained stuck waiting for DMA write");
+    read_pba();
+    if (rd_rsp_data[0] !== 1'b0) $fatal(1, "completed resumed MSI-X write did not clear PBA");
+    for (i = 0; i < 16; i = i + 1) begin
+        cycle();
+        if (msix_writes !== 1 || irq_delivery_valid) $fatal(1, "resumed event duplicated or remained pending");
+    end
+    $finish;
+end
+endmodule
+`
+	runVerilatorSimulation(t, map[string]string{
+		"msix_table_init.hex":             strings.Repeat("00000000\n", 16),
+		"pcileech_dma_tag_service.sv":     tagSV,
+		"pcileech_interrupt_service.sv":   interruptSV,
+		"pcileech_msix_table.sv":          tableSV,
+		"pcileech_nvme_admin_responder.sv": responderSV,
+		"pcileech_nvme_dma_bridge.sv":     bridgeSV,
+		"tb.sv":                            testbench,
+	})
+}
+
+func runVerilatorSimulation(t *testing.T, sources map[string]string) {
+	t.Helper()
+	verilator, err := exec.LookPath("verilator")
+	if err != nil {
+		t.Skip("verilator not installed")
+	}
+	dir := t.TempDir()
+	var names []string
+	for name := range sources {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var paths []string
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(sources[name]), 0644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+		if strings.HasSuffix(name, ".sv") {
+			paths = append(paths, path)
+		}
+	}
+	objDir := filepath.Join(dir, "obj")
+	args := []string{"--binary", "--timing", "-Wno-fatal", "--top-module", "tb", "-Mdir", objDir, "-o", "sim"}
+	args = append(args, paths...)
+	build := exec.Command(verilator, args...)
+	build.Dir = dir
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("verilator build failed: %v\n%s", err, output)
+	}
+	sim := exec.Command(filepath.Join(objDir, "sim"))
+	sim.Dir = dir
+	if output, err := sim.CombinedOutput(); err != nil {
+		t.Fatalf("RTL simulation failed: %v\n%s", err, output)
+	}
+}
+
+func writeLegacyWrapperFixture(t *testing.T, dir string) {
+	t.Helper()
+	fixtures := map[string]string{
+		"pcileech_pcie_cfg_a7.sv": `module pcileech_pcie_cfg_a7(
+    input clk
+);
+assign ctx.cfg_interrupt = rw[206];
+endmodule`,
+		"pcileech_pcie_tlp_a7.sv": `module pcileech_pcie_tlp_a7(
+    input rst,
+    input clk_100,
+    input clk_pcie,
+    IfPCIeFifoTlp.mp_pcie dfifo,
+    IfTlp64.sink tlp_static
+);
+endmodule`,
+		"pcileech_pcie_a7.sv": `module pcileech_pcie_a7();
+IfPCIeSignals ctx();
+pcileech_pcie_cfg_a7 i_cfg(
+    .ctx(ctx)
+);
+pcileech_pcie_tlp_a7 i_tlp(
+    .clk_pcie(clk_pcie)
+);
+endmodule`,
+		"pcileech_fifo.sv": `module pcileech_fifo(input clk);
+    rw[143:128] <= 16'h0000; // CFG_SUBSYS_VEND_ID
+    rw[159:144] <= 16'h0000; // CFG_SUBSYS_ID
+    rw[175:160] <= 16'h0000; // CFG_VEND_ID
+    rw[191:176] <= 16'h0000; // CFG_DEV_ID
+    rw[199:192] <= 8'h00; // CFG_REV_ID
+    rw[203] <= 1'b1; // CFGTLP ZERO DATA
+endmodule`,
+	}
+	for name, fixture := range fixtures {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(fixture), 0644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+}
+
+func writeModernInterruptWrapperFixture(t *testing.T, dir string) {
+	t.Helper()
+	fixtures := map[string]string{
+		"pcileech_pcie_cfg_a7.sv": `interface IfPCIeSignals;
+logic cfg_interrupt;
+logic cfg_interrupt_rdy;
+endinterface
+
+module pcileech_pcie_cfg_a7(
+    input rst,
+    input clk,
+    input clk_100,
+    input clk_pcie,
+    IfPCIeSignals ctx
+);
+reg [255:0] rw = 0;
+assign ctx.cfg_interrupt = rw[206];
+endmodule`,
+		"pcileech_pcie_tlp_a7.sv": `module pcileech_pcie_tlp_a7(
+    input clk
+);
+pcileech_tlps128_bar_controller i_bar(
+    .rst(rst)
+);
+endmodule`,
+		"pcileech_pcie_a7.sv": `module pcileech_pcie_a7();
+IfPCIeSignals ctx();
+pcileech_pcie_cfg_a7 i_cfg(
+    .ctx(ctx)
+);
+pcileech_pcie_tlp_a7 i_tlp(
+    .clk(clk)
+);
+endmodule`,
+		"pcileech_fifo.sv": `module pcileech_fifo(input clk);
+    rw[143:128] <= 16'h0000; // CFG_SUBSYS_VEND_ID
+    rw[159:144] <= 16'h0000; // CFG_SUBSYS_ID
+    rw[175:160] <= 16'h0000; // CFG_VEND_ID
+    rw[191:176] <= 16'h0000; // CFG_DEV_ID
+    rw[199:192] <= 8'h00; // CFG_REV_ID
+    rw[203] <= 1'b1; // CFGTLP ZERO DATA
+endmodule`,
+	}
+	for name, fixture := range fixtures {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(fixture), 0644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+}

--- a/internal/firmware/svgen/patcher_test.go
+++ b/internal/firmware/svgen/patcher_test.go
@@ -99,6 +99,34 @@ endmodule`
 	}
 }
 
+func TestPatchCfgSVPreservesD0AndCommandRecovery(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "pcileech_pcie_cfg_a7.sv")
+	cfg := `module pcileech_pcie_cfg_a7;
+    rw[210] <= 0; // cfg_pm_force_state_en
+    rw[21] <= 0; // CFGSPACE_COMMAND_REGISTER_AUTO_SET
+endmodule`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewSVPatcher(firmware.DeviceIDs{}, dir).patchCfgSV(); err != nil {
+		t.Fatalf("patchCfgSV: %v", err)
+	}
+	patched, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"rw[210] <= 1; // cfg_pm_force_state_en",
+		"rw[21] <= 1; // CFGSPACE_COMMAND_REGISTER_AUTO_SET",
+	} {
+		if !contains(string(patched), want) {
+			t.Errorf("patched cfg wrapper missing %q", want)
+		}
+	}
+}
+
 func TestFormatPatchSummary_Empty(t *testing.T) {
 	result := FormatPatchSummary(nil)
 	if result != "  (no patches applied)" {
@@ -151,7 +179,7 @@ endmodule`,
 	if err := patcher.patchCfgSV(); err != nil {
 		t.Fatalf("patchCfgSV: %v", err)
 	}
-	if err := patcher.patchCfgInterruptHandshake(); err != nil {
+	if err := patcher.patchCfgInterruptHandshake("generated_bar_intr_req"); err != nil {
 		t.Fatalf("patchCfgInterruptHandshake: %v", err)
 	}
 	if err := patcher.patchTLPServiceWiring(); err != nil {
@@ -208,6 +236,55 @@ endmodule`,
 		if !contains(string(wrapper), want) {
 			t.Errorf("patched PCIe wrapper missing %q", want)
 		}
+	}
+}
+
+func TestPatchAllUsesTLPDeclaredInterruptPort(t *testing.T) {
+	dir := t.TempDir()
+	fixtures := map[string]string{
+		"pcileech_fifo.sv": `module pcileech_fifo;
+    rw[175:160] <= 16'h0000; // CFG_VEND_ID
+    rw[191:176] <= 16'h0000; // CFG_DEV_ID
+endmodule`,
+		"pcileech_pcie_cfg_a7.sv": `module pcileech_pcie_cfg_a7(
+    input clk
+);
+assign ctx.cfg_interrupt = rw[206];
+assign ctx.cfg_interrupt_assert = rw[205];
+endmodule`,
+		"pcileech_pcie_tlp_a7.sv": `module pcileech_pcie_tlp_a7(
+    output intr_req,
+    input clk
+);
+pcileech_tlps128_bar_controller i_bar(
+    .rst(rst)
+);
+endmodule`,
+		"pcileech_pcie_a7.sv": `module pcileech_pcie_a7();
+IfPCIeSignals ctx();
+pcileech_pcie_cfg_a7 i_cfg(
+    .ctx(ctx)
+);
+pcileech_pcie_tlp_a7 i_tlp(
+    .clk(clk)
+);
+endmodule`,
+	}
+	for name, fixture := range fixtures {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(fixture), 0644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+
+	if err := NewSVPatcher(firmware.DeviceIDs{VendorID: 0xBEEF, DeviceID: 0xCAFE}, dir).PatchAll(); err != nil {
+		t.Fatalf("PatchAll: %v", err)
+	}
+	cfg, err := os.ReadFile(filepath.Join(dir, "pcileech_pcie_cfg_a7.sv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(string(cfg), "input                   intr_req") {
+		t.Fatalf("cfg wrapper did not use TLP interrupt port:\n%s", cfg)
 	}
 }
 

--- a/internal/firmware/svgen/patcher_test.go
+++ b/internal/firmware/svgen/patcher_test.go
@@ -116,6 +116,101 @@ func TestFormatPatchSummary_WithWarnings(t *testing.T) {
 	}
 }
 
+func TestSVPatcherWiresSharedServicesThroughXilinxWrappers(t *testing.T) {
+	dir := t.TempDir()
+	fixtures := map[string]string{
+		"pcileech_pcie_cfg_a7.sv": `module pcileech_pcie_cfg_a7(
+    input clk
+);
+assign ctx.cfg_interrupt = rw[206];
+endmodule`,
+		"pcileech_pcie_tlp_a7.sv": `module pcileech_pcie_tlp_a7(
+    input clk
+);
+pcileech_tlps128_bar_controller i_bar(
+    .rst(rst)
+);
+endmodule`,
+		"pcileech_pcie_a7.sv": `module pcileech_pcie_a7();
+IfPCIeSignals ctx();
+pcileech_pcie_cfg_a7 i_cfg(
+    .ctx(ctx)
+);
+pcileech_pcie_tlp_a7 i_tlp(
+    .clk(clk)
+);
+endmodule`,
+	}
+	for name, fixture := range fixtures {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(fixture), 0644); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+
+	patcher := NewSVPatcher(firmware.DeviceIDs{}, dir)
+	if err := patcher.patchCfgSV(); err != nil {
+		t.Fatalf("patchCfgSV: %v", err)
+	}
+	if err := patcher.patchCfgInterruptHandshake(); err != nil {
+		t.Fatalf("patchCfgInterruptHandshake: %v", err)
+	}
+	if err := patcher.patchTLPServiceWiring(); err != nil {
+		t.Fatalf("patchTLPServiceWiring: %v", err)
+	}
+	if err := patcher.patchPCIeWrapperServiceWiring(); err != nil {
+		t.Fatalf("patchPCIeWrapperServiceWiring: %v", err)
+	}
+
+	cfg, err := os.ReadFile(filepath.Join(dir, "pcileech_pcie_cfg_a7.sv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"input                   generated_bar_intr_req",
+		"reg intr_req_pending = 1'b0;",
+		"else if (generated_bar_intr_req)",
+		"else if (intr_req_pending && ctx.cfg_interrupt_rdy)",
+		"assign ctx.cfg_interrupt = rw[206] | intr_req_pending;",
+	} {
+		if !contains(string(cfg), want) {
+			t.Errorf("patched cfg wrapper missing %q", want)
+		}
+	}
+
+	tlp, err := os.ReadFile(filepath.Join(dir, "pcileech_pcie_tlp_a7.sv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"IfPCIeSignals           ctx",
+		"output wire             generated_bar_intr_req",
+		".cfg_command     ( ctx.cfg_command",
+		".cfg_power_state ( ctx.cfg_pmcsr_powerstate",
+		".cfg_flr_in_process( ctx.cfg_received_func_lvl_rst",
+		".cfg_to_turnoff  ( ctx.cfg_to_turnoff",
+		".cfg_link_up     ( ctx.pl_phy_lnk_up",
+		".intr_req        ( generated_bar_intr_req",
+	} {
+		if !contains(string(tlp), want) {
+			t.Errorf("patched TLP wrapper missing %q", want)
+		}
+	}
+
+	wrapper, err := os.ReadFile(filepath.Join(dir, "pcileech_pcie_a7.sv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"wire                    generated_bar_intr_req;",
+		".generated_bar_intr_req   ( generated_bar_intr_req",
+		".ctx                        ( ctx",
+	} {
+		if !contains(string(wrapper), want) {
+			t.Errorf("patched PCIe wrapper missing %q", want)
+		}
+	}
+}
+
 func contains(s, sub string) bool {
 	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsStr(s, sub))
 }

--- a/internal/firmware/svgen/shared_services_test.go
+++ b/internal/firmware/svgen/shared_services_test.go
@@ -1,0 +1,185 @@
+package svgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/firmware/barmodel"
+	"github.com/sercanarga/pcileechgen/internal/firmware/nvme"
+)
+
+func TestGenerateSharedServiceSVBehavioralContracts(t *testing.T) {
+	cfg := testConfig()
+
+	lifecycleSV, err := GenerateLifecycleServiceSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateLifecycleServiceSV: %v", err)
+	}
+	requireSVContracts(t, lifecycleSV,
+		"module pcileech_lifecycle_service",
+		"assign device_reset = fundamental_reset || flr_in_process;",
+		"(pm_dstate == 2'b00)",
+		"active && memory_space_enable",
+		"active && bus_master_enable",
+		"if (device_reset && !reset_d)",
+	)
+
+	tagSV, err := GenerateDMATagServiceSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateDMATagServiceSV: %v", err)
+	}
+	requireSVContracts(t, tagSV,
+		"module pcileech_dma_tag_service",
+		"reg [INDEX_WIDTH-1:0] alloc_cursor",
+		"scan_index = (int'(alloc_cursor) + i) % TAG_COUNT",
+		"completion_valid && (completion_tag >= TAG_FIRST)",
+		"terminal_pending[completed_index] <= 1'b1",
+		"terminal_status[completed_index] <=",
+		"completion_error ? OUTCOME_ERROR : OUTCOME_COMPLETED",
+		"age[i] >= TIMEOUT_CYCLES - 1'b1",
+		"terminal_pending[timeout_index] <= 1'b1",
+		"terminal_status[timeout_index] <= OUTCOME_TIMEOUT",
+		"cancel_report_pending[i] <= 1'b1",
+		"if (outcome_valid && outcome_ready_i)",
+		"if (active_tags[i] && cancelled[i] && cancel_reported[i] &&",
+		"active_tags[i] <= 1'b0",
+	)
+
+	interruptSV, err := GenerateInterruptServiceSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateInterruptServiceSV: %v", err)
+	}
+	requireSVContracts(t, interruptSV,
+		"module pcileech_interrupt_service",
+		"pending[event_vector[INDEX_WIDTH-1:0]] <= 1'b1",
+		"pending[vector_select[INDEX_WIDTH-1:0]] && function_enable",
+		"!function_mask) begin",
+		"if (delivery_valid) begin",
+		"if (delivery_ready) begin",
+		"if (!(event_valid && (event_vector == delivery_vector)))",
+		"pending[delivery_vector[INDEX_WIDTH-1:0]] <= 1'b0",
+		"if (!msix_mode)",
+		"msi_pulse <= 1'b1",
+		"else if (!vector_masked)",
+		"pba_set_valid <= 1'b1",
+		"pba_clear_valid <= 1'b1",
+	)
+}
+
+func TestGenerateBarControllerWiresSharedLifecycle(t *testing.T) {
+	cfg := testConfig()
+	controllerSV, err := GenerateBarControllerSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarControllerSV: %v", err)
+	}
+	requireSVContracts(t, controllerSV,
+		"input [15:0]            cfg_command",
+		"input [1:0]             cfg_power_state",
+		"input                   cfg_flr_in_process",
+		"pcileech_lifecycle_service i_lifecycle_service",
+		".memory_space_enable ( cfg_mse",
+		".bus_master_enable   ( cfg_bme",
+		"wire in_is_bar      = io_enabled && bar_en",
+		"if ( device_reset ) begin",
+	)
+}
+
+func TestGenerateNVMeWiresSharedDMAInterruptAndPBA(t *testing.T) {
+	cfg := testConfig()
+	cfg.BARModel = &barmodel.BARModel{Size: 16 * 1024}
+	cfg.Bar0Size = 16 * 1024
+	cfg.NVMeIdentify = &nvme.IdentifyData{}
+	cfg.HasMSIX = true
+	cfg.MSIXConfig = &MSIXConfig{NumVectors: 4, TableOffset: 0x2000, PBAOffset: 0x2100}
+	cfg.DonorCapabilities.MSIXCapOffset = 0x70
+
+	controllerSV, err := GenerateBarControllerSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarControllerSV: %v", err)
+	}
+	requireSVContracts(t, controllerSV,
+		"i_nvme_interrupt_service",
+		".event_valid     ( nvme_irq_event_valid",
+		".delivery_valid  ( nvme_irq_delivery_valid",
+		".delivery_vector ( nvme_irq_delivery_vector",
+		".pba_set_valid   ( nvme_msix_pba_set_valid",
+		".pba_clear_valid ( nvme_msix_pba_clear_valid",
+		".pba_clear_vector( nvme_msix_pba_vector",
+		".irq_delivery_valid ( nvme_irq_delivery_valid",
+		"i_nvme_dma_bridge",
+		".rst                ( device_reset",
+		".dma_enabled        ( dma_enabled",
+	)
+	if strings.Contains(controllerSV, ".msix_trigger       ( nvme_msix_trigger") {
+		t.Fatal("NVMe responder and shared interrupt service must not drive the same trigger net")
+	}
+
+	bridgeSV, err := GenerateNVMeDMABridgeSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateNVMeDMABridgeSV: %v", err)
+	}
+	requireSVContracts(t, bridgeSV,
+		"input               dma_enabled",
+		"pcileech_dma_tag_service",
+		".cancel_all         ( !dma_enabled",
+		"if (rst) begin",
+		"if (!dma_enabled) begin",
+		"if (dma_enabled && (bstate != B_IDLE)) begin",
+	)
+
+	msixSV, err := GenerateMSIXTableSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateMSIXTableSV: %v", err)
+	}
+	requireSVContracts(t, msixSV,
+		"input               pba_clear_valid",
+		"input  [15:0]       pba_clear_vector",
+		"if (pba_set_valid && (pba_set_vector < NUM_VECTORS))",
+		"if (pba_clear_valid && (pba_clear_vector < NUM_VECTORS))",
+	)
+}
+
+func TestGenerateHDAWiresSharedDMAAndMSI(t *testing.T) {
+	cfg := testConfig()
+	cfg.DeviceClass = "audio"
+	cfg.ClassCode = 0x040300
+	cfg.BARModel = &barmodel.BARModel{Size: 4096}
+	cfg.NVMeIdentify = nil
+	cfg.MSIXConfig = nil
+	cfg.HasMSIX = false
+	cfg.MSIConfig = &MSIConfig{Enabled: true, AddrLo: 0xFEE00000, Data: 0x40}
+
+	controllerSV, err := GenerateBarControllerSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarControllerSV: %v", err)
+	}
+	requireSVContracts(t, controllerSV,
+		"i_hda_rirb_dma",
+		".rst            ( device_reset",
+		".dma_enabled    ( dma_enabled",
+		"i_hda_interrupt_service",
+		".rst             ( device_reset || hda_crst_falling )",
+		".event_valid     ( hda_msi_trigger",
+		".msi_pulse       ( hda_intr_req",
+	)
+
+	bridgeSV, err := GenerateHDARIRBDMASV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateHDARIRBDMASV: %v", err)
+	}
+	requireSVContracts(t, bridgeSV,
+		"input               dma_enabled",
+		"if (rst) begin",
+		"dma_req_ready <= dma_enabled",
+		"if (dma_enabled && dma_req_valid)",
+	)
+}
+
+func requireSVContracts(t *testing.T, generated string, contracts ...string) {
+	t.Helper()
+	for _, contract := range contracts {
+		if !strings.Contains(generated, contract) {
+			t.Errorf("generated SystemVerilog missing contract %q", contract)
+		}
+	}
+}

--- a/internal/firmware/svgen/shared_services_test.go
+++ b/internal/firmware/svgen/shared_services_test.go
@@ -66,6 +66,7 @@ func TestGenerateSharedServiceSVBehavioralContracts(t *testing.T) {
 	)
 }
 
+
 func TestGenerateBarControllerWiresSharedLifecycle(t *testing.T) {
 	cfg := testConfig()
 	controllerSV, err := GenerateBarControllerSV(cfg)
@@ -99,19 +100,38 @@ func TestGenerateNVMeWiresSharedDMAInterruptAndPBA(t *testing.T) {
 	}
 	requireSVContracts(t, controllerSV,
 		"i_nvme_interrupt_service",
+		".DEFER_MSIX_CLEAR  ( 1 )",
 		".event_valid     ( nvme_irq_event_valid",
 		".delivery_valid  ( nvme_irq_delivery_valid",
+		".delivery_done   ( nvme_irq_delivery_done",
 		".delivery_vector ( nvme_irq_delivery_vector",
 		".pba_set_valid   ( nvme_msix_pba_set_valid",
 		".pba_clear_valid ( nvme_msix_pba_clear_valid",
 		".pba_clear_vector( nvme_msix_pba_vector",
 		".irq_delivery_valid ( nvme_irq_delivery_valid",
+		".irq_delivery_done  ( nvme_irq_delivery_done",
+		".pba_set_vector     ( nvme_irq_event_vector",
 		"i_nvme_dma_bridge",
 		".rst                ( device_reset",
 		".dma_enabled        ( dma_enabled",
 	)
 	if strings.Contains(controllerSV, ".msix_trigger       ( nvme_msix_trigger") {
 		t.Fatal("NVMe responder and shared interrupt service must not drive the same trigger net")
+	}
+	if strings.Contains(controllerSV, ".msix_vector_select (") {
+		t.Fatal("NVMe responder must not expose a second MSI-X vector driver")
+	}
+
+	responderSV, err := GenerateNVMeResponderSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateNVMeResponderSV: %v", err)
+	}
+	requireSVContracts(t, responderSV,
+		"output reg          irq_delivery_done",
+		"pba_set_vector <= active_io ? io_vector : 16'h0000",
+	)
+	if strings.Contains(responderSV, "msix_vector_select") {
+		t.Fatal("NVMe responder retains an obsolete externally-driven MSI-X selector")
 	}
 
 	bridgeSV, err := GenerateNVMeDMABridgeSV(cfg)

--- a/internal/firmware/svgen/templates/bar_controller.sv.tmpl
+++ b/internal/firmware/svgen/templates/bar_controller.sv.tmpl
@@ -338,6 +338,7 @@ module pcileech_tlps128_bar_controller(
     wire        nvme_irq_delivery_valid;
     wire [15:0] nvme_irq_delivery_vector;
     wire        nvme_irq_delivery_ready;
+    wire        nvme_irq_delivery_done;
     wire        nvme_msix_pba_set_valid;
     wire        nvme_msix_pba_clear_valid;
     wire [15:0] nvme_msix_pba_vector;
@@ -573,7 +574,8 @@ module pcileech_tlps128_bar_controller(
 
 {{ if eq .DeviceClass "nvme" }}
     pcileech_interrupt_service #(
-        .NUM_VECTORS    ( {{ .MSIXConfig.NumVectors }} )
+        .NUM_VECTORS       ( {{ .MSIXConfig.NumVectors }} ),
+        .DEFER_MSIX_CLEAR  ( 1 )
     ) i_nvme_interrupt_service(
         .clk             ( clk                           ),
         .rst             ( device_reset                  ),
@@ -586,6 +588,7 @@ module pcileech_tlps128_bar_controller(
         .vector_select   ( nvme_msix_vector_select       ),
         .vector_masked   ( nvme_msix_vector_masked       ),
         .delivery_ready  ( nvme_irq_delivery_ready       ),
+        .delivery_done   ( nvme_irq_delivery_done        ),
         .delivery_valid  ( nvme_irq_delivery_valid       ),
         .delivery_vector ( nvme_irq_delivery_vector      ),
         .msi_pulse       ( nvme_msix_trigger             ),
@@ -696,6 +699,7 @@ module pcileech_tlps128_bar_controller(
         .vector_select   (                               ),
         .vector_masked   ( 1'b0                          ),
         .delivery_ready  ( 1'b1                          ),
+        .delivery_done   ( 1'b0                          ),
         .delivery_valid  (                               ),
         .delivery_vector (                               ),
         .msi_pulse       ( hda_intr_req                  ),
@@ -795,11 +799,11 @@ module pcileech_tlps128_bar_controller(
         .doorbell_is_cq     ( nvme_db_is_cq                 ),
         .doorbell_qid       ( nvme_db_qid                   ),
         .doorbell_val       ( nvme_db_val                   ),
-        .msix_vector_select ( nvme_irq_event_vector        ),
         .msix_vector_addr   ( nvme_msix_vector_addr         ),
         .msix_vector_data   ( nvme_msix_vector_data         ),
         .irq_delivery_valid ( nvme_irq_delivery_valid       ),
         .irq_delivery_ready ( nvme_irq_delivery_ready       ),
+        .irq_delivery_done  ( nvme_irq_delivery_done        ),
         .pba_set_valid      ( nvme_irq_event_valid          ),
         .pba_set_vector     ( nvme_irq_event_vector         ),
         .dma_rd_req         ( nvme_dma_rd_req               ),

--- a/internal/firmware/svgen/templates/bar_controller.sv.tmpl
+++ b/internal/firmware/svgen/templates/bar_controller.sv.tmpl
@@ -14,6 +14,14 @@ module pcileech_tlps128_bar_controller(
     input                   clk,
     input                   bar_en,
     input [15:0]            pcie_id,
+    input [15:0]            cfg_command,
+    input [1:0]             cfg_power_state,
+    input                   cfg_flr_in_process,
+    input                   cfg_to_turnoff,
+    input                   cfg_link_up,
+    input                   cfg_msi_enable,
+    input                   cfg_msix_enable,
+    input                   cfg_msix_function_mask,
     output                  flash_csn,
     output                  flash_sdi_dq0,
     input                   flash_sdo_dq1,
@@ -29,16 +37,45 @@ module pcileech_tlps128_bar_controller(
     output                  intr_req
 );
 
+    wire cfg_mse = (cfg_command[1] === 1'b0) ? 1'b0 : 1'b1;
+    wire cfg_bme = (cfg_command[2] === 1'b0) ? 1'b0 : 1'b1;
+    wire [1:0] cfg_dstate = (^cfg_power_state === 1'bx) ? 2'b00 : cfg_power_state;
+    wire cfg_flr = (cfg_flr_in_process === 1'b1);
+    wire cfg_turnoff = (cfg_to_turnoff === 1'b1);
+    wire cfg_link = (cfg_link_up === 1'b0) ? 1'b0 : 1'b1;
+    wire cfg_msi_enabled = (cfg_msi_enable === 1'b0) ? 1'b0 : 1'b1;
+    wire device_reset;
+    wire io_enabled;
+    wire dma_enabled;
+    wire lifecycle_quiesce;
+    wire [31:0] lifecycle_generation;
+
+    pcileech_lifecycle_service i_lifecycle_service(
+        .clk                 ( clk                  ),
+        .fundamental_reset   ( rst                  ),
+        .flr_in_process      ( cfg_flr              ),
+        .pm_dstate           ( cfg_dstate           ),
+        .memory_space_enable ( cfg_mse              ),
+        .bus_master_enable   ( cfg_bme              ),
+        .turnoff_pending     ( cfg_turnoff          ),
+        .link_up             ( cfg_link             ),
+        .device_reset        ( device_reset         ),
+        .io_enabled          ( io_enabled           ),
+        .dma_enabled         ( dma_enabled          ),
+        .quiesce             ( lifecycle_quiesce    ),
+        .generation          ( lifecycle_generation )
+    );
+
     // TLP receive
     wire in_is_wr_ready;
     bit  in_is_wr_last;
     wire in_is_first    = tlps_in.tuser[0];
-    wire in_is_bar      = bar_en && (tlps_in.tuser[8:2] != 0);
+    wire in_is_bar      = io_enabled && bar_en && (tlps_in.tuser[8:2] != 0);
     wire in_is_rd       = (in_is_first && tlps_in.tlast && ((tlps_in.tdata[31:25] == 7'b0000000) || (tlps_in.tdata[31:25] == 7'b0010000) || (tlps_in.tdata[31:24] == 8'b00000010)));
     wire in_is_wr       = in_is_wr_last || (in_is_first && in_is_wr_ready && ((tlps_in.tdata[31:25] == 7'b0100000) || (tlps_in.tdata[31:25] == 7'b0110000) || (tlps_in.tdata[31:24] == 8'b01000010)));
 
     always @ ( posedge clk )
-        if ( rst ) begin
+        if ( device_reset ) begin
             in_is_wr_last <= 0;
         end
         else if ( tlps_in.tvalid ) begin
@@ -101,7 +138,7 @@ module pcileech_tlps128_bar_controller(
     IfAXIS128 tlps_rdeng();
 
     pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
-        .rst            ( rst                           ),
+        .rst            ( device_reset                  ),
         .clk            ( clk                           ),
         .pcie_id        ( pcie_id                       ),
         .tlps_in        ( tlps_in                       ),
@@ -120,7 +157,7 @@ module pcileech_tlps128_bar_controller(
     IfAXIS128 tlps_rdeng();
 
     pcileech_tlps128_bar_rdengine i_pcileech_tlps128_bar_rdengine(
-        .rst            ( rst                           ),
+        .rst            ( device_reset                  ),
         .clk            ( clk                           ),
         .pcie_id        ( pcie_id                       ),
         .tlps_in        ( tlps_in                       ),
@@ -139,7 +176,7 @@ module pcileech_tlps128_bar_controller(
     wire        wrengine_ready;
 
     pcileech_tlps128_bar_wrengine i_pcileech_tlps128_bar_wrengine(
-        .rst            ( rst                           ),
+        .rst            ( device_reset                  ),
         .clk            ( clk                           ),
         .tlps_in        ( tlps_in                       ),
         .tlps_in_valid  ( tlps_in.tvalid && in_is_bar && in_is_wr ),
@@ -292,13 +329,18 @@ module pcileech_tlps128_bar_controller(
     wire        msix_rsp_valid;
     wire        msix_addr_hit;
 {{ if eq .DeviceClass "nvme" }}
-    // NVMe responder <-> MSI-X table (per-vector select) and <-> BRAM disk cache.
+    wire [15:0] nvme_irq_event_vector;
+    wire        nvme_irq_event_valid;
     wire [15:0] nvme_msix_vector_select;
     wire [63:0] nvme_msix_vector_addr;
     wire [31:0] nvme_msix_vector_data;
     wire        nvme_msix_vector_masked;
+    wire        nvme_irq_delivery_valid;
+    wire [15:0] nvme_irq_delivery_vector;
+    wire        nvme_irq_delivery_ready;
     wire        nvme_msix_pba_set_valid;
-    wire [15:0] nvme_msix_pba_set_vector;
+    wire        nvme_msix_pba_clear_valid;
+    wire [15:0] nvme_msix_pba_vector;
 
     wire        nvme_disk_req_valid;
     wire        nvme_disk_req_write;
@@ -366,7 +408,7 @@ module pcileech_tlps128_bar_controller(
 {{ else }}
     pcileech_bar_impl_zerowrite4k i_bar0(
 {{ end }}
-        .rst            ( rst                           ),
+        .rst            ( device_reset                  ),
         .clk            ( clk                           ),
         .wr_addr        ( {{ if .BARModel }}wr_addr_bar0{{ else }}wr_addr{{ end }}                       ),
         .wr_be          ( wr_be                         ),
@@ -416,7 +458,7 @@ module pcileech_tlps128_bar_controller(
 {{ if .LatencyConfig }}
     tlp_latency_emulator i_latency_emu(
         .clk            ( clk                           ),
-        .rst            ( rst                           ),
+        .rst            ( device_reset                  ),
         .crst_falling   ( hda_crst_falling              ),
         .req_valid      ( !bar0_buf_empty               ), // data available in buffer
         .req_ctx        ( bar0_buf_ctx_w                ), // read from buffer head
@@ -502,6 +544,12 @@ module pcileech_tlps128_bar_controller(
     reg msix_enable_reg;        // driven by CfgWr0 snoop when MSI-X present; else 0
     reg msix_function_mask_reg;
 {{ if .MSIXConfig }}
+    wire msix_enable_effective =
+        (cfg_msix_enable === 1'b1) ? 1'b1 :
+        (cfg_msix_enable === 1'b0) ? 1'b0 : msix_enable_reg;
+    wire msix_mask_effective =
+        (cfg_msix_function_mask === 1'b1) ? 1'b1 :
+        (cfg_msix_function_mask === 1'b0) ? 1'b0 : msix_function_mask_reg;
     // Snoop CfgWr0 to MSI-X Message Control (cap @ {{ hex04 .DonorCapabilities.MSIXCapOffset }}) for enable/mask bits.
     
     wire        cfg_wren = tlps_in.tvalid && tlps_in.tuser[0] && (tlps_in.tdata[31:25] == 7'b0100010);
@@ -512,7 +560,7 @@ module pcileech_tlps128_bar_controller(
     localparam [9:0] MSIX_CAP_DWORD = 16'h{{ hex04 .DonorCapabilities.MSIXCapOffset }} >> 2;
     
     always @(posedge clk) begin
-        if (rst) begin
+        if (device_reset) begin
             msix_enable_reg <= 1'b0;
             msix_function_mask_reg <= 1'b0;
         end else if (cfg_wren && (cfg_addr == MSIX_CAP_DWORD)) begin
@@ -523,12 +571,36 @@ module pcileech_tlps128_bar_controller(
         end
     end
 
+{{ if eq .DeviceClass "nvme" }}
+    pcileech_interrupt_service #(
+        .NUM_VECTORS    ( {{ .MSIXConfig.NumVectors }} )
+    ) i_nvme_interrupt_service(
+        .clk             ( clk                           ),
+        .rst             ( device_reset                  ),
+        .quiesce         ( lifecycle_quiesce             ),
+        .msix_mode       ( 1'b1                          ),
+        .function_enable ( msix_enable_effective          ),
+        .function_mask   ( msix_mask_effective            ),
+        .event_valid     ( nvme_irq_event_valid          ),
+        .event_vector    ( nvme_irq_event_vector         ),
+        .vector_select   ( nvme_msix_vector_select       ),
+        .vector_masked   ( nvme_msix_vector_masked       ),
+        .delivery_ready  ( nvme_irq_delivery_ready       ),
+        .delivery_valid  ( nvme_irq_delivery_valid       ),
+        .delivery_vector ( nvme_irq_delivery_vector      ),
+        .msi_pulse       ( nvme_msix_trigger             ),
+        .pba_set_valid   ( nvme_msix_pba_set_valid       ),
+        .pba_clear_valid ( nvme_msix_pba_clear_valid     ),
+        .pba_vector      ( nvme_msix_pba_vector          )
+    );
+{{ end }}
+
     pcileech_msix_table #(
         .NUM_VECTORS    ( {{ .MSIXConfig.NumVectors }}  ),
         .TABLE_OFFSET   ( 32'h{{ printf "%08X" .MSIXConfig.TableOffset }} ),
         .PBA_OFFSET     ( 32'h{{ printf "%08X" .MSIXConfig.PBAOffset }}   )
     ) i_msix_table(
-        .rst            ( rst                           ),
+        .rst            ( device_reset                  ),
         .clk            ( clk                           ),
         .wr_addr        ( {{ if .BARModel }}wr_addr_bar0{{ else }}wr_addr{{ end }}                       ),
         .wr_data        ( wr_data                       ),
@@ -546,13 +618,17 @@ module pcileech_tlps128_bar_controller(
         .vector_data    ( nvme_msix_vector_data         ),
         .vector_masked  ( nvme_msix_vector_masked       ),
         .pba_set_valid  ( nvme_msix_pba_set_valid       ),
-        .pba_set_vector ( nvme_msix_pba_set_vector      ),
+        .pba_set_vector ( nvme_msix_pba_vector          ),
+        .pba_clear_valid( nvme_msix_pba_clear_valid     ),
+        .pba_clear_vector( nvme_msix_pba_vector         ),
 {{ else }}        .vector_select  ( 16'd0                         ),
         .vector_addr    (                               ),
         .vector_data    (                               ),
         .vector_masked  (                               ),
         .pba_set_valid  ( 1'b0                          ),
-        .pba_set_vector (                               ),
+        .pba_set_vector ( 16'd0                         ),
+        .pba_clear_valid( 1'b0                          ),
+        .pba_clear_vector( 16'd0                        ),
 {{ end }}        .addr_hit       ( msix_addr_hit                 )
     );
 {{ end }}
@@ -581,8 +657,9 @@ module pcileech_tlps128_bar_controller(
     wire [8:0]   hda_tlp_tx_tuser;
 
     pcileech_hda_rirb_dma i_hda_rirb_dma(
-        .rst            ( rst                           ),
+        .rst            ( device_reset                  ),
         .clk            ( clk                           ),
+        .dma_enabled    ( dma_enabled                   ),
         .pcie_id        ( pcie_id                       ),
         .crst_falling   ( hda_crst_falling              ),
         .dma_req_valid  ( hda_dma_req_valid             ),
@@ -601,25 +678,30 @@ module pcileech_tlps128_bar_controller(
         .tlp_tx_tready  ( tlps_out.tready && !dma_yield  )
     );
 
-    // ========================================================================
-    // HDA MSI Interrupt Generator
-    // Fires an intr_req pulse when RIRBINTSTS.INTFL transitions 0->1.
-    // The cfg module routes this to cfg_interrupt for MSI TLP generation -
-    // without MSI, the hdaudio.sys driver polls RIRBWP endlessly and
-    // eventually times out with Code 10.
-    // ========================================================================
     wire        hda_msi_trigger;
     wire [31:0] hda_rirbintsts;
     wire        hda_intr_req;
 
-    pcileech_hda_msi i_hda_msi(
-        .rst            ( rst                           ),
-        .clk            ( clk                           ),
-        .pcie_id        ( pcie_id                       ),
-        .msi_trigger    ( hda_msi_trigger               ),
-        .rirbintsts     ( hda_rirbintsts                ),
-        .crst_falling   ( hda_crst_falling              ),
-        .intr_req       ( hda_intr_req                  )
+    pcileech_interrupt_service #(
+        .NUM_VECTORS    ( 1 )
+    ) i_hda_interrupt_service(
+        .clk             ( clk                           ),
+        .rst             ( device_reset || hda_crst_falling ),
+        .quiesce         ( lifecycle_quiesce             ),
+        .msix_mode       ( 1'b0                          ),
+        .function_enable ( cfg_msi_enabled                ),
+        .function_mask   ( 1'b0                          ),
+        .event_valid     ( hda_msi_trigger               ),
+        .event_vector    ( 16'd0                         ),
+        .vector_select   (                               ),
+        .vector_masked   ( 1'b0                          ),
+        .delivery_ready  ( 1'b1                          ),
+        .delivery_valid  (                               ),
+        .delivery_vector (                               ),
+        .msi_pulse       ( hda_intr_req                  ),
+        .pba_set_valid   (                               ),
+        .pba_clear_valid (                               ),
+        .pba_vector      (                               )
     );
 
 {{ end }}
@@ -698,8 +780,9 @@ module pcileech_tlps128_bar_controller(
         .NVME_TIMING_ENABLE      ( NVME_TIMING_ENABLED          ),
         .NVME_TIMING_CLK_HZ      ( NVME_TIMING_CLOCK_HZ         )
     ) i_nvme_responder(
-        .rst                ( rst                           ),
+        .rst                ( device_reset                  ),
         .clk                ( clk                           ),
+        .dma_enabled        ( dma_enabled                   ),
         .cc_en              ( nvme_reg_cc[0]                ),
         .cc_enable_wr       ( nvme_cc_enable_wr             ),
         .cc_disable_wr      ( nvme_cc_disable_wr            ),
@@ -712,14 +795,13 @@ module pcileech_tlps128_bar_controller(
         .doorbell_is_cq     ( nvme_db_is_cq                 ),
         .doorbell_qid       ( nvme_db_qid                   ),
         .doorbell_val       ( nvme_db_val                   ),
-        .msix_enable        ( msix_enable_reg               ),
-        .msix_function_mask ( msix_function_mask_reg        ),
-        .msix_vector_select ( nvme_msix_vector_select       ),
+        .msix_vector_select ( nvme_irq_event_vector        ),
         .msix_vector_addr   ( nvme_msix_vector_addr         ),
         .msix_vector_data   ( nvme_msix_vector_data         ),
-        .msix_vector_masked ( nvme_msix_vector_masked       ),
-        .pba_set_valid      ( nvme_msix_pba_set_valid       ),
-        .pba_set_vector     ( nvme_msix_pba_set_vector      ),
+        .irq_delivery_valid ( nvme_irq_delivery_valid       ),
+        .irq_delivery_ready ( nvme_irq_delivery_ready       ),
+        .pba_set_valid      ( nvme_irq_event_valid          ),
+        .pba_set_vector     ( nvme_irq_event_vector         ),
         .dma_rd_req         ( nvme_dma_rd_req               ),
         .dma_rd_addr        ( nvme_dma_rd_addr              ),
         .dma_rd_len         ( nvme_dma_rd_len               ),
@@ -743,7 +825,7 @@ module pcileech_tlps128_bar_controller(
         .disk_req_hit       ( nvme_disk_req_hit             ),
         .disk_busy          ( nvme_disk_busy                ),
         .disk_error         ( nvme_disk_error               ),
-        .msix_trigger       ( nvme_msix_trigger             ),
+        .msix_trigger       (                               ),
         .id_rom_addr        ( nvme_id_rom_addr              ),
         .id_rom_data        ( nvme_id_rom_data              ),
         .dbg_state          ( nvme_resp_dbg_state           ),
@@ -761,7 +843,7 @@ module pcileech_tlps128_bar_controller(
     pcileech_bram_disk #(
         .DISK_WORDS              ( NVME_BRAM_DISK_WORDS )
     ) i_nvme_bram_disk(
-        .rst            ( rst                       ),
+        .rst            ( device_reset              ),
         .clk            ( clk                       ),
         .req_valid      ( nvme_disk_req_valid       ),
         .req_write      ( nvme_disk_req_write       ),
@@ -779,8 +861,9 @@ module pcileech_tlps128_bar_controller(
     );
 
     pcileech_nvme_dma_bridge i_nvme_dma_bridge(
-        .rst                ( rst                           ),
+        .rst                ( device_reset                  ),
         .clk                ( clk                           ),
+        .dma_enabled        ( dma_enabled                   ),
         .pcie_id            ( pcie_id                       ),
         .dma_wr_req         ( nvme_dma_wr_req               ),
         .dma_wr_addr        ( nvme_dma_wr_addr              ),
@@ -816,8 +899,6 @@ module pcileech_tlps128_bar_controller(
         nvme_id_rom_data_r <= nvme_identify_rom[nvme_id_rom_addr[11:2]];
     assign nvme_id_rom_data = nvme_id_rom_data_r;
 
-// FIFO buffers DMA bridge TLPs before muxing onto tlps_out.
-// DMA TLPs on separate stream (tlps_dma_out); BAR reads on tlps_out.
     wire         nvme_dma_fifo_full;
     wire         nvme_dma_fifo_first;
     wire         nvme_dma_fifo_tlast;
@@ -825,19 +906,22 @@ module pcileech_tlps128_bar_controller(
     wire [127:0] nvme_dma_fifo_tdata;
     wire         nvme_dma_fifo_tvalid;
     reg  [10:0]  nvme_dma_pkt_count;
+    reg  [2:0]   nvme_dma_burst_count;
+    wire         nvme_dma_yield = (nvme_dma_burst_count == 3'd7);
+    wire         nvme_dma_select = nvme_dma_fifo_tvalid && !nvme_dma_yield;
 
     wire nvme_dma_fifo_wr_en = nvme_tlp_tx_tvalid && !nvme_dma_fifo_full;
+    wire nvme_dma_fifo_rd_en = tlps_out.tready && nvme_dma_select;
     wire nvme_dma_pkt_inc    = nvme_dma_fifo_wr_en && nvme_tlp_tx_tlast;
-    wire nvme_dma_pkt_dec    = nvme_dma_fifo_tvalid && nvme_dma_fifo_tlast;
+    wire nvme_dma_pkt_dec    = nvme_dma_fifo_rd_en && nvme_dma_fifo_tlast;
     wire [10:0] nvme_dma_pkt_count_next = nvme_dma_pkt_count +
                                           {10'h000, nvme_dma_pkt_inc} -
                                           {10'h000, nvme_dma_pkt_dec};
-    wire nvme_dma_fifo_rd_en = tlps_dma_out.tready && (nvme_dma_pkt_count_next != 11'd0);
 
     assign nvme_tlp_tx_tready = !nvme_dma_fifo_full;
 
     fifo_134_134_clk1_bar_rdrsp i_fifo_nvme_dma(
-        .srst       ( rst                                                        ),
+        .srst       ( device_reset                                                ),
         .clk        ( clk                                                        ),
         .din        ( { nvme_tlp_tx_tuser[0], nvme_tlp_tx_tlast,
                         nvme_tlp_tx_tkeepdw, nvme_tlp_tx_tdata }                ),
@@ -852,23 +936,34 @@ module pcileech_tlps128_bar_controller(
     );
 
     always @(posedge clk) begin
-        nvme_dma_pkt_count <= rst ? 11'd0 : nvme_dma_pkt_count_next;
+        if (device_reset) begin
+            nvme_dma_pkt_count <= 11'd0;
+            nvme_dma_burst_count <= 3'd0;
+        end else begin
+            nvme_dma_pkt_count <= nvme_dma_pkt_count_next;
+            if (nvme_dma_fifo_rd_en)
+                nvme_dma_burst_count <= nvme_dma_burst_count + 1'b1;
+            else
+                nvme_dma_burst_count <= 3'd0;
+        end
     end
 
-    assign tlps_dma_out.tdata    = nvme_dma_fifo_tdata;
-    assign tlps_dma_out.tkeepdw  = nvme_dma_fifo_tkeepdw;
-    assign tlps_dma_out.tvalid   = nvme_dma_fifo_tvalid;
-    assign tlps_dma_out.tlast    = nvme_dma_fifo_tlast;
-    assign tlps_dma_out.tuser    = {7'h00, nvme_dma_fifo_tlast, nvme_dma_fifo_first};
-    assign tlps_dma_out.has_data = (nvme_dma_pkt_count_next != 11'd0);
+    assign tlps_out.tdata    = nvme_dma_select ? nvme_dma_fifo_tdata   : tlps_rdeng.tdata;
+    assign tlps_out.tkeepdw  = nvme_dma_select ? nvme_dma_fifo_tkeepdw : tlps_rdeng.tkeepdw;
+    assign tlps_out.tvalid   = nvme_dma_select ? nvme_dma_fifo_tvalid  : tlps_rdeng.tvalid;
+    assign tlps_out.tlast    = nvme_dma_select ? nvme_dma_fifo_tlast   : tlps_rdeng.tlast;
+    assign tlps_out.tuser    = nvme_dma_select ?
+                              {7'h00, nvme_dma_fifo_tlast, nvme_dma_fifo_first} :
+                              tlps_rdeng.tuser;
+    assign tlps_out.has_data = (nvme_dma_pkt_count_next != 11'd0) || tlps_rdeng.has_data;
+    assign tlps_rdeng.tready = tlps_out.tready && !nvme_dma_select;
 
-    assign tlps_out.tdata    = tlps_rdeng.tdata;
-    assign tlps_out.tkeepdw  = tlps_rdeng.tkeepdw;
-    assign tlps_out.tvalid   = tlps_rdeng.tvalid;
-    assign tlps_out.tlast    = tlps_rdeng.tlast;
-    assign tlps_out.tuser    = tlps_rdeng.tuser;
-    assign tlps_out.has_data = tlps_rdeng.has_data;
-    assign tlps_rdeng.tready = tlps_out.tready;
+    assign tlps_dma_out.tdata    = 128'h0;
+    assign tlps_dma_out.tkeepdw  = 4'h0;
+    assign tlps_dma_out.tvalid   = 1'b0;
+    assign tlps_dma_out.tlast    = 1'b0;
+    assign tlps_dma_out.tuser    = 9'h0;
+    assign tlps_dma_out.has_data = 1'b0;
 {{ end }}
 
 {{ if and (eq .DeviceClass "audio") .BARModel }}{{ if not (and (eq .DeviceClass "nvme") .NVMeIdentify) }}
@@ -912,7 +1007,7 @@ module pcileech_tlps128_bar_controller(
 
     // BAR1: address loopback
     pcileech_bar_impl_loopaddr i_bar1(
-        .rst            ( rst                           ),
+        .rst            ( device_reset                  ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
         .wr_be          ( wr_be                         ),
@@ -930,7 +1025,7 @@ module pcileech_tlps128_bar_controller(
     wire        bar2_intr_req;
 
     pcileech_bar_impl_msi i_bar2(
-        .rst            ( rst                           ),
+        .rst            ( device_reset                  ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
         .wr_be          ( wr_be                         ),
@@ -950,7 +1045,7 @@ module pcileech_tlps128_bar_controller(
     generate
         for (gi = 3; gi < 7; gi = gi + 1) begin : gen_bar_none
             pcileech_bar_impl_none i_bar_none(
-                .rst            ( rst                           ),
+                .rst            ( device_reset                  ),
                 .clk            ( clk                           ),
                 .wr_addr        ( wr_addr                       ),
                 .wr_be          ( wr_be                         ),
@@ -966,6 +1061,6 @@ module pcileech_tlps128_bar_controller(
         end
     endgenerate
 
-    assign intr_req = bar2_intr_req{{ if eq .DeviceClass "audio" }} | hda_intr_req{{ end }}{{ if eq .DeviceClass "nvme" }} | nvme_msix_trigger{{ end }};
+    assign intr_req = !lifecycle_quiesce && (bar2_intr_req{{ if eq .DeviceClass "audio" }} | hda_intr_req{{ end }}{{ if eq .DeviceClass "nvme" }} | nvme_msix_trigger{{ end }});
 
 endmodule

--- a/internal/firmware/svgen/templates/dma_tag_service.sv.tmpl
+++ b/internal/firmware/svgen/templates/dma_tag_service.sv.tmpl
@@ -1,0 +1,192 @@
+`timescale 1ns / 1ps
+
+module pcileech_dma_tag_service #(
+    parameter [7:0] TAG_FIRST = 8'h10,
+    parameter integer TAG_COUNT = 16,
+    parameter integer TIMEOUT_WIDTH = 24,
+    parameter [TIMEOUT_WIDTH-1:0] TIMEOUT_CYCLES = {TIMEOUT_WIDTH{1'b1}}
+)(
+    input                         clk,
+    input                         rst,
+    input                         alloc_valid,
+    output reg                    alloc_ready,
+    output reg [7:0]              alloc_tag,
+    input                         completion_valid,
+    input [7:0]                   completion_tag,
+    input                         completion_error,
+    input                         cancel_all,
+    output reg                    outcome_valid,
+    input tri1                    outcome_ready,
+    output reg [7:0]              outcome_tag,
+    output reg [1:0]              outcome_status,
+    output reg [TAG_COUNT-1:0]    active_tags,
+    output reg [$clog2(TAG_COUNT+1)-1:0] outstanding_count
+);
+    localparam [1:0] OUTCOME_COMPLETED = 2'd0;
+    localparam [1:0] OUTCOME_ERROR     = 2'd1;
+    localparam [1:0] OUTCOME_TIMEOUT   = 2'd2;
+    localparam [1:0] OUTCOME_CANCELLED = 2'd3;
+    localparam integer INDEX_WIDTH = (TAG_COUNT <= 1) ? 1 : $clog2(TAG_COUNT);
+
+    reg [TIMEOUT_WIDTH-1:0] age [0:TAG_COUNT-1];
+    reg [1:0] terminal_status [0:TAG_COUNT-1];
+    reg [TAG_COUNT-1:0] cancelled;
+    reg [TAG_COUNT-1:0] cancel_reported;
+    reg [TAG_COUNT-1:0] cancel_report_pending;
+    reg [TAG_COUNT-1:0] terminal_pending;
+    reg [INDEX_WIDTH-1:0] alloc_cursor;
+    integer i;
+    integer scan_index;
+    integer selected;
+    integer completed_index;
+    integer outcome_index;
+    reg timeout_found;
+    reg [INDEX_WIDTH-1:0] timeout_index;
+    reg cancel_found;
+    reg [INDEX_WIDTH-1:0] cancel_index;
+    reg terminal_found;
+    reg [INDEX_WIDTH-1:0] terminal_index;
+    wire outcome_ready_i = outcome_ready;
+
+    always @(*) begin
+        alloc_ready = 1'b0;
+        alloc_tag = TAG_FIRST;
+        selected = -1;
+        scan_index = 0;
+        completed_index = {24'd0, completion_tag} - {24'd0, TAG_FIRST};
+        outcome_index = {24'd0, outcome_tag} - {24'd0, TAG_FIRST};
+        outstanding_count = 0;
+        timeout_found = 1'b0;
+        timeout_index = 0;
+        cancel_found = 1'b0;
+        cancel_index = 0;
+        terminal_found = 1'b0;
+        terminal_index = 0;
+        for (i = 0; i < TAG_COUNT; i = i + 1) begin
+            if (active_tags[i]) begin
+                outstanding_count = outstanding_count + 1'b1;
+                if (!timeout_found && !terminal_pending[i] &&
+                    (TIMEOUT_CYCLES != 0) &&
+                    (age[i] >= TIMEOUT_CYCLES - 1'b1)) begin
+                    timeout_found = 1'b1;
+                    timeout_index = INDEX_WIDTH'(i);
+                end
+            end
+            if (!cancel_found && cancel_report_pending[i]) begin
+                cancel_found = 1'b1;
+                cancel_index = INDEX_WIDTH'(i);
+            end
+            if (!terminal_found && terminal_pending[i] && !cancelled[i]) begin
+                terminal_found = 1'b1;
+                terminal_index = INDEX_WIDTH'(i);
+            end
+        end
+        if (!(|cancel_report_pending) && !cancel_all) begin
+            for (i = 0; i < TAG_COUNT; i = i + 1) begin
+                scan_index = (int'(alloc_cursor) + i) % TAG_COUNT;
+                if ((selected < 0) && !active_tags[scan_index]) begin
+                    selected = scan_index;
+                    alloc_ready = 1'b1;
+                    alloc_tag = TAG_FIRST + 8'(scan_index);
+                end
+            end
+        end
+    end
+
+    always @(posedge clk) begin
+        if (rst) begin
+            active_tags <= {TAG_COUNT{1'b0}};
+            cancelled <= {TAG_COUNT{1'b0}};
+            cancel_reported <= {TAG_COUNT{1'b0}};
+            cancel_report_pending <= {TAG_COUNT{1'b0}};
+            terminal_pending <= {TAG_COUNT{1'b0}};
+            alloc_cursor <= {INDEX_WIDTH{1'b0}};
+            outcome_valid <= 1'b0;
+            outcome_tag <= TAG_FIRST;
+            outcome_status <= OUTCOME_CANCELLED;
+            for (i = 0; i < TAG_COUNT; i = i + 1) begin
+                age[i] <= {TIMEOUT_WIDTH{1'b0}};
+                terminal_status[i] <= OUTCOME_COMPLETED;
+            end
+        end else begin
+            for (i = 0; i < TAG_COUNT; i = i + 1) begin
+                if (active_tags[i] && !terminal_pending[i])
+                    age[i] <= age[i] + 1'b1;
+                if (cancel_all && active_tags[i] && !cancelled[i] &&
+                    !terminal_pending[i]) begin
+                    cancelled[i] <= 1'b1;
+                    cancel_report_pending[i] <= 1'b1;
+                end
+                if (active_tags[i] && cancelled[i] && cancel_reported[i] &&
+                    terminal_pending[i]) begin
+                    active_tags[i] <= 1'b0;
+                    cancelled[i] <= 1'b0;
+                    cancel_reported[i] <= 1'b0;
+                    terminal_pending[i] <= 1'b0;
+                    age[i] <= {TIMEOUT_WIDTH{1'b0}};
+                end
+            end
+
+            if (outcome_valid && outcome_ready_i) begin
+                outcome_valid <= 1'b0;
+                if (outcome_index >= 0 && outcome_index < TAG_COUNT) begin
+                    if (outcome_status == OUTCOME_CANCELLED) begin
+                        cancel_reported[outcome_index] <= 1'b1;
+                    end else begin
+                        active_tags[outcome_index] <= 1'b0;
+                        terminal_pending[outcome_index] <= 1'b0;
+                        age[outcome_index] <= {TIMEOUT_WIDTH{1'b0}};
+                    end
+                end
+            end else if (!outcome_valid && cancel_found) begin
+                cancel_report_pending[cancel_index] <= 1'b0;
+                outcome_valid <= 1'b1;
+                outcome_tag <= TAG_FIRST + 8'(cancel_index);
+                outcome_status <= OUTCOME_CANCELLED;
+            end else if (!outcome_valid && terminal_found) begin
+                outcome_valid <= 1'b1;
+                outcome_tag <= TAG_FIRST + 8'(terminal_index);
+                outcome_status <= terminal_status[terminal_index];
+            end
+
+            if (completion_valid && (completion_tag >= TAG_FIRST) &&
+                (completed_index < TAG_COUNT) && active_tags[completed_index] &&
+                !terminal_pending[completed_index]) begin
+                if (cancelled[completed_index] && cancel_reported[completed_index]) begin
+                    active_tags[completed_index] <= 1'b0;
+                    cancelled[completed_index] <= 1'b0;
+                    cancel_reported[completed_index] <= 1'b0;
+                    age[completed_index] <= {TIMEOUT_WIDTH{1'b0}};
+                end else begin
+                    terminal_pending[completed_index] <= 1'b1;
+                    terminal_status[completed_index] <=
+                        completion_error ? OUTCOME_ERROR : OUTCOME_COMPLETED;
+                end
+            end else if (timeout_found) begin
+                if (cancelled[timeout_index] && cancel_reported[timeout_index]) begin
+                    active_tags[timeout_index] <= 1'b0;
+                    cancelled[timeout_index] <= 1'b0;
+                    cancel_reported[timeout_index] <= 1'b0;
+                    age[timeout_index] <= {TIMEOUT_WIDTH{1'b0}};
+                end else begin
+                    terminal_pending[timeout_index] <= 1'b1;
+                    terminal_status[timeout_index] <= OUTCOME_TIMEOUT;
+                end
+            end
+
+            if (alloc_valid && alloc_ready) begin
+                active_tags[selected] <= 1'b1;
+                cancelled[selected] <= 1'b0;
+                cancel_reported[selected] <= 1'b0;
+                cancel_report_pending[selected] <= 1'b0;
+                terminal_pending[selected] <= 1'b0;
+                terminal_status[selected] <= OUTCOME_COMPLETED;
+                age[selected] <= {TIMEOUT_WIDTH{1'b0}};
+                if (selected >= TAG_COUNT - 1)
+                    alloc_cursor <= {INDEX_WIDTH{1'b0}};
+                else
+                    alloc_cursor <= INDEX_WIDTH'(selected + 1);
+            end
+        end
+    end
+endmodule

--- a/internal/firmware/svgen/templates/hda_rirb_dma.sv.tmpl
+++ b/internal/firmware/svgen/templates/hda_rirb_dma.sv.tmpl
@@ -13,6 +13,7 @@
 module pcileech_hda_rirb_dma(
     input               rst,
     input               clk,
+    input               dma_enabled,
 
     input [15:0]        pcie_id,        // our BDF, goes into requester ID
 
@@ -64,7 +65,7 @@ module pcileech_hda_rirb_dma(
     always @(posedge clk) begin
         if (rst) begin
             dstate          <= D_IDLE;
-            dma_req_ready   <= 1'b1;
+            dma_req_ready   <= 1'b0;
             dma_done        <= 1'b0;
             d_tag           <= 8'h80;
             d_resp_lo       <= 32'h0;
@@ -80,7 +81,7 @@ module pcileech_hda_rirb_dma(
 
             // CRST falling: reset to IDLE and clear ALL latched data. Without clearing,
             // a still-asserted dma_req_valid_r re-accepts stale data next cycle -> corrupt RIRB entries.
-            if (crst_falling) begin
+            if (crst_falling && (dstate == D_IDLE)) begin
                 dstate          <= D_IDLE;
                 dma_req_ready   <= 1'b1;
                 d_tlp_timeout   <= 20'h0;
@@ -96,11 +97,11 @@ module pcileech_hda_rirb_dma(
 
                 // ---- idle: accept new response from BAR module ---------------
                 D_IDLE: begin
-                    dma_req_ready <= 1'b1;
+                    dma_req_ready <= dma_enabled;
                     d_tlp_timeout   <= 20'h0;
                     d_tlp_timed_out <= 1'b0;
 
-                    if (dma_req_valid) begin
+                    if (dma_enabled && dma_req_valid) begin
                         // Latch inputs; don't depend on live signals during TLP emission.
                         d_resp_lo   <= dma_req_lo;
                         d_resp_hi   <= dma_req_hi;
@@ -117,21 +118,18 @@ module pcileech_hda_rirb_dma(
                 // ---- first beat: header (64-bit) or header+data0 (32-bit) ----
                 D_WR_TLP1: begin
                     d_tlp_timeout <= d_tlp_timeout + 1'b1;
-                    if (d_tlp_timeout >= 20'hFFFFF) begin
+                    if (d_tlp_timeout >= 20'hFFFFF)
                         d_tlp_timed_out <= 1'b1;
-                        dstate          <= D_IDLE;
-                    end else if (tlp_tx_tready) begin
+                    if (tlp_tx_tready)
                         dstate <= D_WR_TLP2;
-                    end
                 end
 
                 // ---- data beat 1: type+NID (64-bit) or payload (32-bit) ------
                 D_WR_TLP2: begin
                     d_tlp_timeout <= d_tlp_timeout + 1'b1;
-                    if (d_tlp_timeout >= 20'hFFFFF) begin
+                    if (d_tlp_timeout >= 20'hFFFFF)
                         d_tlp_timed_out <= 1'b1;
-                        dstate          <= D_IDLE;
-                    end else if (tlp_tx_tready) begin
+                    if (tlp_tx_tready) begin
                         if (d_is_64bit) begin
                             dstate <= D_WR_TLP3;
                         end else begin
@@ -143,12 +141,10 @@ module pcileech_hda_rirb_dma(
                 // ---- data beat 2: payload (64-bit only) ----------------------
                 D_WR_TLP3: begin
                     d_tlp_timeout <= d_tlp_timeout + 1'b1;
-                    if (d_tlp_timeout >= 20'hFFFFF) begin
+                    if (d_tlp_timeout >= 20'hFFFFF)
                         d_tlp_timed_out <= 1'b1;
-                        dstate          <= D_IDLE;
-                    end else if (tlp_tx_tready) begin
+                    if (tlp_tx_tready)
                         dstate <= D_DONE;
-                    end
                 end
 
                 // ---- signal completion to BAR module -------------------------

--- a/internal/firmware/svgen/templates/interrupt_service.sv.tmpl
+++ b/internal/firmware/svgen/templates/interrupt_service.sv.tmpl
@@ -1,7 +1,8 @@
 `timescale 1ns / 1ps
 
 module pcileech_interrupt_service #(
-    parameter integer NUM_VECTORS = 1
+    parameter integer NUM_VECTORS = 1,
+    parameter integer DEFER_MSIX_CLEAR = 0
 )(
     input               clk,
     input               rst,
@@ -14,6 +15,7 @@ module pcileech_interrupt_service #(
     output reg [15:0]   vector_select,
     input               vector_masked,
     input               delivery_ready,
+    input               delivery_done,
     output reg          delivery_valid,
     output reg [15:0]   delivery_vector,
     output reg          msi_pulse,
@@ -64,7 +66,15 @@ module pcileech_interrupt_service #(
             end
 
             if (delivery_valid) begin
-                if (delivery_ready) begin
+                if (DEFER_MSIX_CLEAR && msix_mode) begin
+                    if (delivery_done) begin
+                        delivery_valid <= 1'b0;
+                        if (!(event_valid && (event_vector == delivery_vector)))
+                            pending[delivery_vector[INDEX_WIDTH-1:0]] <= 1'b0;
+                        pba_clear_valid <= 1'b1;
+                        pba_vector <= delivery_vector;
+                    end
+                end else if (delivery_ready) begin
                     delivery_valid <= 1'b0;
                     if (!(event_valid && (event_vector == delivery_vector)))
                         pending[delivery_vector[INDEX_WIDTH-1:0]] <= 1'b0;

--- a/internal/firmware/svgen/templates/interrupt_service.sv.tmpl
+++ b/internal/firmware/svgen/templates/interrupt_service.sv.tmpl
@@ -1,0 +1,107 @@
+`timescale 1ns / 1ps
+
+module pcileech_interrupt_service #(
+    parameter integer NUM_VECTORS = 1
+)(
+    input               clk,
+    input               rst,
+    input               quiesce,
+    input               msix_mode,
+    input               function_enable,
+    input               function_mask,
+    input               event_valid,
+    input [15:0]        event_vector,
+    output reg [15:0]   vector_select,
+    input               vector_masked,
+    input               delivery_ready,
+    output reg          delivery_valid,
+    output reg [15:0]   delivery_vector,
+    output reg          msi_pulse,
+    output reg          pba_set_valid,
+    output reg          pba_clear_valid,
+    output reg [15:0]   pba_vector
+);
+    localparam Q_SELECT = 2'd0;
+    localparam Q_WAIT   = 2'd1;
+    localparam Q_CHECK  = 2'd2;
+    localparam integer INDEX_WIDTH = (NUM_VECTORS <= 1) ? 1 : $clog2(NUM_VECTORS);
+
+    reg [NUM_VECTORS-1:0] pending;
+    reg [INDEX_WIDTH-1:0] scan_vector;
+    reg [1:0] query_state;
+
+    always @(posedge clk) begin
+        pba_set_valid <= 1'b0;
+        pba_clear_valid <= 1'b0;
+
+        if (rst) begin
+            pending <= {NUM_VECTORS{1'b0}};
+            vector_select <= 16'd0;
+            delivery_valid <= 1'b0;
+            delivery_vector <= 16'd0;
+            msi_pulse <= 1'b0;
+            scan_vector <= {INDEX_WIDTH{1'b0}};
+            query_state <= Q_SELECT;
+            pba_vector <= 16'd0;
+        end else if (quiesce) begin
+            delivery_valid <= 1'b0;
+            msi_pulse <= 1'b0;
+            query_state <= Q_SELECT;
+            if (event_valid && (event_vector < 16'(NUM_VECTORS))) begin
+                pending[event_vector[INDEX_WIDTH-1:0]] <= 1'b1;
+                if (msix_mode) begin
+                    pba_set_valid <= 1'b1;
+                    pba_vector <= event_vector;
+                end
+            end
+        end else begin
+            if (event_valid && (event_vector < 16'(NUM_VECTORS))) begin
+                pending[event_vector[INDEX_WIDTH-1:0]] <= 1'b1;
+                if (msix_mode) begin
+                    pba_set_valid <= 1'b1;
+                    pba_vector <= event_vector;
+                end
+            end
+
+            if (delivery_valid) begin
+                if (delivery_ready) begin
+                    delivery_valid <= 1'b0;
+                    if (!(event_valid && (event_vector == delivery_vector)))
+                        pending[delivery_vector[INDEX_WIDTH-1:0]] <= 1'b0;
+                    pba_clear_valid <= 1'b1;
+                    pba_vector <= delivery_vector;
+                end
+            end else if (msi_pulse) begin
+                if (delivery_ready) begin
+                    msi_pulse <= 1'b0;
+                    if (!(event_valid && (event_vector == delivery_vector)))
+                        pending[delivery_vector[INDEX_WIDTH-1:0]] <= 1'b0;
+                end
+            end else begin
+                case (query_state)
+                    Q_SELECT: begin
+                        vector_select <= 16'(scan_vector);
+                        query_state <= Q_WAIT;
+                    end
+                    Q_WAIT: query_state <= Q_CHECK;
+                    Q_CHECK: begin
+                        if (pending[vector_select[INDEX_WIDTH-1:0]] && function_enable &&
+                            !function_mask) begin
+                            delivery_vector <= vector_select;
+                            if (!msix_mode)
+                                msi_pulse <= 1'b1;
+                            else if (!vector_masked)
+                                delivery_valid <= 1'b1;
+                        end
+                        if (scan_vector == INDEX_WIDTH'(NUM_VECTORS - 1))
+                            scan_vector <= {INDEX_WIDTH{1'b0}};
+                        else
+                            scan_vector <= scan_vector + 1'b1;
+                        query_state <= Q_SELECT;
+                    end
+                    default: query_state <= Q_SELECT;
+                endcase
+            end
+        end
+    end
+endmodule

--- a/internal/firmware/svgen/templates/lifecycle_service.sv.tmpl
+++ b/internal/firmware/svgen/templates/lifecycle_service.sv.tmpl
@@ -1,0 +1,33 @@
+`timescale 1ns / 1ps
+
+module pcileech_lifecycle_service(
+    input              clk,
+    input              fundamental_reset,
+    input              flr_in_process,
+    input [1:0]        pm_dstate,
+    input              memory_space_enable,
+    input              bus_master_enable,
+    input              turnoff_pending,
+    input              link_up,
+    output             device_reset,
+    output             io_enabled,
+    output             dma_enabled,
+    output             quiesce,
+    output reg [31:0]  generation
+);
+    wire active = !device_reset && (pm_dstate == 2'b00) &&
+                  !turnoff_pending && link_up;
+
+    assign device_reset = fundamental_reset || flr_in_process;
+    assign io_enabled   = active && memory_space_enable;
+    assign dma_enabled  = active && bus_master_enable;
+    assign quiesce      = !dma_enabled;
+
+    reg reset_d = 1'b0;
+    initial generation = 32'd0;
+    always @(posedge clk) begin
+        reset_d <= device_reset;
+        if (device_reset && !reset_d)
+            generation <= generation + 1'b1;
+    end
+endmodule

--- a/internal/firmware/svgen/templates/msix_table.sv.tmpl
+++ b/internal/firmware/svgen/templates/msix_table.sv.tmpl
@@ -43,6 +43,8 @@ module pcileech_msix_table #(
     // Device-side PBA pending-bit set for a masked vector (spec 6.8.3.4).
     input               pba_set_valid,
     input  [15:0]       pba_set_vector,
+    input               pba_clear_valid,
+    input  [15:0]       pba_clear_vector,
 
     output              addr_hit  // request targets MSI-X region
 );
@@ -103,10 +105,16 @@ module pcileech_msix_table #(
         end
     end
 
-    // device-side PBA pending-bit set (set-only; spec 6.8.3.4).
     always @(posedge clk) begin
-        if (!rst && pba_set_valid && (pba_set_vector < NUM_VECTORS))
-            msix_pba[pba_set_vector >> 5][pba_set_vector & 5'h1f] <= 1'b1;
+        if (rst) begin
+            for (k = 0; k < (NUM_VECTORS+31)/32; k = k + 1)
+                msix_pba[k] <= 32'h0;
+        end else begin
+            if (pba_clear_valid && (pba_clear_vector < NUM_VECTORS))
+                msix_pba[int'(pba_clear_vector[15:5])][pba_clear_vector[4:0]] <= 1'b0;
+            if (pba_set_valid && (pba_set_vector < NUM_VECTORS))
+                msix_pba[int'(pba_set_vector[15:5])][pba_set_vector[4:0]] <= 1'b1;
+        end
     end
 
     // read logic - 2-cycle pipeline

--- a/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
+++ b/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
@@ -37,11 +37,11 @@ module pcileech_nvme_admin_responder #(
     input [15:0]        doorbell_qid,
     input [15:0]        doorbell_val,
 
-    output [15:0]       msix_vector_select,
     input [63:0]        msix_vector_addr,
     input [31:0]        msix_vector_data,
     input               irq_delivery_valid,
     output              irq_delivery_ready,
+    output reg          irq_delivery_done,
 
     (* DONT_TOUCH = "TRUE" *) output reg          dma_rd_req,
     (* DONT_TOUCH = "TRUE" *) output reg [63:0]   dma_rd_addr,
@@ -197,8 +197,7 @@ module pcileech_nvme_admin_responder #(
     wire [15:0] io_cq_tail_next = (io_cq_tail >= io_cq_last) ? 16'h0 : (io_cq_tail + 16'h1);
 
     wire active_io = (active_qid != 16'h0000);
-    assign msix_vector_select = active_io ? io_vector : 16'h0000;
-    assign irq_delivery_ready = dma_enabled && (state == S_IDLE) && cc_en;
+    assign irq_delivery_ready = dma_enabled && (state == S_IDLE) && cc_en && !irq_delivery_done;
     wire [15:0] active_sq_head_next = active_io ? io_sq_head_next : sq_head_next;
     wire [15:0] active_cq_tail      = active_io ? io_cq_tail      : cq_tail;
     wire [15:0] active_cq_last      = active_io ? io_cq_last      : acq_last;
@@ -619,6 +618,7 @@ module pcileech_nvme_admin_responder #(
             dma_wr_data        <= 32'h0;
             dma_wr_be          <= 4'hF;
             dma_wr_valid       <= 1'b0;
+            irq_delivery_done  <= 1'b0;
             disk_req_valid     <= 1'b0;
             disk_req_write     <= 1'b0;
             disk_req_flush     <= 1'b0;
@@ -693,6 +693,7 @@ module pcileech_nvme_admin_responder #(
             dma_wr_valid   <= 1'b0;
             disk_req_valid <= 1'b0;
             msix_trigger   <= 1'b0;
+            irq_delivery_done <= 1'b0;
             pba_set_valid  <= 1'b0;
             if (timing_cmd_active && (timing_elapsed_cycles != 32'hFFFFFFFF))
                 timing_elapsed_cycles <= timing_elapsed_cycles + 1'b1;
@@ -1351,13 +1352,16 @@ module pcileech_nvme_admin_responder #(
                         end
 
                         pba_set_valid  <= 1'b1;
-                        pba_set_vector <= msix_vector_select;
+                        pba_set_vector <= active_io ? io_vector : 16'h0000;
                         state <= S_IDLE;
                     end
 
                     S_WAIT_DMA_WR: begin
-                        if (dma_wr_done)
+                        if (dma_wr_done) begin
+                            if (return_state == S_IDLE)
+                                irq_delivery_done <= 1'b1;
                             state <= return_state;
+                        end
                     end
 
                     S_RESOLVE_IO_PRP: begin

--- a/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
+++ b/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
@@ -20,6 +20,7 @@ module pcileech_nvme_admin_responder #(
 ) (
     input               rst,
     input               clk,
+    input tri1          dma_enabled,
 
     input               cc_en,
     input               cc_enable_wr,
@@ -36,12 +37,11 @@ module pcileech_nvme_admin_responder #(
     input [15:0]        doorbell_qid,
     input [15:0]        doorbell_val,
 
-    input               msix_enable,
-    input               msix_function_mask,
     output [15:0]       msix_vector_select,
     input [63:0]        msix_vector_addr,
     input [31:0]        msix_vector_data,
-    input               msix_vector_masked,
+    input               irq_delivery_valid,
+    output              irq_delivery_ready,
 
     (* DONT_TOUCH = "TRUE" *) output reg          dma_rd_req,
     (* DONT_TOUCH = "TRUE" *) output reg [63:0]   dma_rd_addr,
@@ -198,6 +198,7 @@ module pcileech_nvme_admin_responder #(
 
     wire active_io = (active_qid != 16'h0000);
     assign msix_vector_select = active_io ? io_vector : 16'h0000;
+    assign irq_delivery_ready = dma_enabled && (state == S_IDLE) && cc_en;
     wire [15:0] active_sq_head_next = active_io ? io_sq_head_next : sq_head_next;
     wire [15:0] active_cq_tail      = active_io ? io_cq_tail      : cq_tail;
     wire [15:0] active_cq_last      = active_io ? io_cq_last      : acq_last;
@@ -819,12 +820,25 @@ module pcileech_nvme_admin_responder #(
                 dsm_dw3            <= 32'h0;
                 if (cc_stop_event)
                     stat_unsafe_shutdowns <= stat_unsafe_shutdowns + 1'b1;
+            end else if (!dma_enabled) begin
+                state <= S_IDLE;
+                return_state <= S_IDLE;
+                timing_cmd_active <= 1'b0;
+                timing_done_for_cmd <= 1'b0;
             end else if (!cc_en && state != S_SHUTDOWN) begin
                 state <= S_IDLE;
             end else begin
                 case (state)
                     S_IDLE: begin
-                        if (sq_tail != sq_head) begin
+                        if (irq_delivery_valid && irq_delivery_ready) begin
+                            dma_wr_req   <= 1'b1;
+                            dma_wr_valid <= 1'b1;
+                            dma_wr_addr  <= msix_vector_addr;
+                            dma_wr_data  <= msix_vector_data;
+                            dma_wr_be    <= 4'hF;
+                            return_state <= S_IDLE;
+                            state        <= S_WAIT_DMA_WR;
+                        end else if (sq_tail != sq_head) begin
                             active_qid  <= 16'h0000;
                             dma_rd_req  <= 1'b1;
                             dma_rd_addr <= asq_base + ({48'h0, sq_head} * 64);
@@ -1336,26 +1350,9 @@ module pcileech_nvme_admin_responder #(
                             end
                         end
 
-                        if (msix_enable && !msix_function_mask && !msix_vector_masked &&
-                            (msix_vector_addr != 64'h0000000000000000)) begin
-                            dma_wr_req   <= 1'b1;
-                            dma_wr_valid <= 1'b1;
-                            dma_wr_addr  <= msix_vector_addr;
-                            dma_wr_data  <= msix_vector_data;
-                            dma_wr_be    <= 4'hF;
-                            return_state <= S_IDLE;
-                            state        <= S_WAIT_DMA_WR;
-                        end else begin
-                            if (msix_enable) begin
-                                // MSI-X on but can't deliver (masked or vector not armed): hold pending in PBA.
-                                pba_set_valid  <= 1'b1;
-                                pba_set_vector <= msix_vector_select;
-                            end else begin
-                                // fallback to MSI when MSI-X is disabled
-                                msix_trigger <= 1'b1;
-                            end
-                            state <= S_IDLE;
-                        end
+                        pba_set_valid  <= 1'b1;
+                        pba_set_vector <= msix_vector_select;
+                        state <= S_IDLE;
                     end
 
                     S_WAIT_DMA_WR: begin

--- a/internal/firmware/svgen/templates/nvme_dma_bridge.sv.tmpl
+++ b/internal/firmware/svgen/templates/nvme_dma_bridge.sv.tmpl
@@ -9,6 +9,7 @@
 module pcileech_nvme_dma_bridge(
     input               rst,
     input               clk,
+    input               dma_enabled,
 
     input [15:0]        pcie_id,
 
@@ -54,13 +55,11 @@ module pcileech_nvme_dma_bridge(
     localparam [3:0] B_RD_EMIT  = 4'h6;
 
     reg [3:0]  bstate;
-    reg [7:0]  rd_tag;
     reg [7:0]  rd_active_tag;
     reg [63:0] rd_base_addr;
     reg [9:0]  rd_remaining;
     reg [9:0]  rd_index;
     reg [31:0] rd_payload;
-    reg [23:0] rd_timeout;
 
     reg [31:0] wr_data_hold;
     reg        wr_pending;
@@ -72,35 +71,56 @@ module pcileech_nvme_dma_bridge(
     reg [9:0]  rd_pending_len;
 
     localparam [7:0] NVME_RD_TAG_FIRST = 8'h10;
-    localparam [7:0] NVME_RD_TAG_LAST  = 8'h1F;
-
     // Reorder Xilinx pcie_id {func,dev,bus} -> PCIe Requester ID {bus,dev,func}.
     wire [15:0] pcie_id_fmt = {pcie_id[12:8], pcie_id[15:13], pcie_id[7:0]};
 
-    // Keep NVMe-internal MRd tags in the non-extended 5-bit tag space.  The
-    // bridge only has one outstanding read, so a small rotating window is
-    // enough and does not depend on Extended Tag Enable being set by the host.
-    function [7:0] next_rd_tag;
-        input [7:0] value;
-        begin
-            next_rd_tag = (value >= NVME_RD_TAG_LAST) ? NVME_RD_TAG_FIRST : (value + 8'd1);
-        end
-    endfunction
 
     wire [9:0]  rd_next_index = rd_index + 10'd1;
     wire [63:0] rd_next_addr  = rd_base_addr + {52'h0, rd_next_index, 2'b00};
 
     wire [2:0] cpld_status = tlp_rx_tdata[47:45];
+    wire cpld_has_data = (tlp_rx_tdata[31:25] == 7'b0100101);
     wire cpld_any = tlp_rx_tvalid &&
                     tlp_rx_tuser[0] &&
-                    (tlp_rx_tdata[31:25] == 7'b0100101);
+                    (cpld_has_data ||
+                     (tlp_rx_tdata[31:25] == 7'b0000101));
     wire cpld_tag_match = cpld_any && (tlp_rx_tdata[79:72] == rd_active_tag);
-    wire cpld_match = cpld_tag_match &&
+    wire cpld_match = cpld_tag_match && cpld_has_data &&
                       (cpld_status == 3'b000);
     wire cpld_error = cpld_tag_match &&
-                      (cpld_status != 3'b000);
+                      (!cpld_has_data || (cpld_status != 3'b000));
+    wire        tag_alloc_ready;
+    wire [7:0]  tag_alloc_tag;
+    reg         tag_alloc_valid;
+    wire        tag_outcome_valid;
+    wire [7:0]  tag_outcome_tag;
+    wire [1:0]  tag_outcome_status;
+
+    pcileech_dma_tag_service #(
+        .TAG_FIRST      ( NVME_RD_TAG_FIRST ),
+        .TAG_COUNT      ( 16                ),
+        .TIMEOUT_CYCLES ( 24'hFFFFFF        ),
+        .TIMEOUT_WIDTH  ( 24                )
+    ) i_dma_tag_service(
+        .clk                ( clk                    ),
+        .rst                ( rst                    ),
+        .alloc_valid        ( tag_alloc_valid        ),
+        .alloc_ready        ( tag_alloc_ready        ),
+        .alloc_tag          ( tag_alloc_tag          ),
+        .completion_valid   ( cpld_tag_match         ),
+        .completion_tag     ( tlp_rx_tdata[79:72]    ),
+        .completion_error   ( cpld_error             ),
+        .cancel_all         ( !dma_enabled           ),
+        .outcome_valid      ( tag_outcome_valid      ),
+        .outcome_ready      ( 1'b1                   ),
+        .outcome_tag        ( tag_outcome_tag        ),
+        .outcome_status     ( tag_outcome_status     ),
+        .active_tags        (                        ),
+        .outstanding_count  (                        )
+    );
+
     assign dbg_status = {cpld_any, cpld_tag_match, cpld_match, cpld_status,
-                         bstate, rd_active_tag, rd_tag, rd_remaining[5:0]};
+                         bstate, rd_active_tag, tag_alloc_tag, rd_remaining[5:0]};
 
     function [15:0] bs16;
         input [15:0] value;
@@ -181,13 +201,11 @@ module pcileech_nvme_dma_bridge(
             tlp_tx_tvalid   <= 1'b0;
             tlp_tx_tlast    <= 1'b0;
             tlp_tx_tuser    <= 9'h0;
-            rd_tag          <= NVME_RD_TAG_FIRST;
             rd_active_tag   <= NVME_RD_TAG_FIRST;
             rd_base_addr    <= 64'h0;
             rd_remaining    <= 10'h0;
             rd_index        <= 10'h0;
             rd_payload      <= 32'h0;
-            rd_timeout      <= 24'h0;
             wr_data_hold    <= 32'h0;
             wr_pending      <= 1'b0;
             wr_pending_addr <= 64'h0;
@@ -196,15 +214,18 @@ module pcileech_nvme_dma_bridge(
             rd_pending      <= 1'b0;
             rd_pending_addr <= 64'h0;
             rd_pending_len  <= 10'h0;
+            tag_alloc_valid <= 1'b0;
         end else begin
             dma_wr_done  <= 1'b0;
             dma_rd_valid <= 1'b0;
             dma_rd_done  <= 1'b0;
+            tag_alloc_valid <= 1'b0;
 
-            // The responder pulses requests for one clock.  If the bridge is
-            // still finishing a TLP, remember one command so the NVMe FSM does
-            // not strand itself waiting for a read/write that was never issued.
-            if (bstate != B_IDLE) begin
+            if (!dma_enabled) begin
+                wr_pending <= 1'b0;
+                rd_pending <= 1'b0;
+            end
+            if (dma_enabled && (bstate != B_IDLE)) begin
                 if (dma_wr_valid && !wr_pending) begin
                     wr_pending      <= 1'b1;
                     wr_pending_addr <= dma_wr_addr;
@@ -224,33 +245,33 @@ module pcileech_nvme_dma_bridge(
                     tlp_tx_tlast  <= 1'b0;
                     tlp_tx_tuser  <= 9'h0;
 
-                    if (wr_pending) begin
+                    if (dma_enabled && wr_pending) begin
                         wr_data_hold <= wr_pending_data;
                         load_mwr1(wr_pending_addr, wr_pending_data, wr_pending_be);
                         wr_pending <= 1'b0;
                         bstate <= B_WR_SEND;
-                    end else if (dma_wr_valid) begin
+                    end else if (dma_enabled && dma_wr_valid) begin
                         wr_data_hold <= dma_wr_data;
                         load_mwr1(dma_wr_addr, dma_wr_data, dma_wr_be);
                         bstate <= B_WR_SEND;
-                    end else if (rd_pending) begin
+                    end else if (dma_enabled && rd_pending && tag_alloc_ready) begin
                         rd_base_addr  <= rd_pending_addr;
                         rd_remaining  <= rd_pending_len;
                         rd_index      <= 10'd0;
-                        rd_active_tag <= rd_tag;
-                        load_mrd1(rd_pending_addr, rd_tag);
-                        rd_tag <= next_rd_tag(rd_tag);
+                        rd_active_tag <= tag_alloc_tag;
+                        tag_alloc_valid <= 1'b1;
+                        load_mrd1(rd_pending_addr, tag_alloc_tag);
                         rd_pending <= 1'b0;
                         bstate <= B_RD_SEND;
-                    end else if (dma_rd_req && (dma_rd_len != 10'd0)) begin
+                    end else if (dma_enabled && dma_rd_req && (dma_rd_len != 10'd0) && tag_alloc_ready) begin
                         rd_base_addr  <= dma_rd_addr;
                         rd_remaining  <= dma_rd_len;
                         rd_index      <= 10'd0;
-                        rd_active_tag <= rd_tag;
-                        load_mrd1(dma_rd_addr, rd_tag);
-                        rd_tag <= next_rd_tag(rd_tag);
+                        rd_active_tag <= tag_alloc_tag;
+                        tag_alloc_valid <= 1'b1;
+                        load_mrd1(dma_rd_addr, tag_alloc_tag);
                         bstate <= B_RD_SEND;
-                    end else if (dma_rd_req) begin
+                    end else if (dma_enabled && dma_rd_req) begin
                         dma_rd_done <= 1'b1;
                     end
                 end
@@ -286,7 +307,6 @@ module pcileech_nvme_dma_bridge(
                 B_RD_SEND: begin
                     if (tlp_tx_tvalid && tlp_tx_tready) begin
                         tlp_tx_tvalid <= 1'b0;
-                        rd_timeout <= 24'h0;
                         bstate <= B_RD_WAIT;
                     end
                 end
@@ -300,31 +320,30 @@ module pcileech_nvme_dma_bridge(
                         rd_remaining <= 10'h0;
                         dma_rd_done <= 1'b1;
                         bstate <= B_IDLE;
-                    end else begin
-                        rd_timeout <= rd_timeout + 1'b1;
-                        if (rd_timeout >= 24'hFFFFFF) begin
-                            rd_payload <= 32'h0;
-                            rd_remaining <= 10'h0;
-                            dma_rd_done <= 1'b1;
-                            bstate <= B_IDLE;
-                        end
-                    end
+                    end else if (tag_outcome_valid &&
+                                 (tag_outcome_tag == rd_active_tag) &&
+                                 (tag_outcome_status != 2'd0)) begin
+                        rd_payload <= 32'h0;
+                        rd_remaining <= 10'h0;
+                        dma_rd_done <= 1'b1;
+                        bstate <= B_IDLE;
+                end
                 end
 
                 B_RD_EMIT: begin
                     dma_rd_data  <= rd_payload;
                     dma_rd_valid <= 1'b1;
 
-                    if (rd_remaining <= 10'd1) begin
+                    if ((rd_remaining <= 10'd1) || !dma_enabled) begin
                         dma_rd_done  <= 1'b1;
                         rd_remaining <= 10'd0;
                         bstate <= B_IDLE;
                     end else begin
                         rd_remaining  <= rd_remaining - 10'd1;
                         rd_index      <= rd_next_index;
-                        rd_active_tag <= rd_tag;
-                        load_mrd1(rd_next_addr, rd_tag);
-                        rd_tag <= next_rd_tag(rd_tag);
+                        rd_active_tag <= tag_alloc_tag;
+                        tag_alloc_valid <= 1'b1;
+                        load_mrd1(rd_next_addr, tag_alloc_tag);
                         bstate <= B_RD_SEND;
                     end
                 end

--- a/scripts/hdl-lint.sh
+++ b/scripts/hdl-lint.sh
@@ -23,7 +23,7 @@ if [ "${#BOARDS[@]}" -eq 0 ]; then
 fi
 
 # whitelist of svgen output files (primitives like pcileech_fifo.sv are blackboxed)
-SVGEN_PATTERN='pcileech_bar_impl_device.sv|pcileech_tlps128_bar_controller.sv|pcileech_bar_impl_msi.sv|tlp_latency_emulator.sv|device_config.sv|pcileech_msix_table.sv|pcileech_nvme_admin_responder.sv|pcileech_nvme_dma_bridge.sv|pcileech_hda_rirb_dma.sv|pcileech_hda_msi.sv'
+SVGEN_PATTERN='pcileech_lifecycle_service.sv|pcileech_dma_tag_service.sv|pcileech_interrupt_service.sv|pcileech_bar_impl_device.sv|pcileech_tlps128_bar_controller.sv|pcileech_bar_impl_msi.sv|tlp_latency_emulator.sv|device_config.sv|pcileech_msix_table.sv|pcileech_nvme_admin_responder.sv|pcileech_nvme_dma_bridge.sv|pcileech_hda_rirb_dma.sv|pcileech_hda_msi.sv'
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -42,8 +42,17 @@ for fixture in "${FIXTURES[@]}"; do
     if ! ./bin/pcileechgen build --from-json "$fixture" --board "$board" \
           --skip-vivado --output "$out" --force >"$build_log" 2>&1; then
       # Donor BAR > board BRAM (or other benign incompatibility): skip, do not fail CI.
-      echo "SKIP  $cell (build incompatible — see $build_log)"
-      skip=$((skip+1))
+      if grep -Eq 'board sources not found at' "$build_log"; then
+        echo "SKIP  $cell (board source unavailable — see $build_log)"
+        skip=$((skip+1))
+      elif grep -Eq 'insufficient block RAM|exceeds board BRAM' "$build_log"; then
+        echo "SKIP  $cell (build incompatible — see $build_log)"
+        skip=$((skip+1))
+      else
+        echo "FAIL  $cell (build failed — see $build_log)"
+        cat "$build_log" >&2
+        fail=$((fail+1))
+      fi
       continue
     fi
 


### PR DESCRIPTION
## Summary

Adds shared generated services for lifecycle/reset coordination, PCIe DMA tag ownership, and MSI/MSI-X delivery so class-specific blocks no longer implement incompatible one-off state machines.

- central lifecycle model for power-on, fundamental reset, FLR, PM transitions, link state, quiesce, and turnoff
- reusable DMA tag allocator with owner metadata, terminal outcomes, cancellation tombstones, timeout/FLR retirement, and quiescence accounting
- ready/valid interrupt service with MSI hold-until-ready, MSI-X table/PBA masking, pending replay, and exactly-once delivery
- NVMe and HDA blocks migrated to shared service interfaces
- modern wrapper integration plus explicit preservation of upstream behavior on legacy 64-bit wrappers

## Correctness details

- Xilinx `cfg_interrupt` and associated payload remain asserted/stable until `cfg_interrupt_rdy`
- request+ack collisions preserve the new event
- cancellation emits exactly one backpressure-safe owner status while the numeric tag remains unallocatable until completion/timeout/FLR retirement
- transient quiesce suppresses outward traffic without orphaning MSI-X PBA or dropping MSI events; pending events replay once after resume
- quiesce-edge NVMe delivery cannot enter a responder wait state after the DMA bridge has reset
- same-cycle PBA set dominates clear
- reset remains destructive and clears stale service state

## Verification

- `go test -race -count=1 ./...` under Ubuntu WSL2
- executable Verilator simulations for interrupt backpressure/collisions, cancellation tombstones, timeout/FLR retirement, PBA set-over-clear, NVMe late-completion suppression, transient quiesce replay, HDA MSI replay, and quiesce-edge NVMe recovery
- full generated HDL matrix: 136 pass, 17 explicit unavailable/incompatible skips, 0 fail
- representative modern and legacy skip-Vivado builds
- independent implementation review and repeated targeted closure reviews
- zero comments added

## Research references

The service boundaries and tests were checked against public AMD/Xilinx 7-series PCIe interface guidance, verilog-pcie DMA tag patterns, QEMU MSI-X/PBA behavior, Linux PCI lifecycle behavior, and libvfio-user reset/quiescence contracts.