### PR TITLE
feat: infer and compile bounded MMIO behavior rules

### DIFF
--- a/cmd/pcileechgen/build.go
+++ b/cmd/pcileechgen/build.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sercanarga/pcileechgen/internal/board"
 	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/donor/behavior"
 	"github.com/sercanarga/pcileechgen/internal/firmware"
 	"github.com/sercanarga/pcileechgen/internal/pci"
 	"github.com/sercanarga/pcileechgen/internal/vivado"
@@ -24,6 +25,7 @@ type buildFlags struct {
 	libDir     string
 	fromJSON   string
 	stockBar   bool
+	behaviorRules string
 	force      bool
 }
 
@@ -56,6 +58,11 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	ctx, err := loadDonorContext()
 	if err != nil {
 		return err
+	}
+
+
+	if buildOpts.stockBar && ctx.BehaviorRules != nil {
+		return fmt.Errorf("behavior rules require generated BAR RTL; --stock-bar is unsupported")
 	}
 
 	printBuildSummary(ctx, b)
@@ -94,27 +101,36 @@ func runBuild(cmd *cobra.Command, args []string) error {
 
 // loadDonorContext loads device context from JSON or live device.
 func loadDonorContext() (*donor.DeviceContext, error) {
+	var ctx *donor.DeviceContext
+	var err error
 	if buildOpts.fromJSON != "" {
 		slog.Info("loading device context", "file", buildOpts.fromJSON)
-		return donor.LoadContext(buildOpts.fromJSON)
+		ctx, err = donor.LoadContext(buildOpts.fromJSON)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		if buildOpts.bdf == "" {
+			return nil, fmt.Errorf("either --bdf or --from-json is required")
+		}
+		bdf, parseErr := pci.ParseBDF(buildOpts.bdf)
+		if parseErr != nil {
+			return nil, fmt.Errorf("invalid BDF: %w", parseErr)
+		}
+		slog.Info("target device", "bdf", bdf.String())
+		slog.Info("collecting donor device data")
+		collector := donor.NewCollector()
+		ctx, err = collector.Collect(bdf)
+		if err != nil {
+			return nil, fmt.Errorf("device data collection failed: %w", err)
+		}
 	}
-
-	if buildOpts.bdf == "" {
-		return nil, fmt.Errorf("either --bdf or --from-json is required")
-	}
-
-	bdf, err := pci.ParseBDF(buildOpts.bdf)
-	if err != nil {
-		return nil, fmt.Errorf("invalid BDF: %w", err)
-	}
-
-	slog.Info("target device", "bdf", bdf.String())
-	slog.Info("collecting donor device data")
-
-	collector := donor.NewCollector()
-	ctx, err := collector.Collect(bdf)
-	if err != nil {
-		return nil, fmt.Errorf("device data collection failed: %w", err)
+	if buildOpts.behaviorRules != "" {
+		rules, loadErr := behavior.LoadRuleSet(buildOpts.behaviorRules)
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		ctx.BehaviorRules = rules
 	}
 	return ctx, nil
 }
@@ -149,6 +165,7 @@ func init() {
 	buildCmd.Flags().StringVar(&buildOpts.bdf, "bdf", "", "donor device BDF address (e.g. 0000:03:00.0)")
 	buildCmd.Flags().StringVar(&buildOpts.board, "board", "", "target FPGA board name (required, e.g. PCIeSquirrel)")
 	buildCmd.Flags().StringVar(&buildOpts.fromJSON, "from-json", "", "load donor device data from JSON file (offline build)")
+	buildCmd.Flags().StringVar(&buildOpts.behaviorRules, "behavior-rules", "", "attach a validated behavior-rule JSON artifact")
 	buildCmd.Flags().StringVar(&buildOpts.vivadoPath, "vivado-path", "", "path to Vivado installation")
 	buildCmd.Flags().StringVar(&buildOpts.output, "output", "pcileech_datastore", "output directory")
 	buildCmd.Flags().BoolVar(&buildOpts.skipVivado, "skip-vivado", false, "skip Vivado synthesis (only generate artifacts)")

--- a/cmd/pcileechgen/build_rules_test.go
+++ b/cmd/pcileechgen/build_rules_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/donor/behavior"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func TestLoadDonorContext_AttachesValidatedBehaviorRules(t *testing.T) {
+	dir := t.TempDir()
+	contextPath := filepath.Join(dir, "device_context.json")
+	rulesPath := filepath.Join(dir, "behavior_rules.json")
+	ctx := &donor.DeviceContext{ConfigSpace: pci.NewConfigSpace()}
+	if err := donor.SaveContext(ctx, contextPath); err != nil {
+		t.Fatalf("save context: %v", err)
+	}
+	rules := &behavior.RuleSet{
+		Version: behavior.RuleSchemaVersion, BARIndex: 0, BARSize: 0x1000,
+		ClockHz: 100_000_000, InitialState: "idle",
+		Rules: []behavior.Rule{{
+			ID: "enable", State: "idle", Access: behavior.AccessKind("write"), Width: 4,
+			Offset: 0x20, Value: 1, ValueMask: math.MaxUint32, NextState: "ready",
+			Confidence: 1, Provenance: []string{"test fixture"},
+		}},
+	}
+	data, err := json.Marshal(rules)
+	if err != nil {
+		t.Fatalf("marshal rules: %v", err)
+	}
+	if err := os.WriteFile(rulesPath, data, 0o644); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+
+	previous := buildOpts
+	t.Cleanup(func() { buildOpts = previous })
+	buildOpts = buildFlags{fromJSON: contextPath, behaviorRules: rulesPath}
+	loaded, err := loadDonorContext()
+	if err != nil {
+		t.Fatalf("loadDonorContext: %v", err)
+	}
+	if loaded.BehaviorRules == nil || len(loaded.BehaviorRules.Rules) != 1 {
+		t.Fatalf("loaded behavior rules = %+v", loaded.BehaviorRules)
+	}
+	if loaded.BehaviorRules.Rules[0].ID != "enable" {
+		t.Fatalf("loaded rule ID = %q, want enable", loaded.BehaviorRules.Rules[0].ID)
+	}
+}
+
+func TestLoadDonorContext_RejectsInvalidBehaviorRules(t *testing.T) {
+	dir := t.TempDir()
+	contextPath := filepath.Join(dir, "device_context.json")
+	rulesPath := filepath.Join(dir, "behavior_rules.json")
+	if err := donor.SaveContext(&donor.DeviceContext{ConfigSpace: pci.NewConfigSpace()}, contextPath); err != nil {
+		t.Fatalf("save context: %v", err)
+	}
+	if err := os.WriteFile(rulesPath, []byte(`{"version":999,"bar_size":4096,"initial_state":"idle"}`), 0o644); err != nil {
+		t.Fatalf("write invalid rules: %v", err)
+	}
+
+	previous := buildOpts
+	t.Cleanup(func() { buildOpts = previous })
+	buildOpts = buildFlags{fromJSON: contextPath, behaviorRules: rulesPath}
+	if _, err := loadDonorContext(); err == nil {
+		t.Fatal("expected unsupported rule schema version to be rejected")
+	}
+}

--- a/cmd/pcileechgen/mmio_trace.go
+++ b/cmd/pcileechgen/mmio_trace.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,6 +27,7 @@ type mmioTraceOptions struct {
 	jsonOutput bool
 	outputFile string
 	traceFile  string
+	rulesOutput string
 }
 
 var mmioTraceOpts mmioTraceOptions
@@ -36,8 +38,8 @@ var mmioTraceCmd = &cobra.Command{
 	Long: `Captures MMIO BAR accesses for a short duration using the kernel mmiotrace tracer.
 
 Example:
-  pcileechgen mmio-trace --bdf 0000:03:00.0 --duration 5s
-  pcileechgen mmio-trace --bdf 03:00.0 --bar-size 4096 --class-code 0x010802
+  pcileechgen mmio-trace --bdf 0000:03:00.0 --bar-base 0xf7800000 --bar-size 4096 --duration 5s
+  pcileechgen mmio-trace --bdf 03:00.0 --bar-base 0xf7800000 --bar-size 4096 --class-code 0x010802
   pcileechgen mmio-trace --trace-file mmiotrace.txt --bar-base 0xf7800000 --bar-index 2 --json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if mmioTraceOpts.traceFile == "" {
@@ -74,6 +76,17 @@ Example:
 		profile := behavior.FromMMIOTrace(trace, classCode)
 		timing := behavior.ExtractTimingHistogram(trace)
 
+		if mmioTraceOpts.rulesOutput != "" {
+			rules, inferErr := behavior.Infer(trace)
+			if inferErr != nil {
+				return fmt.Errorf("infer behavior rules: %w", inferErr)
+			}
+			if saveErr := behavior.SaveRuleSet(rules, mmioTraceOpts.rulesOutput); saveErr != nil {
+				return saveErr
+			}
+			fmt.Fprintln(cmd.ErrOrStderr(), color.OK(fmt.Sprintf("saved behavior rules to %s", mmioTraceOpts.rulesOutput)))
+		}
+
 		if mmioTraceOpts.jsonOutput {
 			report := map[string]any{
 				"trace":            trace,
@@ -107,33 +120,40 @@ Example:
 
 func loadMMIOTrace(opts mmioTraceOptions, barBase uint64) (*mmio.TraceResult, error) {
 	if opts.traceFile != "" {
-		f, err := os.Open(opts.traceFile)
+		data, err := os.ReadFile(opts.traceFile)
 		if err != nil {
 			return nil, fmt.Errorf("open trace file %q: %w", opts.traceFile, err)
 		}
-		defer f.Close()
-
-		trace, err := mmio.ParseTextTrace(f, mmio.TextTraceOptions{
+		if json.Valid(data) {
+			trace, parseErr := mmio.ParseJSONTrace(bytes.NewReader(data))
+			if parseErr != nil {
+				return nil, fmt.Errorf("parse trace file %q: %w", opts.traceFile, parseErr)
+			}
+			return trace, nil
+		}
+		trace, parseErr := mmio.ParseTextTrace(bytes.NewReader(data), mmio.TextTraceOptions{
 			BDF:      opts.bdf,
 			BARIndex: opts.barIndex,
 			BARSize:  opts.barSize,
 			BARBase:  barBase,
 		})
-		if err != nil {
-			return nil, fmt.Errorf("parse trace file %q: %w", opts.traceFile, err)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse trace file %q: %w", opts.traceFile, parseErr)
 		}
 		trace.StartTime = time.Now().Add(-trace.Duration)
 		return trace, nil
 	}
 
+	if barBase == 0 {
+		return nil, fmt.Errorf("--bar-base is required for target-aware live capture")
+	}
 	start := time.Now()
-	trace, err := mmio.LiveTrace(opts.bdf, opts.duration)
+	trace, err := mmio.LiveTraceTarget(mmio.TraceTarget{
+		BDF: opts.bdf, BARIndex: opts.barIndex, BARBase: barBase, BARSize: opts.barSize,
+	}, opts.duration)
 	if err != nil {
 		return nil, fmt.Errorf("trace capture failed: %w", err)
 	}
-	trace.BARIndex = opts.barIndex
-	trace.BARSize = opts.barSize
-	trace.Duration = opts.duration
 	trace.StartTime = start
 	return trace, nil
 }
@@ -206,9 +226,10 @@ func init() {
 	mmioTraceCmd.Flags().DurationVar(&mmioTraceOpts.duration, "duration", 5*time.Second, "trace length (e.g. 5s, 1m)")
 	mmioTraceCmd.Flags().IntVar(&mmioTraceOpts.barIndex, "bar-index", 0, "BAR index that was targeted for this trace")
 	mmioTraceCmd.Flags().IntVar(&mmioTraceOpts.barSize, "bar-size", 4096, "expected BAR size hint in bytes")
-	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.barBase, "bar-base", "", "absolute BAR base for offline trace address normalization")
+	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.barBase, "bar-base", "", "absolute target BAR base for capture or text import")
 	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.classCode, "class-code", "", "PCI class code in hex (e.g. 0x010802)")
 	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.outputFile, "output", "", "save raw trace JSON to file")
+	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.rulesOutput, "rules-output", "", "save inferred behavior rules to a JSON artifact")
 	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.traceFile, "trace-file", "", "analyze an existing mmiotrace text file instead of capturing live")
 	mmioTraceCmd.Flags().BoolVar(&mmioTraceOpts.jsonOutput, "json", false, "emit machine-readable report")
 	rootCmd.AddCommand(mmioTraceCmd)

--- a/cmd/pcileechgen/mmio_trace_rules_test.go
+++ b/cmd/pcileechgen/mmio_trace_rules_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/behavior"
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+)
+
+func TestMMIOTraceCLI_PersistsRulesWithoutChangingRawTraceOutput(t *testing.T) {
+	dir := t.TempDir()
+	textPath := filepath.Join(dir, "mmiotrace.txt")
+	rawPath := filepath.Join(dir, "trace.json")
+	rulesPath := filepath.Join(dir, "rules.json")
+	input := []byte(
+		"W 4 1.000 0xf7800020 0x1\n" +
+			"R 4 1.001 0xf7800024 0x0\n" +
+			"R 4 1.002 0xf7800024 0x1\n" +
+			"W 4 1.010 0xf7800020 0x1\n" +
+			"R 4 1.011 0xf7800024 0x0\n" +
+			"R 4 1.012 0xf7800024 0x1\n")
+	if err := os.WriteFile(textPath, input, 0o644); err != nil {
+		t.Fatalf("write trace fixture: %v", err)
+	}
+
+	previous := mmioTraceOpts
+	t.Cleanup(func() { mmioTraceOpts = previous })
+	mmioTraceOpts = mmioTraceOptions{
+		bdf: "0000:03:00.0", duration: time.Second, barIndex: 2, barSize: 0x1000,
+		barBase: "0xf7800000", traceFile: textPath, outputFile: rawPath, rulesOutput: rulesPath,
+	}
+	var stdout, stderr bytes.Buffer
+	mmioTraceCmd.SetOut(&stdout)
+	mmioTraceCmd.SetErr(&stderr)
+	t.Cleanup(func() {
+		mmioTraceCmd.SetOut(nil)
+		mmioTraceCmd.SetErr(nil)
+	})
+	if err := mmioTraceCmd.RunE(mmioTraceCmd, nil); err != nil {
+		t.Fatalf("mmio-trace RunE: %v", err)
+	}
+
+	rawJSON, err := os.ReadFile(rawPath)
+	if err != nil {
+		t.Fatalf("read raw trace output: %v", err)
+	}
+	var trace mmio.TraceResult
+	if err := json.Unmarshal(rawJSON, &trace); err != nil {
+		t.Fatalf("raw --output is no longer a trace artifact: %v", err)
+	}
+	if len(trace.Records) != 6 {
+		t.Fatalf("raw trace records = %d, want 6", len(trace.Records))
+	}
+
+	rulesJSON, err := os.ReadFile(rulesPath)
+	if err != nil {
+		t.Fatalf("read rules output: %v", err)
+	}
+	var rules behavior.RuleSet
+	if err := json.Unmarshal(rulesJSON, &rules); err != nil {
+		t.Fatalf("decode rules output: %v", err)
+	}
+	if err := behavior.Validate(&rules); err != nil {
+		t.Fatalf("persisted rules are invalid: %v", err)
+	}
+	if rules.Version != behavior.RuleSchemaVersion || len(rules.Rules) == 0 {
+		t.Fatalf("persisted rule set = %+v", rules)
+	}
+}

--- a/internal/donor/behavior/profiler.go
+++ b/internal/donor/behavior/profiler.go
@@ -24,7 +24,7 @@ type InitStep struct {
 	Order     int           `json:"order"`     // step number (1-based)
 	Offset    uint32        `json:"offset"`    // BAR register offset
 	Type      string        `json:"type"`      // "read" or "write"
-	Value     uint32        `json:"value"`     // value read or written
+	Value     uint64        `json:"value"`
 	Timestamp time.Duration `json:"timestamp"` // time since start
 	Purpose   string        `json:"purpose"`   // inferred purpose (if known)
 }
@@ -178,7 +178,7 @@ func FormatReport(profile *Profile) string {
 			if step.Purpose != "" {
 				purpose = " ← " + step.Purpose
 			}
-			sb.WriteString(fmt.Sprintf("  %2d. [%v] %s 0x%03X = 0x%08X%s\n",
+			sb.WriteString(fmt.Sprintf("  %2d. [%v] %s 0x%03X = 0x%016X%s\n",
 				step.Order, step.Timestamp, step.Type, step.Offset, step.Value, purpose))
 		}
 	}

--- a/internal/donor/behavior/rules.go
+++ b/internal/donor/behavior/rules.go
@@ -1,0 +1,773 @@
+package behavior
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+)
+
+const (
+	RuleSchemaVersion = 1
+	DefaultRuleClockHz uint64 = 125_000_000
+	MaxDelayCycles uint32 = 1_000_000
+	MaxRules = 256
+	MaxDelayedEvents = 64
+	maxUpdatesPerAction = 16
+	MaxInitialRegisters = 1024
+)
+
+type AccessKind string
+
+const (
+	AccessRead         AccessKind = "read"
+	AccessWrite        AccessKind = "write"
+	UnknownInputIgnore            = "ignore"
+)
+
+type RuleSet struct {
+	Version          int             `json:"version"`
+	BDF              string          `json:"bdf,omitempty"`
+	BARIndex         int             `json:"bar_index"`
+	BARSize          int             `json:"bar_size"`
+	ClockHz          uint64          `json:"clock_hz"`
+	InitialState     string          `json:"initial_state"`
+	InitialRegisters []RegisterValue `json:"initial_registers,omitempty"`
+	UnknownInputPolicy string          `json:"unknown_input_policy,omitempty"`
+	Rules            []Rule          `json:"rules"`
+}
+
+type RegisterValue struct {
+	Offset      uint32               `json:"offset"`
+	Width       uint8                `json:"width"`
+	Value       uint64               `json:"value"`
+	WritePolicy *RegisterWritePolicy `json:"write_policy,omitempty"`
+}
+
+type RegisterWritePolicy struct {
+	RWMask  uint64 `json:"rw_mask"`
+	W1CMask uint64 `json:"w1c_mask"`
+}
+
+type Rule struct {
+	ID            string          `json:"id"`
+	State         string          `json:"state"`
+	Access        AccessKind      `json:"access"`
+	Width         uint8           `json:"width"`
+	Offset        uint32          `json:"offset"`
+	Value         uint64          `json:"value"`
+	ValueMask     uint64          `json:"value_mask"`
+	NextState     string          `json:"next_state,omitempty"`
+	Updates       []RegisterUpdate `json:"updates,omitempty"`
+	DelayedEvents []DelayedEvent  `json:"delayed_events,omitempty"`
+	Confidence    float64         `json:"confidence"`
+	Provenance    []string        `json:"provenance,omitempty"`
+}
+
+type RegisterUpdate struct {
+	Offset uint32 `json:"offset"`
+	Width  uint8  `json:"width"`
+	Value  uint64 `json:"value"`
+	Mask   uint64 `json:"mask"`
+}
+
+type DelayedEvent struct {
+	DelayCycles uint32           `json:"delay_cycles"`
+	Updates     []RegisterUpdate `json:"updates,omitempty"`
+	NextState   string           `json:"next_state,omitempty"`
+}
+
+type ReadMismatch struct {
+	RecordIndex int    `json:"record_index"`
+	Offset      uint32 `json:"offset"`
+	Expected    uint64 `json:"expected"`
+	Actual      uint64 `json:"actual"`
+}
+
+type ReplayResult struct {
+	TerminalState  string            `json:"terminal_state"`
+	Registers      map[uint32]uint64 `json:"registers"`
+	MatchedRules   []string          `json:"matched_rules"`
+	ReadMismatches []ReadMismatch    `json:"read_mismatches,omitempty"`
+}
+
+func widthMask(width uint8) (uint64, bool) {
+	switch width {
+	case 1:
+		return 0xff, true
+	case 2:
+		return 0xffff, true
+	case 4:
+		return 0xffffffff, true
+	case 8:
+		return ^uint64(0), true
+	default:
+		return 0, false
+	}
+}
+
+func validateUpdate(update RegisterUpdate, barSize int) error {
+	validBits, ok := widthMask(update.Width)
+	if !ok {
+		return fmt.Errorf("unsupported update width %d", update.Width)
+	}
+	if uint64(update.Offset)+uint64(update.Width) > uint64(barSize) {
+		return fmt.Errorf("update at %#x width %d is outside BAR size %#x", update.Offset, update.Width, barSize)
+	}
+	if update.Offset%uint32(update.Width) != 0 {
+		return fmt.Errorf("update at %#x width %d is misaligned", update.Offset, update.Width)
+	}
+	if update.Mask == 0 {
+		return fmt.Errorf("update at %#x has an empty mask", update.Offset)
+	}
+	if update.Mask&^validBits != 0 || update.Value&^validBits != 0 {
+		return fmt.Errorf("update at %#x exceeds its %d-byte width", update.Offset, update.Width)
+	}
+	return nil
+}
+
+func validateUpdateGroup(updates []RegisterUpdate, barSize int) error {
+	for i, update := range updates {
+		if err := validateUpdate(update, barSize); err != nil {
+			return err
+		}
+		for j := range i {
+			previous := updates[j]
+			previousEnd := uint64(previous.Offset) + uint64(previous.Width)
+			updateEnd := uint64(update.Offset) + uint64(update.Width)
+			if uint64(previous.Offset) >= updateEnd || uint64(update.Offset) >= previousEnd {
+				continue
+			}
+			if previous.Offset != update.Offset || previous.Width != update.Width {
+				return fmt.Errorf("updates at %#x and %#x overlap different register widths", previous.Offset, update.Offset)
+			}
+			overlap := previous.Mask & update.Mask
+			if ((previous.Value ^ update.Value) & overlap) != 0 {
+				return fmt.Errorf("updates at %#x assign contradictory overlapping masks", update.Offset)
+			}
+		}
+	}
+	return nil
+}
+
+func Validate(set *RuleSet) error {
+	if set == nil {
+		return fmt.Errorf("behavior rule set is nil")
+	}
+	if set.Version != RuleSchemaVersion {
+		return fmt.Errorf("unsupported behavior rule schema version %d (want %d)", set.Version, RuleSchemaVersion)
+	}
+	if set.BARIndex < 0 || set.BARIndex > 5 {
+		return fmt.Errorf("invalid behavior BAR index %d", set.BARIndex)
+	}
+	if set.BARSize <= 0 {
+		return fmt.Errorf("behavior BAR size must be positive")
+	}
+	if set.ClockHz == 0 || set.ClockHz > 1_000_000_000 {
+		return fmt.Errorf("behavior clock_hz must be between 1 and 1000000000")
+	}
+	if set.InitialState == "" {
+		return fmt.Errorf("behavior initial_state is required")
+	}
+	if len(set.InitialRegisters) > MaxInitialRegisters {
+		return fmt.Errorf("initial register count %d exceeds maximum %d", len(set.InitialRegisters), MaxInitialRegisters)
+	}
+	for i, initial := range set.InitialRegisters {
+		validBits, ok := widthMask(initial.Width)
+		if !ok {
+			return fmt.Errorf("initial register at %#x has unsupported width %d", initial.Offset, initial.Width)
+		}
+		if uint64(initial.Offset)+uint64(initial.Width) > uint64(set.BARSize) {
+			return fmt.Errorf("initial register at %#x is outside BAR size %#x", initial.Offset, set.BARSize)
+		}
+		if initial.Offset%uint32(initial.Width) != 0 || initial.Value&^validBits != 0 {
+			return fmt.Errorf("initial register at %#x is invalid for width %d", initial.Offset, initial.Width)
+		}
+		if initial.WritePolicy != nil {
+			if initial.WritePolicy.RWMask&^validBits != 0 || initial.WritePolicy.W1CMask&^validBits != 0 {
+				return fmt.Errorf("initial register at %#x has write-policy bits outside width %d", initial.Offset, initial.Width)
+			}
+			if initial.WritePolicy.RWMask&initial.WritePolicy.W1CMask != 0 {
+				return fmt.Errorf("initial register at %#x has overlapping RW/W1C masks", initial.Offset)
+			}
+		}
+		for j := range i {
+			previous := set.InitialRegisters[j]
+			if uint64(previous.Offset) < uint64(initial.Offset)+uint64(initial.Width) &&
+				uint64(initial.Offset) < uint64(previous.Offset)+uint64(previous.Width) {
+				return fmt.Errorf("initial registers at %#x and %#x overlap", previous.Offset, initial.Offset)
+			}
+		}
+	}
+	if set.UnknownInputPolicy != "" && set.UnknownInputPolicy != UnknownInputIgnore {
+		return fmt.Errorf("unsupported unknown_input_policy %q", set.UnknownInputPolicy)
+	}
+	if len(set.Rules) > MaxRules {
+		return fmt.Errorf("behavior rule count %d exceeds maximum %d", len(set.Rules), MaxRules)
+	}
+
+	ids := make(map[string]struct{}, len(set.Rules))
+	seenRules := make([]Rule, 0, len(set.Rules))
+	delayedCount := 0
+	var allDelayedUpdates []RegisterUpdate
+	for i, rule := range set.Rules {
+		if rule.ID == "" {
+			return fmt.Errorf("rule %d has no id", i)
+		}
+		if _, exists := ids[rule.ID]; exists {
+			return fmt.Errorf("duplicate behavior rule id %q", rule.ID)
+		}
+		ids[rule.ID] = struct{}{}
+		if rule.State == "" {
+			return fmt.Errorf("rule %q has no state", rule.ID)
+		}
+		if rule.Access != AccessRead && rule.Access != AccessWrite {
+			return fmt.Errorf("rule %q has invalid access %q", rule.ID, rule.Access)
+		}
+		validBits, ok := widthMask(rule.Width)
+		if !ok {
+			return fmt.Errorf("rule %q has unsupported width %d", rule.ID, rule.Width)
+		}
+		if uint64(rule.Offset)+uint64(rule.Width) > uint64(set.BARSize) {
+			return fmt.Errorf("rule %q access is outside BAR size %#x", rule.ID, set.BARSize)
+		}
+		if rule.Offset%uint32(rule.Width) != 0 {
+			return fmt.Errorf("rule %q access is misaligned", rule.ID)
+		}
+		if rule.ValueMask&^validBits != 0 || rule.Value&^validBits != 0 {
+			return fmt.Errorf("rule %q match exceeds its %d-byte width", rule.ID, rule.Width)
+		}
+		if rule.Confidence < 0 || rule.Confidence > 1 {
+			return fmt.Errorf("rule %q confidence must be between 0 and 1", rule.ID)
+		}
+		for _, previous := range seenRules {
+			sameKey := previous.State == rule.State && previous.Access == rule.Access &&
+				previous.Width == rule.Width && previous.Offset == rule.Offset
+			if sameKey && ((previous.Value^rule.Value)&previous.ValueMask&rule.ValueMask) == 0 {
+				return fmt.Errorf("rules %q and %q have overlapping matches", previous.ID, rule.ID)
+			}
+		}
+		seenRules = append(seenRules, rule)
+		if len(rule.Updates) > maxUpdatesPerAction {
+			return fmt.Errorf("rule %q has too many immediate updates", rule.ID)
+		}
+		if err := validateUpdateGroup(rule.Updates, set.BARSize); err != nil {
+			return fmt.Errorf("rule %q: %w", rule.ID, err)
+		}
+		delayUpdates := make(map[uint32][]RegisterUpdate)
+		delayStates := make(map[uint32]string)
+		for _, event := range rule.DelayedEvents {
+			delayedCount++
+			if event.DelayCycles == 0 || event.DelayCycles > MaxDelayCycles {
+				return fmt.Errorf("rule %q delay %d is outside 1..%d cycles", rule.ID, event.DelayCycles, MaxDelayCycles)
+			}
+			if len(event.Updates) == 0 && event.NextState == "" {
+				return fmt.Errorf("rule %q has an empty delayed event", rule.ID)
+			}
+			if len(event.Updates) > maxUpdatesPerAction {
+				return fmt.Errorf("rule %q delayed event has too many updates", rule.ID)
+			}
+			if err := validateUpdateGroup(event.Updates, set.BARSize); err != nil {
+				return fmt.Errorf("rule %q delayed event: %w", rule.ID, err)
+			}
+			if state := delayStates[event.DelayCycles]; state != "" && event.NextState != "" && state != event.NextState {
+				return fmt.Errorf("rule %q has contradictory states at delay %d", rule.ID, event.DelayCycles)
+			}
+			if event.NextState != "" {
+				delayStates[event.DelayCycles] = event.NextState
+			}
+			delayUpdates[event.DelayCycles] = append(delayUpdates[event.DelayCycles], event.Updates...)
+			allDelayedUpdates = append(allDelayedUpdates, event.Updates...)
+			if len(delayUpdates[event.DelayCycles]) > maxUpdatesPerAction {
+				return fmt.Errorf("rule %q has too many combined updates at delay %d", rule.ID, event.DelayCycles)
+			}
+		}
+		for delay, updates := range delayUpdates {
+			if err := validateUpdateGroup(updates, set.BARSize); err != nil {
+				return fmt.Errorf("rule %q events at delay %d: %w", rule.ID, delay, err)
+			}
+		}
+	}
+	if err := validateUpdateGroup(allDelayedUpdates, set.BARSize); err != nil {
+		return fmt.Errorf("delayed events: %w", err)
+	}
+	if delayedCount > MaxDelayedEvents {
+		return fmt.Errorf("behavior delayed event count %d exceeds maximum %d", delayedCount, MaxDelayedEvents)
+	}
+	return nil
+}
+
+func LoadRuleSet(path string) (*RuleSet, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read behavior rules %q: %w", path, err)
+	}
+	var set RuleSet
+	if err := json.Unmarshal(data, &set); err != nil {
+		return nil, fmt.Errorf("decode behavior rules %q: %w", path, err)
+	}
+	if err := Validate(&set); err != nil {
+		return nil, fmt.Errorf("validate behavior rules %q: %w", path, err)
+	}
+	return &set, nil
+}
+
+func SaveRuleSet(set *RuleSet, path string) error {
+	if err := Validate(set); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(set, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode behavior rules: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write behavior rules %q: %w", path, err)
+	}
+	return nil
+}
+
+type pendingEvent struct {
+	key       string
+	order     int
+	remaining uint32
+	event     DelayedEvent
+}
+
+type Engine struct {
+	set     *RuleSet
+	state   string
+	regs    map[uint32]uint64
+	pending []pendingEvent
+	matched []string
+	suppressNext bool
+	eventOrder map[string]int
+	writePolicies map[uint32]RegisterWritePolicy
+}
+
+func NewEngine(set *RuleSet) (*Engine, error) {
+	if err := Validate(set); err != nil {
+		return nil, err
+	}
+	regs := make(map[uint32]uint64, len(set.InitialRegisters))
+	for _, rule := range set.Rules {
+		for _, update := range rule.Updates {
+			if _, exists := regs[update.Offset]; !exists {
+				regs[update.Offset] = 0
+			}
+		}
+		for _, event := range rule.DelayedEvents {
+			for _, update := range event.Updates {
+				if _, exists := regs[update.Offset]; !exists {
+					regs[update.Offset] = 0
+				}
+			}
+		}
+	}
+	writePolicies := make(map[uint32]RegisterWritePolicy)
+	for _, initial := range set.InitialRegisters {
+		regs[initial.Offset] = initial.Value
+		if initial.WritePolicy != nil {
+			writePolicies[initial.Offset] = *initial.WritePolicy
+		}
+	}
+	eventOrder := make(map[string]int)
+	order := 0
+	for _, rule := range set.Rules {
+		for eventIndex := range rule.DelayedEvents {
+			eventOrder[fmt.Sprintf("%s/%d", rule.ID, eventIndex)] = order
+			order++
+		}
+	}
+	return &Engine{
+		set: set, state: set.InitialState, regs: regs, eventOrder: eventOrder, writePolicies: writePolicies,
+	}, nil
+}
+
+func (e *Engine) State() string { return e.state }
+
+func (e *Engine) Register(offset uint32) (uint64, bool) {
+	value, ok := e.regs[offset]
+	return value, ok
+}
+
+func applyUpdates(regs map[uint32]uint64, updates []RegisterUpdate) {
+	for _, update := range updates {
+		old := regs[update.Offset]
+		regs[update.Offset] = (old &^ update.Mask) | (update.Value & update.Mask)
+	}
+}
+
+func normalWriteValue(oldValue, writeValue uint64, width uint8, policy *RegisterWritePolicy) uint64 {
+	validBits, _ := widthMask(width)
+	rwMask := validBits
+	var w1cMask uint64
+	if policy != nil {
+		rwMask = policy.RWMask
+		w1cMask = policy.W1CMask
+	}
+	next := (oldValue &^ rwMask) | (writeValue & rwMask)
+	next &^= writeValue & w1cMask
+	return next & validBits
+}
+
+func (e *Engine) Apply(record mmio.AccessRecord) error {
+	if e == nil || e.set == nil {
+		return fmt.Errorf("behavior engine is nil")
+	}
+	width := record.Width
+	if width == 0 {
+		width = 4
+	}
+	var access AccessKind
+	switch record.Type {
+	case mmio.AccessRead:
+		access = AccessRead
+	case mmio.AccessWrite:
+		access = AccessWrite
+	default:
+		return fmt.Errorf("invalid MMIO access type %d", record.Type)
+	}
+	if e.suppressNext {
+		e.suppressNext = false
+		return nil
+	}
+	for _, rule := range e.set.Rules {
+		if rule.State != e.state || rule.Access != access || rule.Width != width || rule.Offset != record.Offset {
+			continue
+		}
+		if ((record.Value ^ rule.Value) & rule.ValueMask) != 0 {
+			continue
+		}
+		if access == AccessWrite {
+			for _, update := range rule.Updates {
+				if update.Offset == record.Offset && update.Width == width {
+					policy, hasPolicy := e.writePolicies[record.Offset]
+					if hasPolicy {
+						e.regs[record.Offset] = normalWriteValue(e.regs[record.Offset], record.Value, width, &policy)
+					} else {
+						e.regs[record.Offset] = normalWriteValue(e.regs[record.Offset], record.Value, width, nil)
+					}
+					break
+				}
+			}
+		}
+		applyUpdates(e.regs, rule.Updates)
+		if rule.NextState != "" {
+			e.state = rule.NextState
+		}
+		for eventIndex, event := range rule.DelayedEvents {
+			key := fmt.Sprintf("%s/%d", rule.ID, eventIndex)
+			alreadyPending := false
+			for _, pending := range e.pending {
+				if pending.key == key {
+					alreadyPending = true
+					break
+				}
+			}
+			if alreadyPending {
+				continue
+			}
+			if len(e.pending) >= MaxDelayedEvents {
+				return fmt.Errorf("pending behavior event limit %d exceeded", MaxDelayedEvents)
+			}
+			e.pending = append(e.pending, pendingEvent{key: key, order: e.eventOrder[key], remaining: event.DelayCycles, event: event})
+		}
+		e.matched = append(e.matched, rule.ID)
+		break
+	}
+	return nil
+}
+
+func (e *Engine) Advance(cycles uint32) error {
+	if e == nil {
+		return fmt.Errorf("behavior engine is nil")
+	}
+	exactDeadline := false
+	remaining := e.pending[:0]
+	var due []pendingEvent
+	for _, pending := range e.pending {
+		if pending.remaining > cycles {
+			pending.remaining -= cycles
+			remaining = append(remaining, pending)
+			continue
+		}
+		if pending.remaining == cycles && cycles != 0 {
+			exactDeadline = true
+		}
+		due = append(due, pending)
+	}
+	sort.Slice(due, func(i, j int) bool { return due[i].order < due[j].order })
+	var dueUpdates []RegisterUpdate
+	for _, pending := range due {
+		dueUpdates = append(dueUpdates, pending.event.Updates...)
+		if pending.event.NextState != "" {
+			e.state = pending.event.NextState
+		}
+	}
+	applyUpdates(e.regs, dueUpdates)
+	e.pending = remaining
+	e.suppressNext = exactDeadline
+	return nil
+}
+
+func durationToCycles(delta time.Duration, clockHz uint64) (uint64, error) {
+	if delta < 0 {
+		return 0, fmt.Errorf("negative duration")
+	}
+	seconds := uint64(delta / time.Second)
+	remainder := uint64(delta % time.Second)
+	maximum := ^uint64(0)
+	if seconds != 0 && clockHz > maximum/seconds {
+		return 0, fmt.Errorf("duration cycle conversion overflows")
+	}
+	whole := seconds * clockHz
+	if remainder != 0 && clockHz > maximum/remainder {
+		return 0, fmt.Errorf("duration cycle conversion overflows")
+	}
+	fraction := remainder * clockHz / uint64(time.Second)
+	if whole > maximum-fraction {
+		return 0, fmt.Errorf("duration cycle conversion overflows")
+	}
+	return whole + fraction, nil
+}
+
+func Replay(set *RuleSet, trace *mmio.TraceResult) (*ReplayResult, error) {
+	if trace == nil {
+		return nil, fmt.Errorf("replay trace is nil")
+	}
+	engine, err := NewEngine(set)
+	if err != nil {
+		return nil, err
+	}
+	if trace.BARIndex != set.BARIndex {
+		return nil, fmt.Errorf("trace BAR%d does not match rule BAR%d", trace.BARIndex, set.BARIndex)
+	}
+	var previous time.Duration
+	result := &ReplayResult{}
+	for index, record := range trace.Records {
+		if record.BARIndex != 0 && record.BARIndex != set.BARIndex {
+			return nil, fmt.Errorf("record %d BAR%d does not match rule BAR%d", index, record.BARIndex, set.BARIndex)
+		}
+		if record.Timestamp < previous {
+			return nil, fmt.Errorf("record %d timestamp is not monotonic", index)
+		}
+		delta := record.Timestamp - previous
+		cycles64, cycleErr := durationToCycles(delta, set.ClockHz)
+		if cycleErr != nil {
+			return nil, fmt.Errorf("record %d: %w", index, cycleErr)
+		}
+		if cycles64 > uint64(^uint32(0)) {
+			return nil, fmt.Errorf("record %d cycle delta %d exceeds engine bound", index, cycles64)
+		}
+		if err := engine.Advance(uint32(cycles64)); err != nil {
+			return nil, err
+		}
+		previous = record.Timestamp
+		if record.Type == mmio.AccessRead {
+			actual := engine.regs[record.Offset]
+			if actual != record.Value {
+				result.ReadMismatches = append(result.ReadMismatches, ReadMismatch{RecordIndex: index, Offset: record.Offset, Expected: record.Value, Actual: actual})
+			}
+		}
+		if err := engine.Apply(record); err != nil {
+			return nil, fmt.Errorf("record %d: %w", index, err)
+		}
+	}
+	result.TerminalState = engine.state
+	result.Registers = make(map[uint32]uint64, len(engine.regs))
+	for offset, value := range engine.regs {
+		result.Registers[offset] = value
+	}
+	result.MatchedRules = append(result.MatchedRules, engine.matched...)
+	return result, nil
+}
+
+type inferredObservation struct {
+	ordinal       int
+	triggerOffset uint32
+	triggerWidth  uint8
+	triggerValue  uint64
+	updateOffset  uint32
+	updateWidth   uint8
+	before        uint64
+	after         uint64
+	delayCycles   uint32
+	sessionIndex  int
+	provenance    string
+}
+
+func observations(trace *mmio.TraceResult, clockHz uint64, sessionIndex int) []inferredObservation {
+	var out []inferredObservation
+	ordinal := 0
+	for i, record := range trace.Records {
+		if record.Type != mmio.AccessWrite || record.Width != 4 || record.Offset%4 != 0 {
+			continue
+		}
+		baseline := make(map[uint32]mmio.AccessRecord)
+		for j := i + 1; j < len(trace.Records); j++ {
+			candidate := trace.Records[j]
+			if candidate.Type == mmio.AccessWrite {
+				break
+			}
+			if candidate.Type != mmio.AccessRead || candidate.Width != 4 || candidate.Offset%4 != 0 {
+				continue
+			}
+			before, exists := baseline[candidate.Offset]
+			if !exists {
+				baseline[candidate.Offset] = candidate
+				continue
+			}
+			if before.Value == candidate.Value || before.Width != candidate.Width {
+				continue
+			}
+			delta := candidate.Timestamp - record.Timestamp
+			if delta < 0 {
+				break
+			}
+			cycles, cycleErr := durationToCycles(delta, clockHz)
+			if cycleErr != nil || cycles > uint64(MaxDelayCycles) {
+				break
+			}
+			out = append(out, inferredObservation{
+				sessionIndex: sessionIndex,
+				ordinal: ordinal, triggerOffset: record.Offset, triggerWidth: record.Width,
+				triggerValue: record.Value, updateOffset: candidate.Offset, updateWidth: candidate.Width,
+				before: before.Value, after: candidate.Value, delayCycles: uint32(cycles),
+				provenance: fmt.Sprintf("session=%d trace=%s bar=%d record=%d", sessionIndex, trace.StartTime.UTC().Format(time.RFC3339Nano), trace.BARIndex, i),
+			})
+			ordinal++
+			break
+		}
+	}
+	return out
+}
+
+func Infer(traces ...*mmio.TraceResult) (*RuleSet, error) {
+	if len(traces) == 0 {
+		return nil, fmt.Errorf("behavior inference requires at least one trace")
+	}
+	first := traces[0]
+	if first == nil || first.BARSize <= 0 {
+		return nil, fmt.Errorf("trace 0 has no valid BAR aperture")
+	}
+	set := &RuleSet{
+		Version: RuleSchemaVersion, BDF: first.BDF, BARIndex: first.BARIndex, BARSize: first.BARSize,
+		ClockHz: DefaultRuleClockHz, InitialState: "initial", UnknownInputPolicy: UnknownInputIgnore,
+	}
+	type candidateGroup struct {
+		key      string
+		ordinal  int
+		outcomes map[uint64][]inferredObservation
+	}
+	groups := make(map[string]*candidateGroup)
+	for traceIndex, trace := range traces {
+		if trace == nil {
+			return nil, fmt.Errorf("trace %d is nil", traceIndex)
+		}
+		if trace.BDF != first.BDF || trace.BARIndex != first.BARIndex || trace.BARSize != first.BARSize {
+			return nil, fmt.Errorf("trace %d target does not match trace 0", traceIndex)
+		}
+		for _, obs := range observations(trace, set.ClockHz, traceIndex) {
+			key := fmt.Sprintf("%d/%d/%x/%d/%d/%x", obs.triggerOffset, obs.triggerWidth, obs.triggerValue, obs.updateOffset, obs.updateWidth, obs.before)
+			group, exists := groups[key]
+			if !exists {
+				group = &candidateGroup{key: key, ordinal: obs.ordinal, outcomes: make(map[uint64][]inferredObservation)}
+				groups[key] = group
+			}
+			if obs.ordinal < group.ordinal {
+				group.ordinal = obs.ordinal
+			}
+			group.outcomes[obs.after] = append(group.outcomes[obs.after], obs)
+		}
+	}
+	ordered := make([]*candidateGroup, 0, len(groups))
+	for _, group := range groups {
+		ordered = append(ordered, group)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].ordinal == ordered[j].ordinal {
+			return ordered[i].key < ordered[j].key
+		}
+		return ordered[i].ordinal < ordered[j].ordinal
+	})
+	initialValues := make(map[uint32]uint64)
+	for _, group := range ordered {
+		if len(group.outcomes) > 1 {
+			counterexamples := make([]string, 0, len(group.outcomes))
+			for value, observations := range group.outcomes {
+				sources := make([]string, 0, len(observations))
+				for _, observation := range observations {
+					sources = append(sources, observation.provenance)
+				}
+				sort.Strings(sources)
+				counterexamples = append(counterexamples, fmt.Sprintf("value=%#x provenance=%v", value, sources))
+			}
+			sort.Strings(counterexamples)
+			return nil, fmt.Errorf("conflicting observed transitions for %s: %v", group.key, counterexamples)
+		}
+		var supported []inferredObservation
+		for _, observations := range group.outcomes {
+			supported = observations
+		}
+		if len(supported) < 2 {
+			continue
+		}
+		sort.SliceStable(supported, func(i, j int) bool { return supported[i].delayCycles < supported[j].delayCycles })
+		obs := supported[len(supported)/2]
+		mask := obs.before ^ obs.after
+		if mask == 0 {
+			continue
+		}
+		if initial, exists := initialValues[obs.updateOffset]; exists && initial != obs.before {
+			return nil, fmt.Errorf("conflicting initial values at %#x", obs.updateOffset)
+		}
+		if _, exists := initialValues[obs.updateOffset]; !exists {
+			initialValues[obs.updateOffset] = obs.before
+			set.InitialRegisters = append(set.InitialRegisters, RegisterValue{Offset: obs.updateOffset, Width: obs.updateWidth, Value: obs.before})
+		}
+		state := "initial"
+		sessions := make(map[int]struct{})
+		for _, observation := range supported {
+			sessions[observation.sessionIndex] = struct{}{}
+		}
+		confidence := float64(len(sessions)) / float64(len(traces))
+		independentEvidence := float64(len(sessions)) / 2
+		if independentEvidence > 1 {
+			independentEvidence = 1
+		}
+		if confidence > independentEvidence {
+			confidence = independentEvidence
+		}
+		update := RegisterUpdate{Offset: obs.updateOffset, Width: obs.updateWidth, Value: obs.after, Mask: mask}
+		rule := Rule{
+			ID: fmt.Sprintf("trace_rule_%d", len(set.Rules)+1), State: state, Access: AccessWrite,
+			Width: obs.triggerWidth, Offset: obs.triggerOffset, Value: obs.triggerValue,
+			ValueMask: mustWidthMask(obs.triggerWidth), Confidence: confidence,
+		}
+		for _, source := range supported {
+			rule.Provenance = append(rule.Provenance, source.provenance)
+		}
+		if obs.delayCycles == 0 {
+			rule.Updates = []RegisterUpdate{update}
+		} else {
+			rule.DelayedEvents = []DelayedEvent{{DelayCycles: obs.delayCycles, Updates: []RegisterUpdate{update}}}
+		}
+		set.Rules = append(set.Rules, rule)
+		if len(set.Rules) >= MaxRules {
+			break
+		}
+	}
+	if err := Validate(set); err != nil {
+		return nil, err
+	}
+	return set, nil
+}
+
+func mustWidthMask(width uint8) uint64 {
+	mask, _ := widthMask(width)
+	return mask
+}

--- a/internal/donor/behavior/rules_pending_test.go
+++ b/internal/donor/behavior/rules_pending_test.go
@@ -1,0 +1,233 @@
+package behavior
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+)
+
+func TestReplayRetriggerKeepsFirstPendingDeadline(t *testing.T) {
+	set := validReviewerRuleSet()
+	set.Rules = []Rule{{
+		ID: "queue", State: "idle", Access: AccessWrite, Width: 4,
+		Offset: 0x20, Value: 1, ValueMask: math.MaxUint32,
+		DelayedEvents: []DelayedEvent{{
+			DelayCycles: 5,
+			Updates: []RegisterUpdate{{Offset: 0x24, Width: 4, Value: 1, Mask: math.MaxUint32}},
+		}},
+		Confidence: 1, Provenance: []string{"test"},
+	}}
+	trace := &mmio.TraceResult{
+		BARIndex: 0, BARSize: 0x1000, Duration: 70 * time.Nanosecond,
+		Records: []mmio.AccessRecord{
+			{Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 1},
+			{Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 1, Timestamp: 20 * time.Nanosecond},
+			{Type: mmio.AccessRead, Width: 4, Offset: 0x24, Value: 1, Timestamp: 50 * time.Nanosecond},
+			{Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 1, Timestamp: 70 * time.Nanosecond},
+		},
+	}
+	result, err := Replay(set, trace)
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if len(result.ReadMismatches) != 0 {
+		t.Fatalf("first deadline was restarted or lost: %+v", result.ReadMismatches)
+	}
+	if len(result.MatchedRules) != 3 {
+		t.Fatalf("matched rules = %v, want initial, retrigger, and post-deadline trigger", result.MatchedRules)
+	}
+}
+
+func simultaneousReviewerRules() *RuleSet {
+	set := validReviewerRuleSet()
+	set.Rules = []Rule{
+		{
+			ID: "low", State: "idle", Access: AccessWrite, Width: 4,
+			Offset: 0x20, Value: 1, ValueMask: math.MaxUint32,
+			DelayedEvents: []DelayedEvent{{
+				DelayCycles: 5,
+				Updates: []RegisterUpdate{{Offset: 0x24, Width: 4, Value: 0x05, Mask: 0x0f}},
+				NextState: "first",
+			}},
+			Confidence: 1, Provenance: []string{"test"},
+		},
+		{
+			ID: "high", State: "idle", Access: AccessWrite, Width: 4,
+			Offset: 0x28, Value: 1, ValueMask: math.MaxUint32,
+			DelayedEvents: []DelayedEvent{{
+				DelayCycles: 4,
+				Updates: []RegisterUpdate{{Offset: 0x24, Width: 4, Value: 0xa0, Mask: 0xf0}},
+				NextState: "second",
+			}},
+			Confidence: 1, Provenance: []string{"test"},
+		},
+	}
+	return set
+}
+
+func TestReplayComposesCrossRuleEventsDueTogether(t *testing.T) {
+	set := simultaneousReviewerRules()
+	if err := Validate(set); err != nil {
+		t.Fatalf("disjoint cross-rule events should validate: %v", err)
+	}
+	trace := &mmio.TraceResult{
+		BARIndex: 0, BARSize: 0x1000, Duration: 50 * time.Nanosecond,
+		Records: []mmio.AccessRecord{
+			{Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 1},
+			{Type: mmio.AccessWrite, Width: 4, Offset: 0x28, Value: 1, Timestamp: 10 * time.Nanosecond},
+			{Type: mmio.AccessRead, Width: 4, Offset: 0x24, Value: 0xa5, Timestamp: 50 * time.Nanosecond},
+		},
+	}
+	result, err := Replay(set, trace)
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if len(result.ReadMismatches) != 0 || result.Registers[0x24] != 0xa5 {
+		t.Fatalf("cross-rule composed result = %+v", result)
+	}
+	if result.TerminalState != "second" {
+		t.Fatalf("terminal state = %q, want stable later-event state second", result.TerminalState)
+	}
+}
+
+func TestValidateRejectsContradictoryCrossRuleDelayedUpdates(t *testing.T) {
+	set := simultaneousReviewerRules()
+	set.Rules[1].DelayedEvents[0].Updates[0] = RegisterUpdate{Offset: 0x24, Width: 4, Value: 0, Mask: 1}
+	if err := Validate(set); err == nil {
+		t.Fatal("potentially simultaneous contradictory cross-rule updates should be rejected")
+	}
+}
+
+func TestInferDoesNotCrossTraceSessionBoundary(t *testing.T) {
+	first := &mmio.TraceResult{
+		BDF: "0000:03:00.0", BARIndex: 0, BARSize: 0x1000,
+		Records: []mmio.AccessRecord{{
+			Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 1,
+		}},
+	}
+	second := &mmio.TraceResult{
+		BDF: "0000:03:00.0", BARIndex: 0, BARSize: 0x1000,
+		Records: []mmio.AccessRecord{
+			{Type: mmio.AccessRead, Width: 4, Offset: 0x24, Value: 0},
+			{Type: mmio.AccessRead, Width: 4, Offset: 0x24, Value: 1, Timestamp: time.Microsecond},
+		},
+	}
+	set, err := Infer(first, second)
+	if err != nil {
+		t.Fatalf("Infer: %v", err)
+	}
+	if len(set.Rules) != 0 {
+		t.Fatalf("inference crossed capture session boundary: %+v", set.Rules)
+	}
+}
+
+func TestEngineAndReplayComposeTriggerWriteBeforeSameRegisterUpdate(t *testing.T) {
+	set := validReviewerRuleSet()
+	set.Rules = []Rule{{
+		ID: "compose-self", State: "idle", Access: AccessWrite, Width: 4,
+		Offset: 0x20, Value: 0x12345678, ValueMask: math.MaxUint32,
+		Updates: []RegisterUpdate{{
+			Offset: 0x20, Width: 4, Value: 0x0000ab00, Mask: 0x0000ff00,
+		}},
+		Confidence: 1, Provenance: []string{"test"},
+	}}
+	engine, err := NewEngine(set)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	record := mmio.AccessRecord{Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 0x12345678}
+	if err := engine.Apply(record); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got, ok := engine.Register(0x20); !ok || got != 0x1234ab78 {
+		t.Fatalf("engine composed value = %#x, present=%v, want 0x1234ab78", got, ok)
+	}
+	result, err := Replay(set, &mmio.TraceResult{
+		BARIndex: 0, BARSize: 0x1000, Records: []mmio.AccessRecord{record},
+	})
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if got := result.Registers[0x20]; got != 0x1234ab78 {
+		t.Fatalf("replay composed value = %#x, want 0x1234ab78", got)
+	}
+}
+
+func TestEngineAndReplayApplyWritePolicyBeforeSameRegisterRuleUpdate(t *testing.T) {
+	set := validReviewerRuleSet()
+	set.InitialRegisters = []RegisterValue{{
+		Offset: 0x20, Width: 4, Value: 0xa5f0cc33,
+		WritePolicy: &RegisterWritePolicy{RWMask: 0x0000000f, W1CMask: 0x000000f0},
+	}}
+	set.Rules = []Rule{{
+		ID: "compose-policy", State: "idle", Access: AccessWrite, Width: 4,
+		Offset: 0x20, Value: 0x123456a5, ValueMask: math.MaxUint32,
+		Updates: []RegisterUpdate{{
+			Offset: 0x20, Width: 4, Value: 0x00005a00, Mask: 0x0000ff00,
+		}},
+		Confidence: 1, Provenance: []string{"test"},
+	}}
+	record := mmio.AccessRecord{
+		Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 0x123456a5,
+	}
+	engine, err := NewEngine(set)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	if err := engine.Apply(record); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got, ok := engine.Register(0x20); !ok || got != 0xa5f05a15 {
+		t.Fatalf("engine policy composition = %#x, present=%v, want 0xa5f05a15", got, ok)
+	}
+	result, err := Replay(set, &mmio.TraceResult{
+		BARIndex: 0, BARSize: 0x1000, Records: []mmio.AccessRecord{record},
+	})
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if got := result.Registers[0x20]; got != 0xa5f05a15 {
+		t.Fatalf("replay policy composition = %#x, want 0xa5f05a15", got)
+	}
+}
+
+func TestReplayMasksExtraneousBitsPerSimultaneousDelayedContribution(t *testing.T) {
+	set := validReviewerRuleSet()
+	set.InitialRegisters = []RegisterValue{{Offset: 0x24, Width: 4, Value: 3}}
+	set.Rules = []Rule{
+		{
+			ID: "clear-bit0", State: "idle", Access: AccessWrite, Width: 4,
+			Offset: 0x20, Value: 1, ValueMask: math.MaxUint32,
+			DelayedEvents: []DelayedEvent{{
+				DelayCycles: 5,
+				Updates: []RegisterUpdate{{Offset: 0x24, Width: 4, Value: 2, Mask: 1}},
+			}},
+			Confidence: 1, Provenance: []string{"test"},
+		},
+		{
+			ID: "clear-bit1", State: "idle", Access: AccessWrite, Width: 4,
+			Offset: 0x28, Value: 1, ValueMask: math.MaxUint32,
+			DelayedEvents: []DelayedEvent{{
+				DelayCycles: 4,
+				Updates: []RegisterUpdate{{Offset: 0x24, Width: 4, Value: 0, Mask: 2}},
+			}},
+			Confidence: 1, Provenance: []string{"test"},
+		},
+	}
+	result, err := Replay(set, &mmio.TraceResult{
+		BARIndex: 0, BARSize: 0x1000,
+		Records: []mmio.AccessRecord{
+			{Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 1},
+			{Type: mmio.AccessWrite, Width: 4, Offset: 0x28, Value: 1, Timestamp: 10 * time.Nanosecond},
+			{Type: mmio.AccessRead, Width: 4, Offset: 0x24, Value: 0, Timestamp: 50 * time.Nanosecond},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if len(result.ReadMismatches) != 0 || result.Registers[0x24] != 0 {
+		t.Fatalf("extraneous contribution bits leaked: %+v", result)
+	}
+}

--- a/internal/donor/behavior/rules_reviewer_test.go
+++ b/internal/donor/behavior/rules_reviewer_test.go
@@ -1,0 +1,193 @@
+package behavior
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+)
+
+func validReviewerRuleSet() *RuleSet {
+	return &RuleSet{
+		Version: RuleSchemaVersion, BARSize: 0x1000, ClockHz: 100_000_000, InitialState: "idle",
+	}
+}
+
+func TestValidateUpdateCompositionAndContradiction(t *testing.T) {
+	set := validReviewerRuleSet()
+	set.Rules = []Rule{{
+		ID: "compose", State: "idle", Access: AccessWrite, Width: 4,
+		Offset: 0x20, Value: 1, ValueMask: math.MaxUint32,
+		Updates: []RegisterUpdate{
+			{Offset: 0x24, Width: 4, Value: 0x00000005, Mask: 0x0000000f},
+			{Offset: 0x24, Width: 4, Value: 0x000000a0, Mask: 0x000000f0},
+		},
+		DelayedEvents: []DelayedEvent{
+			{DelayCycles: 3, Updates: []RegisterUpdate{
+				{Offset: 0x24, Width: 4, Value: 0x00000300, Mask: 0x00000f00},
+			}},
+			{DelayCycles: 3, Updates: []RegisterUpdate{
+				{Offset: 0x24, Width: 4, Value: 0x0000c000, Mask: 0x0000f000},
+			}},
+		},
+		Confidence: 1, Provenance: []string{"test"},
+	}}
+	if err := Validate(set); err != nil {
+		t.Fatalf("disjoint same-register updates should compose: %v", err)
+	}
+	engine, err := NewEngine(set)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	if err := engine.Apply(mmio.AccessRecord{Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 1}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got, ok := engine.Register(0x24); !ok || got != 0x000000a5 {
+		t.Fatalf("immediate composed value = %#x, present=%v, want 0xa5", got, ok)
+	}
+	if err := engine.Advance(3); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if got, ok := engine.Register(0x24); !ok || got != 0x0000c3a5 {
+		t.Fatalf("delayed composed value = %#x, present=%v, want 0xc3a5", got, ok)
+	}
+
+	set.Rules[0].Updates = []RegisterUpdate{
+		{Offset: 0x24, Width: 4, Value: 0, Mask: 1},
+		{Offset: 0x24, Width: 4, Value: 1, Mask: 1},
+	}
+	set.Rules[0].DelayedEvents = nil
+	if err := Validate(set); err == nil {
+		t.Fatal("contradictory overlapping updates to one register should be rejected")
+	}
+	set.Rules[0].Updates = nil
+	set.Rules[0].DelayedEvents = []DelayedEvent{
+		{DelayCycles: 3, Updates: []RegisterUpdate{{Offset: 0x24, Width: 4, Value: 0, Mask: 1}}},
+		{DelayCycles: 3, Updates: []RegisterUpdate{{Offset: 0x24, Width: 4, Value: 1, Mask: 1}}},
+	}
+	if err := Validate(set); err == nil {
+		t.Fatal("contradictory overlapping updates at one deadline should be rejected")
+	}
+}
+
+func reviewerInferenceTrace(triggerWidth uint8, triggerOffset uint32, statusWidth uint8, statusOffset uint32) *mmio.TraceResult {
+	return &mmio.TraceResult{
+		BDF: "0000:03:00.0", BARIndex: 0, BARSize: 0x1000,
+		Records: []mmio.AccessRecord{
+			{Type: mmio.AccessWrite, Width: triggerWidth, Offset: triggerOffset, Value: 1},
+			{Type: mmio.AccessRead, Width: statusWidth, Offset: statusOffset, Value: 0, Timestamp: time.Microsecond},
+			{Type: mmio.AccessRead, Width: statusWidth, Offset: statusOffset, Value: 1, Timestamp: 2 * time.Microsecond},
+			{Type: mmio.AccessWrite, Width: triggerWidth, Offset: triggerOffset, Value: 1, Timestamp: 3 * time.Microsecond},
+			{Type: mmio.AccessRead, Width: statusWidth, Offset: statusOffset, Value: 0, Timestamp: 4 * time.Microsecond},
+			{Type: mmio.AccessRead, Width: statusWidth, Offset: statusOffset, Value: 1, Timestamp: 5 * time.Microsecond},
+		},
+	}
+}
+
+func TestInferFiltersRulesUnsupportedByRTL(t *testing.T) {
+	cases := []struct {
+		name          string
+		triggerWidth  uint8
+		triggerOffset uint32
+		statusWidth   uint8
+		statusOffset  uint32
+	}{
+		{name: "byte trigger", triggerWidth: 1, triggerOffset: 0x20, statusWidth: 4, statusOffset: 0x24},
+		{name: "word trigger", triggerWidth: 2, triggerOffset: 0x20, statusWidth: 4, statusOffset: 0x24},
+		{name: "qword trigger", triggerWidth: 8, triggerOffset: 0x20, statusWidth: 4, statusOffset: 0x24},
+		{name: "unaligned trigger", triggerWidth: 4, triggerOffset: 0x22, statusWidth: 4, statusOffset: 0x24},
+		{name: "byte status", triggerWidth: 4, triggerOffset: 0x20, statusWidth: 1, statusOffset: 0x24},
+		{name: "word status", triggerWidth: 4, triggerOffset: 0x20, statusWidth: 2, statusOffset: 0x24},
+		{name: "qword status", triggerWidth: 4, triggerOffset: 0x20, statusWidth: 8, statusOffset: 0x28},
+		{name: "unaligned status", triggerWidth: 4, triggerOffset: 0x20, statusWidth: 4, statusOffset: 0x26},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			set, err := Infer(reviewerInferenceTrace(tc.triggerWidth, tc.triggerOffset, tc.statusWidth, tc.statusOffset))
+			if err != nil {
+				t.Fatalf("Infer should filter unsupported observation, not fail: %v", err)
+			}
+			if len(set.Rules) != 0 {
+				t.Fatalf("inferred unsupported rules = %+v", set.Rules)
+			}
+		})
+	}
+}
+
+func TestReplaySuppressesTriggerAtDelayedEventDeadline(t *testing.T) {
+	set := validReviewerRuleSet()
+	set.Rules = []Rule{
+		{
+			ID: "arm", State: "idle", Access: AccessWrite, Width: 4,
+			Offset: 0x20, Value: 1, ValueMask: math.MaxUint32,
+			DelayedEvents: []DelayedEvent{{
+				DelayCycles: 5,
+				Updates: []RegisterUpdate{{Offset: 0x24, Width: 4, Value: 1, Mask: math.MaxUint32}},
+				NextState: "armed",
+			}},
+			Confidence: 1, Provenance: []string{"test"},
+		},
+		{
+			ID: "fire", State: "armed", Access: AccessWrite, Width: 4,
+			Offset: 0x28, Value: 1, ValueMask: math.MaxUint32, NextState: "fired",
+			Confidence: 1, Provenance: []string{"test"},
+		},
+	}
+	trace := &mmio.TraceResult{
+		BARIndex: 0, BARSize: 0x1000, Duration: 50 * time.Nanosecond,
+		Records: []mmio.AccessRecord{
+			{Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 1},
+			{Type: mmio.AccessWrite, Width: 4, Offset: 0x28, Value: 1, Timestamp: 50 * time.Nanosecond},
+		},
+	}
+	result, err := Replay(set, trace)
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if result.TerminalState != "armed" {
+		t.Fatalf("terminal state = %q, want delayed event state armed", result.TerminalState)
+	}
+	if len(result.MatchedRules) != 1 || result.MatchedRules[0] != "arm" {
+		t.Fatalf("same-cycle trigger was not suppressed: matched %v", result.MatchedRules)
+	}
+	if got := result.Registers[0x24]; got != 1 {
+		t.Fatalf("deadline update = %#x, want 1", got)
+	}
+}
+
+func TestReplayRejectsOverflowingTimestampCycleDelta(t *testing.T) {
+	set := validReviewerRuleSet()
+	trace := &mmio.TraceResult{
+		BARIndex: 0, BARSize: 0x1000,
+		Records: []mmio.AccessRecord{{
+			Type: mmio.AccessRead, Width: 4, Offset: 0x24,
+			Timestamp: 147573952590 * time.Nanosecond,
+		}},
+	}
+	if _, err := Replay(set, trace); err == nil {
+		t.Fatal("overflowing timestamp conversion should reject instead of wrapping to an immediate cycle")
+	}
+}
+
+func TestInferDoesNotWrapHugeDelayIntoImmediateRule(t *testing.T) {
+	delta := 147573952590 * time.Nanosecond
+	trace := &mmio.TraceResult{
+		BDF: "0000:03:00.0", BARIndex: 0, BARSize: 0x1000,
+		Records: []mmio.AccessRecord{
+			{Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 1},
+			{Type: mmio.AccessRead, Width: 4, Offset: 0x24, Value: 0, Timestamp: time.Nanosecond},
+			{Type: mmio.AccessRead, Width: 4, Offset: 0x24, Value: 1, Timestamp: delta},
+			{Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 1, Timestamp: delta + time.Nanosecond},
+			{Type: mmio.AccessRead, Width: 4, Offset: 0x24, Value: 0, Timestamp: delta + 2*time.Nanosecond},
+			{Type: mmio.AccessRead, Width: 4, Offset: 0x24, Value: 1, Timestamp: 2*delta + time.Nanosecond},
+		},
+	}
+	set, err := Infer(trace)
+	if err != nil {
+		t.Fatalf("Infer: %v", err)
+	}
+	if len(set.Rules) != 0 {
+		t.Fatalf("huge delay wrapped into inferred rule: %+v", set.Rules)
+	}
+}

--- a/internal/donor/behavior/rules_test.go
+++ b/internal/donor/behavior/rules_test.go
@@ -1,0 +1,258 @@
+package behavior
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+)
+
+func transitionTrace(polls int) *mmio.TraceResult {
+	records := []mmio.AccessRecord{
+		{BDF: "0000:03:00.0", BARIndex: 2, Address: 0xf7800020, Offset: 0x20, Width: 4, Type: mmio.AccessWrite, Value: 1, Timestamp: 0},
+	}
+	for i := range polls {
+		records = append(records, mmio.AccessRecord{
+			BDF: "0000:03:00.0", BARIndex: 2, Address: 0xf7800024, Offset: 0x24, Width: 4,
+			Type: mmio.AccessRead, Value: 0, Timestamp: time.Duration(i+1) * 10 * time.Microsecond,
+		})
+	}
+	records = append(records, mmio.AccessRecord{
+		BDF: "0000:03:00.0", BARIndex: 2, Address: 0xf7800024, Offset: 0x24, Width: 4,
+		Type: mmio.AccessRead, Value: 1, Timestamp: time.Duration(polls+1) * 10 * time.Microsecond,
+	})
+	return &mmio.TraceResult{
+		BDF: "0000:03:00.0", BARIndex: 2, BARSize: 0x4000, Records: records,
+	}
+}
+
+func TestInfer_DeterministicRulesCarryConfidenceAndProvenance(t *testing.T) {
+	first, err := Infer(transitionTrace(3), transitionTrace(5))
+	if err != nil {
+		t.Fatalf("Infer first: %v", err)
+	}
+	second, err := Infer(transitionTrace(3), transitionTrace(5))
+	if err != nil {
+		t.Fatalf("Infer second: %v", err)
+	}
+	if err := Validate(first); err != nil {
+		t.Fatalf("inferred rules are invalid: %v", err)
+	}
+	if len(first.Rules) == 0 {
+		t.Fatal("expected a repeated write-triggered status transition to produce a rule")
+	}
+
+	firstJSON, err := json.Marshal(first)
+	if err != nil {
+		t.Fatalf("marshal first rules: %v", err)
+	}
+	secondJSON, err := json.Marshal(second)
+	if err != nil {
+		t.Fatalf("marshal second rules: %v", err)
+	}
+	if !bytes.Equal(firstJSON, secondJSON) {
+		t.Fatalf("identical traces produced nondeterministic JSON:\nfirst:  %s\nsecond: %s", firstJSON, secondJSON)
+	}
+
+	var document struct {
+		Version int `json:"version"`
+		Rules   []struct {
+			Confidence float64         `json:"confidence"`
+			Provenance json.RawMessage `json:"provenance"`
+		} `json:"rules"`
+	}
+	if err := json.Unmarshal(firstJSON, &document); err != nil {
+		t.Fatalf("decode rule schema: %v", err)
+	}
+	if document.Version != RuleSchemaVersion {
+		t.Fatalf("schema version = %d, want %d", document.Version, RuleSchemaVersion)
+	}
+	for i, rule := range document.Rules {
+		if rule.Confidence <= 0 || rule.Confidence > 1 {
+			t.Errorf("rule %d confidence = %v, want (0,1]", i, rule.Confidence)
+		}
+		if len(rule.Provenance) == 0 || bytes.Equal(rule.Provenance, []byte("null")) || bytes.Equal(rule.Provenance, []byte(`""`)) {
+			t.Errorf("rule %d has no provenance: %s", i, rule.Provenance)
+		}
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(firstJSON, &schema); err != nil {
+		t.Fatalf("decode canonical schema: %v", err)
+	}
+	for _, key := range []string{"version", "bar_index", "bar_size", "clock_hz", "initial_state", "rules"} {
+		if _, ok := schema[key]; !ok {
+			t.Errorf("canonical rule JSON missing snake_case field %q: %v", key, schema)
+		}
+	}
+	ruleObjects, ok := schema["rules"].([]any)
+	if !ok || len(ruleObjects) == 0 {
+		t.Fatalf("canonical rules field = %#v", schema["rules"])
+	}
+	ruleObject, ok := ruleObjects[0].(map[string]any)
+	if !ok {
+		t.Fatalf("canonical first rule = %#v", ruleObjects[0])
+	}
+	for _, key := range []string{"id", "state", "access", "width", "offset", "value_mask", "confidence", "provenance"} {
+		if _, ok := ruleObject[key]; !ok {
+			t.Errorf("canonical rule JSON missing snake_case field %q: %v", key, ruleObject)
+		}
+	}
+}
+
+func TestInfer_RejectsConflictingObservedTransitions(t *testing.T) {
+	readyOne := transitionTrace(3)
+	readyTwo := transitionTrace(3)
+	readyTwo.Records[len(readyTwo.Records)-1].Value = 2
+	if _, err := Infer(readyOne, readyTwo); err == nil {
+		t.Fatal("expected conflicting observations of the same trigger and status register to be rejected")
+	}
+}
+
+func TestValidate_RejectsConflictingRules(t *testing.T) {
+	rules := &RuleSet{
+		Version:      RuleSchemaVersion,
+		BARSize:      0x1000,
+		ClockHz:      100_000_000,
+		InitialState: "idle",
+		Rules: []Rule{
+			{ID: "to-a", State: "idle", Access: AccessKind("write"), Width: 4, Offset: 0x20, Value: 1, ValueMask: math.MaxUint32, NextState: "a", Confidence: 1, Provenance: []string{"test"}},
+			{ID: "to-b", State: "idle", Access: AccessKind("write"), Width: 4, Offset: 0x20, Value: 1, ValueMask: math.MaxUint32, NextState: "b", Confidence: 1, Provenance: []string{"test"}},
+		},
+	}
+	if err := Validate(rules); err == nil {
+		t.Fatal("expected indistinguishable triggers with conflicting effects to be rejected")
+	}
+}
+
+func TestValidate_RejectsUnboundedDelay(t *testing.T) {
+	rules := &RuleSet{
+		Version:      RuleSchemaVersion,
+		BARSize:      0x1000,
+		ClockHz:      100_000_000,
+		InitialState: "idle",
+		Rules: []Rule{{
+			ID: "unbounded", State: "idle", Access: AccessKind("write"), Width: 4,
+			Offset: 0x20, Value: 1, ValueMask: math.MaxUint32,
+			DelayedEvents: []DelayedEvent{{DelayCycles: MaxDelayCycles + 1, NextState: "ready"}},
+			Confidence: 1, Provenance: []string{"test"},
+		}},
+	}
+	if err := Validate(rules); err == nil {
+		t.Fatal("expected an unbounded learned delay to be rejected")
+	}
+	rules.Rules[0].DelayedEvents[0].DelayCycles = MaxDelayCycles
+	if err := Validate(rules); err != nil {
+		t.Fatalf("maximum bounded delay should be valid: %v", err)
+	}
+}
+
+func TestEngine_DelayedTransitionIsPollingInsensitive(t *testing.T) {
+	rules := &RuleSet{
+		Version:      RuleSchemaVersion,
+		BARSize:      0x1000,
+		ClockHz:      100_000_000,
+		InitialState: "idle",
+		Rules: []Rule{{
+			ID: "start", State: "idle", Access: AccessKind("write"), Width: 4,
+			Offset: 0x20, Value: 1, ValueMask: math.MaxUint32, NextState: "waiting",
+			DelayedEvents: []DelayedEvent{{
+				DelayCycles: 5,
+				Updates: []RegisterUpdate{{Offset: 0x24, Width: 4, Value: 1, Mask: math.MaxUint32}},
+				NextState: "ready",
+			}},
+			Confidence: 1, Provenance: []string{"test"},
+		}},
+	}
+
+	run := func(t *testing.T, polls int) (*Engine, uint64) {
+		t.Helper()
+		engine, err := NewEngine(rules)
+		if err != nil {
+			t.Fatalf("NewEngine: %v", err)
+		}
+		if err := engine.Apply(mmio.AccessRecord{Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 1}); err != nil {
+			t.Fatalf("apply trigger: %v", err)
+		}
+		engine.Advance(4)
+		for i := range polls {
+			if err := engine.Apply(mmio.AccessRecord{Type: mmio.AccessRead, Width: 4, Offset: 0x24}); err != nil {
+				t.Fatalf("apply poll %d: %v", i, err)
+			}
+		}
+		if engine.State() != "waiting" {
+			t.Fatalf("state before final cycle = %q, want waiting", engine.State())
+		}
+		engine.Advance(1)
+		value, ok := engine.Register(0x24)
+		if !ok {
+			t.Fatal("status register missing after delayed update")
+		}
+		return engine, value
+	}
+
+	withoutPolls, valueWithoutPolls := run(t, 0)
+	withPolls, valueWithPolls := run(t, 100)
+	if withoutPolls.State() != "ready" || withPolls.State() != "ready" {
+		t.Fatalf("final states = %q and %q, want ready", withoutPolls.State(), withPolls.State())
+	}
+	if valueWithoutPolls != 1 || valueWithPolls != 1 {
+		t.Fatalf("status values = %#x and %#x, want 1", valueWithoutPolls, valueWithPolls)
+	}
+}
+
+func TestReplay_PollCountDoesNotChangeObservedTransition(t *testing.T) {
+	rules := &RuleSet{
+		Version: RuleSchemaVersion, BARSize: 0x1000, ClockHz: 100_000_000, InitialState: "idle",
+		Rules: []Rule{{
+			ID: "start", State: "idle", Access: AccessKind("write"), Width: 4,
+			Offset: 0x20, Value: 1, ValueMask: math.MaxUint32, NextState: "waiting",
+			DelayedEvents: []DelayedEvent{{
+				DelayCycles: 5,
+				Updates: []RegisterUpdate{{Offset: 0x24, Width: 4, Value: 1, Mask: math.MaxUint32}},
+				NextState: "ready",
+			}},
+			Confidence: 1, Provenance: []string{"test"},
+		}},
+	}
+	traceWithPolls := func(polls int) *mmio.TraceResult {
+		records := []mmio.AccessRecord{
+			{Type: mmio.AccessWrite, Width: 4, Offset: 0x20, Value: 1},
+		}
+		for range polls {
+			records = append(records, mmio.AccessRecord{
+				Type: mmio.AccessRead, Width: 4, Offset: 0x24, Value: 0, Timestamp: 10 * time.Nanosecond,
+			})
+		}
+		records = append(records, mmio.AccessRecord{
+			Type: mmio.AccessRead, Width: 4, Offset: 0x24, Value: 1, Timestamp: 50 * time.Nanosecond,
+		})
+		return &mmio.TraceResult{BARSize: 0x1000, Duration: 50 * time.Nanosecond, Records: records}
+	}
+
+	for _, polls := range []int{0, 1, 100} {
+		result, err := Replay(rules, traceWithPolls(polls))
+		if err != nil {
+			t.Errorf("Replay with %d redundant polls: %v", polls, err)
+			continue
+		}
+		if result == nil {
+			t.Errorf("Replay with %d redundant polls returned nil result", polls)
+			continue
+		}
+		if result.TerminalState != "ready" {
+			t.Errorf("Replay with %d polls terminal state = %q, want ready", polls, result.TerminalState)
+		}
+		if got := result.Registers[0x24]; got != 1 {
+			t.Errorf("Replay with %d polls status = %#x, want 1", polls, got)
+		}
+		if len(result.MatchedRules) != 1 || result.MatchedRules[0] != "start" {
+			t.Errorf("Replay with %d polls matched rules = %v, want [start]", polls, result.MatchedRules)
+		}
+		if len(result.ReadMismatches) != 0 {
+			t.Errorf("Replay with %d polls mismatches = %+v", polls, result.ReadMismatches)
+		}
+	}
+}

--- a/internal/donor/context.go
+++ b/internal/donor/context.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/sercanarga/pcileechgen/internal/donor/behavior"
 	"github.com/sercanarga/pcileechgen/internal/pci"
 )
 
@@ -47,6 +48,7 @@ type DeviceContext struct {
 	ExtCapabilities []pci.ExtCapability `json:"ext_capabilities,omitempty"`
 	MSIXData        *MSIXData           `json:"msix_data,omitempty"`
 	NVMeIdentity    *NVMeIdentity       `json:"nvme_identity,omitempty"`
+	BehaviorRules   *behavior.RuleSet   `json:"behavior_rules,omitempty"`
 }
 
 // JSON wire format - config space as hex words, BARs as base64.
@@ -64,6 +66,7 @@ type deviceContextJSON struct {
 	ExtCapabilities []pci.ExtCapability    `json:"ext_capabilities,omitempty"`
 	MSIXData        *MSIXData              `json:"msix_data,omitempty"`
 	NVMeIdentity    *NVMeIdentity          `json:"nvme_identity,omitempty"`
+	BehaviorRules   *behavior.RuleSet      `json:"behavior_rules,omitempty"`
 }
 
 func (dc *DeviceContext) MarshalJSON() ([]byte, error) {
@@ -77,6 +80,7 @@ func (dc *DeviceContext) MarshalJSON() ([]byte, error) {
 		ExtCapabilities: dc.ExtCapabilities,
 		MSIXData:        dc.MSIXData,
 		NVMeIdentity:    dc.NVMeIdentity,
+		BehaviorRules:   dc.BehaviorRules,
 	}
 
 	if dc.ConfigSpace != nil {
@@ -125,6 +129,7 @@ func (dc *DeviceContext) UnmarshalJSON(data []byte) error {
 	dc.ExtCapabilities = j.ExtCapabilities
 	dc.MSIXData = j.MSIXData
 	dc.NVMeIdentity = j.NVMeIdentity
+	dc.BehaviorRules = j.BehaviorRules
 
 	// Reconstruct config space from hex words
 	if len(j.ConfigSpaceHex) > 0 {
@@ -179,6 +184,12 @@ func FromJSON(data []byte) (*DeviceContext, error) {
 
 	if dc.ConfigSpace == nil {
 		return nil, fmt.Errorf("config_space_hex not found in JSON, file may be from an unsupported tool")
+	}
+
+	if dc.BehaviorRules != nil {
+		if err := behavior.Validate(dc.BehaviorRules); err != nil {
+			return nil, fmt.Errorf("invalid behavior_rules: %w", err)
+		}
 	}
 
 	return dc, nil

--- a/internal/donor/context_behavior_test.go
+++ b/internal/donor/context_behavior_test.go
@@ -1,0 +1,70 @@
+package donor
+
+import (
+	"bytes"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/behavior"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func TestDeviceContext_BehaviorRulesRoundTripDeterministically(t *testing.T) {
+	ctx := &DeviceContext{
+		ConfigSpace: pci.NewConfigSpace(),
+		BehaviorRules: &behavior.RuleSet{
+			Version:      behavior.RuleSchemaVersion,
+			BDF:          "0000:03:00.0",
+			BARIndex:     2,
+			BARSize:      0x4000,
+			ClockHz:      100_000_000,
+			InitialState: "idle",
+			Rules: []behavior.Rule{{
+				ID: "enable-ready", State: "idle", Access: behavior.AccessKind("write"),
+				Width: 4, Offset: 0x20, Value: 1, ValueMask: math.MaxUint32,
+				NextState: "waiting",
+				DelayedEvents: []behavior.DelayedEvent{{
+					DelayCycles: 12,
+					Updates: []behavior.RegisterUpdate{{Offset: 0x24, Width: 4, Value: 1, Mask: math.MaxUint32}},
+					NextState: "ready",
+				}},
+				Confidence: 1, Provenance: []string{"test fixture"},
+			},},
+		},
+	}
+
+	firstPath := filepath.Join(t.TempDir(), "first.json")
+	secondPath := filepath.Join(t.TempDir(), "second.json")
+	if err := SaveContext(ctx, firstPath); err != nil {
+		t.Fatalf("SaveContext first: %v", err)
+	}
+	loaded, err := LoadContext(firstPath)
+	if err != nil {
+		t.Fatalf("LoadContext: %v", err)
+	}
+	if loaded.BehaviorRules == nil {
+		t.Fatal("behavior rules were dropped while loading device context")
+	}
+	if err := behavior.Validate(loaded.BehaviorRules); err != nil {
+		t.Fatalf("loaded behavior rules are invalid: %v", err)
+	}
+	if len(loaded.BehaviorRules.Rules) != 1 || loaded.BehaviorRules.Rules[0].ID != "enable-ready" {
+		t.Fatalf("loaded behavior rules = %+v", loaded.BehaviorRules)
+	}
+	if err := SaveContext(loaded, secondPath); err != nil {
+		t.Fatalf("SaveContext second: %v", err)
+	}
+	firstJSON, err := os.ReadFile(firstPath)
+	if err != nil {
+		t.Fatalf("read first context: %v", err)
+	}
+	secondJSON, err := os.ReadFile(secondPath)
+	if err != nil {
+		t.Fatalf("read second context: %v", err)
+	}
+	if !bytes.Equal(firstJSON, secondJSON) {
+		t.Fatalf("context rule persistence is nondeterministic after round trip")
+	}
+}

--- a/internal/donor/mmio/import.go
+++ b/internal/donor/mmio/import.go
@@ -2,6 +2,7 @@ package mmio
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -16,23 +17,47 @@ type TextTraceOptions struct {
 	BARBase  uint64
 }
 
+type TraceTarget struct {
+	BDF      string
+	BARIndex int
+	BARBase  uint64
+	BARSize  int
+}
+
 func ParseTextTrace(r io.Reader, opts TextTraceOptions) (*TraceResult, error) {
 	if r == nil {
 		return nil, fmt.Errorf("trace reader is nil")
 	}
 
-	trace := &TraceResult{
+	target := TraceTarget{
 		BDF:      opts.BDF,
 		BARIndex: opts.BARIndex,
+		BARBase:  opts.BARBase,
 		BARSize:  opts.BARSize,
+	}
+	if err := validateTraceTarget(target); err != nil {
+		return nil, err
+	}
+
+	trace := &TraceResult{
+		SchemaVersion: TraceSchemaVersion,
+		BDF:           target.BDF,
+		BARIndex:      target.BARIndex,
+		BARBase:       target.BARBase,
+		BARSize:       target.BARSize,
 	}
 
 	var first time.Duration
 	var last time.Duration
+	lineNumber := 0
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		rec, ok := parseTextTraceLine(scanner.Text(), opts.BARBase)
-		if !ok {
+		lineNumber++
+		rec, isMMIO, err := parseTextTraceRecord(scanner.Text(), target)
+		if err != nil {
+			return nil, fmt.Errorf("parse MMIO trace line %d: %w", lineNumber, err)
+		}
+		if !isMMIO {
 			continue
 		}
 		if len(trace.Records) == 0 {
@@ -54,67 +79,163 @@ func ParseTextTrace(r io.Reader, opts TextTraceOptions) (*TraceResult, error) {
 	return trace, nil
 }
 
-func parseTextTraceLine(line string, barBase uint64) (AccessRecord, bool) {
+func ParseJSONTrace(r io.Reader) (*TraceResult, error) {
+	if r == nil {
+		return nil, fmt.Errorf("trace reader is nil")
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read MMIO trace JSON: %w", err)
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, fmt.Errorf("decode MMIO trace JSON: %w", err)
+	}
+	if raw, ok := envelope["trace"]; ok {
+		data = raw
+	}
+	var trace TraceResult
+	if err := json.Unmarshal(data, &trace); err != nil {
+		return nil, fmt.Errorf("decode MMIO trace JSON: %w", err)
+	}
+	return &trace, nil
+}
+
+func parseTextTraceRecord(line string, target TraceTarget) (AccessRecord, bool, error) {
+	rec, isMMIO, err := parseRawMMIOTraceLine(line)
+	if err != nil || !isMMIO {
+		return AccessRecord{}, isMMIO, err
+	}
+	if err := applyTraceTarget(&rec, target); err != nil {
+		return AccessRecord{}, true, err
+	}
+	return rec, true, nil
+}
+
+func parseRawMMIOTraceLine(line string) (AccessRecord, bool, error) {
 	fields := strings.Fields(strings.TrimSpace(line))
+	if len(fields) == 0 || (fields[0] != "R" && fields[0] != "W") {
+		return AccessRecord{}, false, nil
+	}
 	if len(fields) < 5 {
-		return AccessRecord{}, false
+		return AccessRecord{}, true, fmt.Errorf("incomplete MMIO record")
 	}
 
 	var rec AccessRecord
-	switch fields[0] {
-	case "R":
+	if fields[0] == "R" {
 		rec.Type = AccessRead
-	case "W":
+	} else {
 		rec.Type = AccessWrite
-	default:
-		return AccessRecord{}, false
 	}
+
+	width, err := strconv.ParseUint(fields[1], 10, 8)
+	if err != nil {
+		return AccessRecord{}, true, fmt.Errorf("invalid access width %q: %w", fields[1], err)
+	}
+	rec.Width = uint8(width)
+	if !validAccessWidth(rec.Width) {
+		return AccessRecord{}, true, fmt.Errorf("unsupported access width %d", rec.Width)
+	}
+
+	timestamp, err := strconv.ParseFloat(fields[2], 64)
+	if err != nil {
+		return AccessRecord{}, true, fmt.Errorf("invalid timestamp %q: %w", fields[2], err)
+	}
+	rec.Timestamp = time.Duration(timestamp * float64(time.Second))
 
 	addrField, valueField, ok := traceAddressValueFields(fields)
 	if !ok {
-		return AccessRecord{}, false
+		return AccessRecord{}, true, fmt.Errorf("missing MMIO address or value")
 	}
-
-	addr, err := parseHexUint64(addrField)
+	rec.Address, err = parseHexUint64(addrField)
 	if err != nil {
-		return AccessRecord{}, false
+		return AccessRecord{}, true, fmt.Errorf("invalid address %q: %w", addrField, err)
 	}
-	value, err := parseHexUint32(valueField)
+	rec.Value, err = parseHexUint64(valueField)
 	if err != nil {
+		return AccessRecord{}, true, fmt.Errorf("invalid value %q: %w", valueField, err)
+	}
+	if rec.Width < 8 && rec.Value >= uint64(1)<<(rec.Width*8) {
+		return AccessRecord{}, true, fmt.Errorf("value %#x does not fit %d-byte access", rec.Value, rec.Width)
+	}
+
+	return rec, true, nil
+}
+
+func parseTextTraceLine(line string, barBase uint64) (AccessRecord, bool) {
+	rec, isMMIO, err := parseRawMMIOTraceLine(line)
+	if err != nil || !isMMIO || rec.Address < barBase {
 		return AccessRecord{}, false
 	}
-
-	rec.Offset = traceOffset(addr, barBase)
-	rec.Value = value
-	if ts, err := strconv.ParseFloat(fields[2], 64); err == nil {
-		rec.Timestamp = time.Duration(ts * float64(time.Second))
+	offset := rec.Address - barBase
+	if offset > uint64(^uint32(0)) {
+		return AccessRecord{}, false
 	}
-
+	rec.Offset = uint32(offset)
 	return rec, true
 }
 
 func traceAddressValueFields(fields []string) (string, string, bool) {
-	if strings.HasPrefix(fields[3], "0x") {
+	if len(fields) >= 5 && hasHexPrefix(fields[3]) {
 		return fields[3], fields[4], true
 	}
-	if len(fields) >= 6 && strings.HasPrefix(fields[4], "0x") {
+	if len(fields) >= 6 && hasHexPrefix(fields[4]) {
 		return fields[4], fields[5], true
 	}
 	return "", "", false
 }
 
+func hasHexPrefix(raw string) bool {
+	return strings.HasPrefix(raw, "0x") || strings.HasPrefix(raw, "0X")
+}
+
 func parseHexUint64(raw string) (uint64, error) {
-	return strconv.ParseUint(strings.TrimPrefix(strings.TrimPrefix(raw, "0x"), "0X"), 16, 64)
-}
-
-func parseHexUint32(raw string) (uint32, error) {
-	value, err := strconv.ParseUint(strings.TrimPrefix(strings.TrimPrefix(raw, "0x"), "0X"), 16, 32)
-	return uint32(value), err
-}
-
-func traceOffset(addr uint64, barBase uint64) uint32 {
-	if barBase != 0 && addr >= barBase {
-		return uint32(addr - barBase)
+	raw = strings.TrimSpace(raw)
+	if !hasHexPrefix(raw) {
+		return 0, fmt.Errorf("missing hexadecimal prefix")
 	}
-	return uint32(addr & 0xFFF)
+	return strconv.ParseUint(raw[2:], 16, 64)
+}
+
+func validateTraceTarget(target TraceTarget) error {
+	if target.BARIndex < 0 || target.BARIndex > 5 {
+		return fmt.Errorf("invalid BAR index %d", target.BARIndex)
+	}
+	if target.BARSize <= 0 {
+		return fmt.Errorf("BAR size must be positive")
+	}
+	size := uint64(target.BARSize)
+	if target.BARBase > ^uint64(0)-size {
+		return fmt.Errorf("BAR aperture overflows physical address space: base=%#x size=%#x", target.BARBase, size)
+	}
+	return nil
+}
+
+func applyTraceTarget(rec *AccessRecord, target TraceTarget) error {
+	if err := validateTraceTarget(target); err != nil {
+		return err
+	}
+	if rec.Address < target.BARBase {
+		return fmt.Errorf("address %#x is below BAR base %#x", rec.Address, target.BARBase)
+	}
+	offset := rec.Address - target.BARBase
+	size := uint64(target.BARSize)
+	if offset >= size {
+		return fmt.Errorf("address %#x is outside BAR aperture [%#x, %#x)", rec.Address, target.BARBase, target.BARBase+size)
+	}
+	width := uint64(rec.Width)
+	if width > size-offset {
+		return fmt.Errorf("%d-byte access at %#x crosses BAR aperture end %#x", rec.Width, rec.Address, target.BARBase+size)
+	}
+	if rec.Address%width != 0 {
+		return fmt.Errorf("%d-byte access at %#x is misaligned", rec.Width, rec.Address)
+	}
+	if offset > uint64(^uint32(0)) {
+		return fmt.Errorf("BAR offset %#x exceeds uint32 range", offset)
+	}
+
+	rec.BDF = target.BDF
+	rec.BARIndex = target.BARIndex
+	rec.Offset = uint32(offset)
+	return nil
 }

--- a/internal/donor/mmio/import_bir_test.go
+++ b/internal/donor/mmio/import_bir_test.go
@@ -1,0 +1,98 @@
+package mmio
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestParseJSONTrace_CanonicalRecordBARIndexMustMatchEnvelope(t *testing.T) {
+	canonical := []byte(`{
+		"schema_version":1,
+		"bdf":"0000:03:00.0",
+		"bar_index":1,
+		"bar_base":4096,
+		"bar_size":4096,
+		"started_at":"2026-07-09T12:30:00Z",
+		"duration_ns":1,
+		"records":[{
+			"bdf":"0000:03:00.0",
+			"bar_index":0,
+			"address":4100,
+			"offset":4,
+			"width":4,
+			"operation":"read",
+			"value":0,
+			"timestamp_ns":1
+		}]
+	}`)
+	if _, err := ParseJSONTrace(bytes.NewReader(canonical)); err == nil {
+		t.Fatal("canonical BAR0 record inside a BAR1 envelope should be rejected")
+	}
+}
+
+func TestParseJSONTrace_LegacyMissingBARIndexInheritsEnvelope(t *testing.T) {
+	legacy := []byte(`{
+		"BDF":"0000:03:00.0",
+		"BARIndex":1,
+		"BARBase":4096,
+		"BARSize":4096,
+		"Duration":1,
+		"Records":[{
+			"BDF":"0000:03:00.0",
+			"Address":4100,
+			"Offset":4,
+			"Width":4,
+			"Type":0,
+			"Value":0,
+			"Timestamp":1
+		}]
+	}`)
+	trace, err := ParseJSONTrace(bytes.NewReader(legacy))
+	if err != nil {
+		t.Fatalf("ParseJSONTrace legacy: %v", err)
+	}
+	if len(trace.Records) != 1 || trace.Records[0].BARIndex != 1 {
+		t.Fatalf("legacy record target = %+v, want inherited BAR1", trace.Records)
+	}
+}
+
+func TestParseJSONTrace_LegacyExplicitBARZeroDoesNotInheritBAROne(t *testing.T) {
+	legacy := []byte(`{
+		"BDF":"0000:03:00.0",
+		"BARIndex":1,
+		"BARBase":4096,
+		"BARSize":4096,
+		"Duration":1,
+		"Records":[{
+			"BDF":"0000:03:00.0",
+			"BARIndex":0,
+			"Address":4100,
+			"Offset":4,
+			"Width":4,
+			"Type":0,
+			"Value":0,
+			"Timestamp":1
+		}]
+	}`)
+	if _, err := ParseJSONTrace(bytes.NewReader(legacy)); err == nil {
+		t.Fatal("schema-less legacy BAR0 record inside a BAR1 envelope should be rejected")
+	}
+}
+
+func TestTraceResultMarshalRejectsRecordBARIndexMismatch(t *testing.T) {
+	trace := TraceResult{
+		SchemaVersion: TraceSchemaVersion,
+		BDF:           "0000:03:00.0",
+		BARIndex:      1,
+		BARBase:       0x1000,
+		BARSize:       0x1000,
+		Records: []AccessRecord{{
+			BDF: "0000:03:00.0", BARIndex: 0, Address: 0x1004,
+			Offset: 4, Width: 4, Type: AccessRead,
+		}},
+	}
+	if _, err := json.Marshal(trace); err == nil {
+		t.Fatal("marshal should reject a BAR0 record instead of rewriting it into BAR1")
+	}
+}

--- a/internal/donor/mmio/import_bounds_test.go
+++ b/internal/donor/mmio/import_bounds_test.go
@@ -1,0 +1,184 @@
+package mmio
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseTextTrace_PreservesWideOffsetsWidthsAndValues(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		"R 1 1.000 0xf7801001 0x7f",
+		"W 2 1.010 0xf7801002 0xbeef",
+		"R 4 1.020 0xf7801004 0x89abcdef",
+		"W 8 1.030 0xf7801008 0x1122334455667788",
+	}, "\n"))
+
+	trace, err := ParseTextTrace(input, TextTraceOptions{
+		BDF:      "0000:03:00.0",
+		BARIndex: 2,
+		BARBase: 0xf7800000,
+		BARSize: 0x4000,
+	})
+	if err != nil {
+		t.Fatalf("ParseTextTrace returned error: %v", err)
+	}
+
+	want := []AccessRecord{
+		{BDF: "0000:03:00.0", BARIndex: 2, Address: 0xf7801001, Offset: 0x1001, Width: 1, Type: AccessRead, Value: 0x7f},
+		{BDF: "0000:03:00.0", BARIndex: 2, Address: 0xf7801002, Offset: 0x1002, Width: 2, Type: AccessWrite, Value: 0xbeef},
+		{BDF: "0000:03:00.0", BARIndex: 2, Address: 0xf7801004, Offset: 0x1004, Width: 4, Type: AccessRead, Value: 0x89abcdef},
+		{BDF: "0000:03:00.0", BARIndex: 2, Address: 0xf7801008, Offset: 0x1008, Width: 8, Type: AccessWrite, Value: 0x1122334455667788},
+	}
+	if len(trace.Records) != len(want) {
+		t.Fatalf("records = %d, want %d: %+v", len(trace.Records), len(want), trace.Records)
+	}
+	for i := range want {
+		got := trace.Records[i]
+		if got.BDF != want[i].BDF || got.BARIndex != want[i].BARIndex || got.Address != want[i].Address ||
+			got.Offset != want[i].Offset || got.Width != want[i].Width || got.Type != want[i].Type || got.Value != want[i].Value {
+			t.Errorf("record %d = %+v, want %+v", i, got, want[i])
+		}
+	}
+}
+
+func TestParseTextTrace_RejectsAddressesOutsideBARWithoutAliasing(t *testing.T) {
+	const base = uint64(0xf7800000)
+	cases := map[string]string{
+		"below base":       "R 4 1.000 0xf77ffffc 0xaaaaaaaa\n",
+		"crossing end":     "R 8 1.020 0xf7800ffc 0xbbbbbbbb\n",
+		"at end":           "R 4 1.030 0xf7801000 0xcccccccc\n",
+		"unrelated region": "R 4 1.040 0xf790010c 0xdddddddd\n",
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ParseTextTrace(strings.NewReader(input), TextTraceOptions{BARBase: base, BARSize: 0x1000}); err == nil {
+				t.Fatal("expected out-of-aperture record to be rejected instead of aliased")
+			}
+		})
+	}
+}
+
+func TestParseTextTrace_RejectsOverflowingBARRange(t *testing.T) {
+	input := strings.NewReader("R 4 1.000 0xfffffffffffffffc 0x1\n")
+	_, err := ParseTextTrace(input, TextTraceOptions{
+		BARBase: math.MaxUint64 - 3,
+		BARSize: 8,
+	})
+	if err == nil {
+		t.Fatal("expected overflowing BAR base + size to be rejected")
+	}
+}
+
+func TestParseTextTrace_RejectsUnsupportedWidths(t *testing.T) {
+	for _, width := range []string{"0", "3", "16"} {
+		t.Run(width, func(t *testing.T) {
+			input := strings.NewReader("R " + width + " 1.000 0xf7800000 0x1\n")
+			if _, err := ParseTextTrace(input, TextTraceOptions{BARBase: 0xf7800000, BARSize: 0x1000}); err == nil {
+				t.Fatalf("expected width %s to be rejected", width)
+			}
+		})
+	}
+}
+
+func TestAccessRecord_LegacyJSONDefaultsToDWordWidth(t *testing.T) {
+	legacy := []byte(`{"Offset":4660,"Type":0,"Value":2309737967,"Timestamp":1000}`)
+	var record AccessRecord
+	if err := json.Unmarshal(legacy, &record); err != nil {
+		t.Fatalf("unmarshal legacy record: %v", err)
+	}
+	if record.Offset != 0x1234 || record.Width != 4 || record.Type != AccessRead || record.Value != 0x89abcdef {
+		t.Fatalf("legacy record = %+v, want offset/value preserved and width defaulted to 4", record)
+	}
+}
+
+func TestTraceResult_CanonicalV1JSONRoundTripIsDeterministic(t *testing.T) {
+	start := time.Date(2026, time.July, 9, 12, 30, 0, 123, time.UTC)
+	trace := &TraceResult{
+		SchemaVersion: TraceSchemaVersion,
+		BDF:           "0000:03:00.0",
+		BARIndex:      2,
+		BARBase:       0xf7800000,
+		BARSize:       0x4000,
+		Duration:      25 * time.Microsecond,
+		StartTime:     start,
+		Records: []AccessRecord{{
+			BDF: "0000:03:00.0", BARIndex: 2, Address: 0xf7801008, Offset: 0x1008,
+			Width: 8, Type: AccessWrite, Value: 0x1122334455667788, Timestamp: 25 * time.Microsecond,
+		}},
+	}
+	first, err := json.Marshal(trace)
+	if err != nil {
+		t.Fatalf("marshal canonical trace: %v", err)
+	}
+	second, err := json.Marshal(trace)
+	if err != nil {
+		t.Fatalf("marshal canonical trace again: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatalf("canonical trace JSON is nondeterministic:\nfirst:  %s\nsecond: %s", first, second)
+	}
+
+	var schema map[string]any
+	if err := json.Unmarshal(first, &schema); err != nil {
+		t.Fatalf("decode canonical trace schema: %v", err)
+	}
+	for _, key := range []string{"schema_version", "bdf", "bar_index", "bar_base", "bar_size", "duration_ns", "started_at", "records"} {
+		if _, ok := schema[key]; !ok {
+			t.Errorf("canonical trace JSON missing field %q: %v", key, schema)
+		}
+	}
+
+	roundTrip, err := ParseJSONTrace(bytes.NewReader(first))
+	if err != nil {
+		t.Fatalf("ParseJSONTrace canonical v1: %v", err)
+	}
+	if roundTrip.SchemaVersion != TraceSchemaVersion || roundTrip.BDF != trace.BDF ||
+		roundTrip.BARIndex != trace.BARIndex || roundTrip.BARBase != trace.BARBase ||
+		roundTrip.BARSize != trace.BARSize || roundTrip.Duration != trace.Duration ||
+		!roundTrip.StartTime.Equal(trace.StartTime) || len(roundTrip.Records) != 1 {
+		t.Fatalf("canonical round trip = %+v, want %+v", roundTrip, trace)
+	}
+	got := roundTrip.Records[0]
+	want := trace.Records[0]
+	if got.BDF != want.BDF || got.BARIndex != want.BARIndex || got.Address != want.Address ||
+		got.Offset != want.Offset || got.Width != want.Width || got.Type != want.Type ||
+		got.Value != want.Value || got.Timestamp != want.Timestamp {
+		t.Fatalf("canonical record round trip = %+v, want %+v", got, want)
+	}
+}
+
+func TestParseJSONTrace_LegacyPascalCaseDefaultsWidths(t *testing.T) {
+	legacy := []byte(`{
+		"BDF":"0000:03:00.0",
+		"BARIndex":2,
+		"BARSize":16384,
+		"Duration":25000,
+		"StartTime":"2026-07-09T12:30:00Z",
+		"Records":[{
+			"BDF":"0000:03:00.0",
+			"BARIndex":2,
+			"Address":4152360964,
+			"Offset":4100,
+			"Type":0,
+			"Value":2309737967,
+			"Timestamp":25000
+		}]
+	}`)
+	trace, err := ParseJSONTrace(bytes.NewReader(legacy))
+	if err != nil {
+		t.Fatalf("ParseJSONTrace legacy: %v", err)
+	}
+	if trace.SchemaVersion != TraceSchemaVersion || trace.BDF != "0000:03:00.0" ||
+		trace.BARIndex != 2 || trace.BARSize != 16384 || trace.Duration != 25*time.Microsecond ||
+		len(trace.Records) != 1 {
+		t.Fatalf("legacy trace = %+v", trace)
+	}
+	if got := trace.Records[0]; got.Width != 4 || got.Offset != 0x1004 ||
+		got.Value != 0x89abcdef || got.BDF != trace.BDF || got.BARIndex != trace.BARIndex {
+		t.Fatalf("legacy record = %+v, want inherited metadata and dword width", got)
+	}
+}

--- a/internal/donor/mmio/import_test.go
+++ b/internal/donor/mmio/import_test.go
@@ -39,7 +39,7 @@ func TestParseTextTrace_Ret2cShapeWithBARBase(t *testing.T) {
 func TestParseTextTrace_LiveTracePipeShape(t *testing.T) {
 	input := strings.NewReader("R 4 1234567.890 0xfee00100 0x00000001 extra\n")
 
-	trace, err := ParseTextTrace(input, TextTraceOptions{BARSize: 4096})
+	trace, err := ParseTextTrace(input, TextTraceOptions{BARBase: 0xfee00000, BARSize: 4096})
 
 	if err != nil {
 		t.Fatalf("ParseTextTrace returned error: %v", err)
@@ -53,7 +53,7 @@ func TestParseTextTrace_LiveTracePipeShape(t *testing.T) {
 }
 
 func TestParseTextTrace_RejectsEmptyTrace(t *testing.T) {
-	_, err := ParseTextTrace(strings.NewReader("not a trace line\n"), TextTraceOptions{})
+	_, err := ParseTextTrace(strings.NewReader("not a trace line\n"), TextTraceOptions{BARSize: 4096})
 	if err == nil {
 		t.Fatal("expected error for empty trace")
 	}
@@ -65,7 +65,7 @@ func TestParseTextTrace_DurationUsesLastTimestamp(t *testing.T) {
 		"R 4 1.250 0x1004 0x2",
 	}, "\n"))
 
-	trace, err := ParseTextTrace(input, TextTraceOptions{})
+	trace, err := ParseTextTrace(input, TextTraceOptions{BARBase: 0x1000, BARSize: 8})
 
 	if err != nil {
 		t.Fatalf("ParseTextTrace returned error: %v", err)

--- a/internal/donor/mmio/trace_live.go
+++ b/internal/donor/mmio/trace_live.go
@@ -6,6 +6,7 @@ package mmio
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"time"
@@ -18,14 +19,105 @@ const (
 	tracingOnPath = tracingDir + "/tracing_on"
 )
 
-// LiveTrace enables mmiotrace, records BAR accesses for `duration`, then stops.
 func LiveTrace(bdf string, duration time.Duration) (*TraceResult, error) {
-	// debugfs present?
+	return nil, fmt.Errorf("target BAR aperture is required for live MMIO capture")
+}
+
+func LiveTraceTarget(target TraceTarget, duration time.Duration) (*TraceResult, error) {
+	if err := validateTraceTarget(target); err != nil {
+		return nil, err
+	}
+	return captureLiveTrace(&target, target.BDF, duration)
+}
+
+type liveTraceOutcome struct {
+	record    AccessRecord
+	hasRecord bool
+	err       error
+	done      bool
+}
+
+func collectLiveTrace(reader io.ReadCloser, target TraceTarget, duration time.Duration) ([]AccessRecord, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("trace reader is nil")
+	}
+	if err := validateTraceTarget(target); err != nil {
+		return nil, err
+	}
+	if duration <= 0 {
+		return nil, fmt.Errorf("trace duration must be positive")
+	}
+	events := make(chan liveTraceOutcome)
+	stop := make(chan struct{})
+	go func() {
+		scanner := bufio.NewScanner(reader)
+		var firstTimestamp time.Duration
+		haveFirst := false
+		for scanner.Scan() {
+			rec, isMMIO, parseErr := parseRawMMIOTraceLine(scanner.Text())
+			if parseErr != nil || !isMMIO {
+				continue
+			}
+			if applyErr := applyTraceTarget(&rec, target); applyErr != nil {
+				continue
+			}
+			if !haveFirst {
+				firstTimestamp = rec.Timestamp
+				haveFirst = true
+			}
+			rec.Timestamp -= firstTimestamp
+			select {
+			case events <- liveTraceOutcome{record: rec, hasRecord: true}:
+			case <-stop:
+				return
+			}
+		}
+		select {
+		case events <- liveTraceOutcome{err: scanner.Err(), done: true}:
+		case <-stop:
+		}
+	}()
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	defer reader.Close()
+	var records []AccessRecord
+	for {
+		select {
+		case event := <-events:
+			if event.hasRecord {
+				records = append(records, event.record)
+			}
+			if event.done {
+				if event.err != nil {
+					return nil, fmt.Errorf("read trace pipe: %w", event.err)
+				}
+				return records, nil
+			}
+		case <-timer.C:
+			close(stop)
+			_ = reader.Close()
+			grace := time.NewTimer(10 * time.Millisecond)
+			select {
+			case event := <-events:
+				grace.Stop()
+				if event.done && event.err != nil {
+					return records, nil
+				}
+			case <-grace.C:
+			}
+			return records, nil
+		}
+	}
+}
+
+func captureLiveTrace(target *TraceTarget, bdf string, duration time.Duration) (*TraceResult, error) {
+	if duration <= 0 {
+		return nil, fmt.Errorf("trace duration must be positive")
+	}
 	if _, err := os.Stat(currentTracer); err != nil {
 		return nil, fmt.Errorf("ftrace not available (debugfs mounted?): %w", err)
 	}
 
-	// save + restore previous tracer
 	prevTracer, err := os.ReadFile(currentTracer)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read current tracer: %w", err)
@@ -36,13 +128,11 @@ func LiveTrace(bdf string, duration time.Duration) (*TraceResult, error) {
 		}
 	}()
 
-	// switch to mmiotrace
 	if writeErr := os.WriteFile(currentTracer, []byte("mmiotrace"), 0644); writeErr != nil {
 		return nil, fmt.Errorf("cannot enable mmiotrace (CONFIG_MMIOTRACE=y needed): %w", writeErr)
 	}
-
 	if writeErr := os.WriteFile(tracingOnPath, []byte("1"), 0644); writeErr != nil {
-		slog.Warn("failed to enable tracing", "error", writeErr)
+		return nil, fmt.Errorf("cannot enable tracing: %w", writeErr)
 	}
 	defer func() {
 		if writeErr := os.WriteFile(tracingOnPath, []byte("0"), 0644); writeErr != nil {
@@ -50,51 +140,38 @@ func LiveTrace(bdf string, duration time.Duration) (*TraceResult, error) {
 		}
 	}()
 
-	// read from the pipe
 	pipe, err := os.Open(tracePipe)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open trace_pipe: %w", err)
 	}
 	defer pipe.Close()
 
+	startedAt := time.Now()
 	result := &TraceResult{
-		BDF:      bdf,
-		Duration: duration,
+		SchemaVersion: TraceSchemaVersion,
+		BDF:           bdf,
+		Duration:      duration,
+		StartTime:     startedAt,
+	}
+	if target != nil {
+		result.BARIndex = target.BARIndex
+		result.BARBase = target.BARBase
+		result.BARSize = target.BARSize
 	}
 
-	// read records until timeout
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		scanner := bufio.NewScanner(pipe)
-		deadline := time.Now().Add(duration)
-
-		for scanner.Scan() {
-			if time.Now().After(deadline) {
-				break
-			}
-			line := scanner.Text()
-			rec, ok := parseMMIOTraceLine(line)
-			if ok {
-				result.Records = append(result.Records, rec)
-			}
-		}
-	}()
-
-	// wait or timeout
-	select {
-	case <-done:
-	case <-time.After(duration + 500*time.Millisecond):
+	if target == nil {
+		return nil, fmt.Errorf("target BAR aperture is required")
 	}
-
-	if err := os.WriteFile(tracingOnPath, []byte("0"), 0644); err != nil {
-		slog.Warn("failed to stop tracing", "error", err)
+	records, collectErr := collectLiveTrace(pipe, *target, duration)
+	if collectErr != nil {
+		return nil, collectErr
 	}
-
+	result.Records = records
+	result.Duration = time.Since(startedAt)
 	return result, nil
 }
 
-// parseMMIOTraceLine parses one mmiotrace line (R/W <width> <ts> <addr> <val>).
 func parseMMIOTraceLine(line string) (AccessRecord, bool) {
-	return parseTextTraceLine(line, 0)
+	rec, isMMIO, err := parseRawMMIOTraceLine(line)
+	return rec, isMMIO && err == nil
 }

--- a/internal/donor/mmio/trace_live_test.go
+++ b/internal/donor/mmio/trace_live_test.go
@@ -1,0 +1,72 @@
+package mmio
+
+import (
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type quietTraceReader struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newQuietTraceReader() *quietTraceReader {
+	return &quietTraceReader{closed: make(chan struct{})}
+}
+
+func (r *quietTraceReader) Read([]byte) (int, error) {
+	<-r.closed
+	return 0, io.EOF
+}
+
+func (r *quietTraceReader) Close() error {
+	r.once.Do(func() { close(r.closed) })
+	return nil
+}
+
+func TestCollectLiveTracePreservesKernelTimestampDeltas(t *testing.T) {
+	input := strings.Join([]string{
+		"R 4 99.000 0x9000 0x0",
+		"R 4 100.125 0x1000 0x1",
+		"W 4 100.375 0x1004 0x2",
+	}, "\n")
+	target := TraceTarget{BDF: "0000:03:00.0", BARIndex: 1, BARBase: 0x1000, BARSize: 0x1000}
+	records, err := collectLiveTrace(io.NopCloser(strings.NewReader(input)), target, time.Second)
+	if err != nil {
+		t.Fatalf("collectLiveTrace: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("records = %+v, want two target records", records)
+	}
+	if records[0].Timestamp != 0 || records[1].Timestamp != 250*time.Millisecond {
+		t.Fatalf("normalized timestamps = %v, %v, want 0 and 250ms", records[0].Timestamp, records[1].Timestamp)
+	}
+}
+
+func TestCollectLiveTraceQuietReaderReturnsAtDeadline(t *testing.T) {
+	reader := newQuietTraceReader()
+	target := TraceTarget{BDF: "0000:03:00.0", BARIndex: 1, BARBase: 0x1000, BARSize: 0x1000}
+	started := time.Now()
+	records, err := collectLiveTrace(reader, target, 20*time.Millisecond)
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatalf("collectLiveTrace: %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("quiet capture records = %+v, want none", records)
+	}
+	if elapsed < 10*time.Millisecond {
+		t.Fatalf("quiet capture returned before deadline after %v", elapsed)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("quiet capture took %v, expected bounded deadline return", elapsed)
+	}
+	select {
+	case <-reader.closed:
+	default:
+		t.Fatal("quiet reader was not closed at deadline")
+	}
+}

--- a/internal/donor/mmio/tracer.go
+++ b/internal/donor/mmio/tracer.go
@@ -2,6 +2,7 @@
 package mmio
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -16,6 +17,8 @@ const (
 	AccessWrite AccessType = 1
 )
 
+const TraceSchemaVersion uint32 = 1
+
 func (a AccessType) String() string {
 	if a == AccessWrite {
 		return "W"
@@ -25,20 +28,26 @@ func (a AccessType) String() string {
 
 // AccessRecord is one captured BAR read or write.
 type AccessRecord struct {
+	BDF       string
+	BARIndex  int
+	Address   uint64
 	Offset    uint32        // byte offset within the BAR
+	Width     uint8
 	Type      AccessType    // read or write
-	Value     uint32        // value read or written
+	Value     uint64
 	Timestamp time.Duration // time since trace started
 }
 
 // TraceResult is everything captured during one tracing session.
 type TraceResult struct {
-	BDF       string        // device BDF (e.g. "0000:03:00.0")
-	BARIndex  int           // which BAR was traced
-	BARSize   int           // BAR size in bytes
-	Duration  time.Duration // total trace duration
-	Records   []AccessRecord
-	StartTime time.Time
+	SchemaVersion uint32
+	BDF           string
+	BARIndex      int
+	BARBase       uint64
+	BARSize       int
+	Duration      time.Duration
+	Records       []AccessRecord
+	StartTime     time.Time
 }
 
 // AccessPattern is the analyzed summary - hot regs, polls, init writes.
@@ -51,14 +60,370 @@ type AccessPattern struct {
 	InitSequence  []AccessRecord // first N unique writes (likely initialization)
 }
 
+type accessRecordJSON struct {
+	BDF         string `json:"bdf"`
+	BARIndex    int    `json:"bar_index"`
+	Address     uint64 `json:"address"`
+	Offset      uint32 `json:"offset"`
+	Width       uint8  `json:"width"`
+	Operation   string `json:"operation"`
+	Value       uint64 `json:"value"`
+	TimestampNS int64  `json:"timestamp_ns"`
+}
+
+type traceResultJSON struct {
+	SchemaVersion uint32             `json:"schema_version"`
+	BDF           string             `json:"bdf"`
+	BARIndex      int                `json:"bar_index"`
+	BARBase       uint64             `json:"bar_base"`
+	BARSize       int                `json:"bar_size"`
+	StartedAt     time.Time          `json:"started_at"`
+	DurationNS    int64              `json:"duration_ns"`
+	Records       []accessRecordJSON `json:"records"`
+}
+
+func (r AccessRecord) MarshalJSON() ([]byte, error) {
+	wire, err := r.canonicalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire)
+}
+
+func (r AccessRecord) canonicalJSON() (accessRecordJSON, error) {
+	width := r.Width
+	if width == 0 {
+		width = 4
+	}
+	if !validAccessWidth(width) {
+		return accessRecordJSON{}, fmt.Errorf("invalid MMIO width %d", width)
+	}
+	if !valueFitsWidth(r.Value, width) {
+		return accessRecordJSON{}, fmt.Errorf("value %#x does not fit %d-byte access", r.Value, width)
+	}
+
+	var operation string
+	switch r.Type {
+	case AccessRead:
+		operation = "read"
+	case AccessWrite:
+		operation = "write"
+	default:
+		return accessRecordJSON{}, fmt.Errorf("invalid MMIO access type %d", r.Type)
+	}
+
+	return accessRecordJSON{
+		BDF:         r.BDF,
+		BARIndex:    r.BARIndex,
+		Address:     r.Address,
+		Offset:      r.Offset,
+		Width:       width,
+		Operation:   operation,
+		Value:       r.Value,
+		TimestampNS: int64(r.Timestamp),
+	}, nil
+}
+
+func (r *AccessRecord) UnmarshalJSON(data []byte) error {
+	if r == nil {
+		return fmt.Errorf("cannot unmarshal MMIO access into nil record")
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	var decoded AccessRecord
+	if err := unmarshalJSONField(fields, &decoded.BDF, "bdf", "BDF"); err != nil {
+		return fmt.Errorf("decode record bdf: %w", err)
+	}
+	if err := unmarshalJSONField(fields, &decoded.BARIndex, "bar_index", "BARIndex"); err != nil {
+		return fmt.Errorf("decode record BAR index: %w", err)
+	}
+	if err := unmarshalJSONField(fields, &decoded.Address, "address", "Address"); err != nil {
+		return fmt.Errorf("decode record address: %w", err)
+	}
+	if err := unmarshalJSONField(fields, &decoded.Offset, "offset", "Offset"); err != nil {
+		return fmt.Errorf("decode record offset: %w", err)
+	}
+
+	decoded.Width = 4
+	if raw, ok := firstJSONField(fields, "width", "Width"); ok {
+		if err := json.Unmarshal(raw, &decoded.Width); err != nil {
+			return fmt.Errorf("decode record width: %w", err)
+		}
+	}
+	if !validAccessWidth(decoded.Width) {
+		return fmt.Errorf("invalid MMIO width %d", decoded.Width)
+	}
+
+	if raw, ok := firstJSONField(fields, "operation"); ok {
+		var operation string
+		if err := json.Unmarshal(raw, &operation); err != nil {
+			return fmt.Errorf("decode record operation: %w", err)
+		}
+		switch operation {
+		case "read":
+			decoded.Type = AccessRead
+		case "write":
+			decoded.Type = AccessWrite
+		default:
+			return fmt.Errorf("invalid MMIO operation %q", operation)
+		}
+	} else if err := unmarshalJSONField(fields, &decoded.Type, "type", "Type"); err != nil {
+		return fmt.Errorf("decode record access type: %w", err)
+	}
+	if decoded.Type != AccessRead && decoded.Type != AccessWrite {
+		return fmt.Errorf("invalid MMIO access type %d", decoded.Type)
+	}
+
+	if err := unmarshalJSONField(fields, &decoded.Value, "value", "Value"); err != nil {
+		return fmt.Errorf("decode record value: %w", err)
+	}
+	if !valueFitsWidth(decoded.Value, decoded.Width) {
+		return fmt.Errorf("value %#x does not fit %d-byte access", decoded.Value, decoded.Width)
+	}
+	var timestampNS int64
+	if raw, ok := firstJSONField(fields, "timestamp_ns"); ok {
+		if err := json.Unmarshal(raw, &timestampNS); err != nil {
+			return fmt.Errorf("decode record timestamp: %w", err)
+		}
+		decoded.Timestamp = time.Duration(timestampNS)
+	} else if err := unmarshalJSONField(fields, &decoded.Timestamp, "timestamp", "Timestamp"); err != nil {
+		return fmt.Errorf("decode record timestamp: %w", err)
+	}
+
+	*r = decoded
+	return nil
+}
+
+func (t TraceResult) MarshalJSON() ([]byte, error) {
+	records := make([]accessRecordJSON, len(t.Records))
+	normalized := make([]AccessRecord, len(t.Records))
+	for i, record := range t.Records {
+		if record.BDF == "" {
+			record.BDF = t.BDF
+		}
+		if record.BARIndex != t.BARIndex {
+			return nil, fmt.Errorf("record %d BAR%d does not match trace BAR%d", i, record.BARIndex, t.BARIndex)
+		}
+		if record.Address == 0 && t.BARBase != 0 && t.BARBase <= ^uint64(0)-uint64(record.Offset) {
+			record.Address = t.BARBase + uint64(record.Offset)
+		}
+		wire, err := record.canonicalJSON()
+		if err != nil {
+			return nil, fmt.Errorf("record %d: %w", i, err)
+		}
+		records[i] = wire
+		normalized[i] = record
+	}
+	validated := t
+	validated.Records = normalized
+	if err := validated.validateRecords(true); err != nil {
+		return nil, err
+	}
+	return json.Marshal(traceResultJSON{
+		SchemaVersion: TraceSchemaVersion,
+		BDF: t.BDF, BARIndex: t.BARIndex, BARBase: t.BARBase, BARSize: t.BARSize,
+		StartedAt: t.StartTime, DurationNS: int64(t.Duration), Records: records,
+	})
+}
+
+func (t *TraceResult) UnmarshalJSON(data []byte) error {
+	if t == nil {
+		return fmt.Errorf("cannot unmarshal MMIO trace into nil result")
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	if raw, canonical := fields["schema_version"]; canonical {
+		var version uint32
+		if err := json.Unmarshal(raw, &version); err != nil {
+			return fmt.Errorf("decode trace schema version: %w", err)
+		}
+		if version != TraceSchemaVersion {
+			return fmt.Errorf("unsupported MMIO trace schema version %d", version)
+		}
+		var wire struct {
+			BDF        string            `json:"bdf"`
+			BARIndex   int               `json:"bar_index"`
+			BARBase    uint64            `json:"bar_base"`
+			BARSize    int               `json:"bar_size"`
+			StartedAt  time.Time         `json:"started_at"`
+			DurationNS int64             `json:"duration_ns"`
+			Records    []json.RawMessage `json:"records"`
+		}
+		if err := json.Unmarshal(data, &wire); err != nil {
+			return err
+		}
+		decoded := TraceResult{
+			SchemaVersion: version, BDF: wire.BDF, BARIndex: wire.BARIndex, BARBase: wire.BARBase,
+			BARSize: wire.BARSize, Duration: time.Duration(wire.DurationNS), StartTime: wire.StartedAt,
+			Records: make([]AccessRecord, len(wire.Records)),
+		}
+		for i, rawRecord := range wire.Records {
+			var recordFields map[string]json.RawMessage
+			if err := json.Unmarshal(rawRecord, &recordFields); err != nil {
+				return fmt.Errorf("record %d: %w", i, err)
+			}
+			if _, present := recordFields["bar_index"]; !present {
+				return fmt.Errorf("record %d: canonical bar_index is required", i)
+			}
+			if err := json.Unmarshal(rawRecord, &decoded.Records[i]); err != nil {
+				return fmt.Errorf("record %d: %w", i, err)
+			}
+		}
+		if err := decoded.validateRecords(true); err != nil {
+			return err
+		}
+		*t = decoded
+		return nil
+	}
+
+	var legacy struct {
+		BDF       string
+		BARIndex  int
+		BARBase   uint64
+		BARSize   int
+		Duration  time.Duration
+		StartTime time.Time
+		Records   []json.RawMessage
+	}
+	if err := unmarshalJSONField(fields, &legacy.BDF, "BDF", "bdf"); err != nil {
+		return err
+	}
+	if err := unmarshalJSONField(fields, &legacy.BARIndex, "BARIndex", "bar_index"); err != nil {
+		return err
+	}
+	if err := unmarshalJSONField(fields, &legacy.BARBase, "BARBase", "bar_base"); err != nil {
+		return err
+	}
+	if err := unmarshalJSONField(fields, &legacy.BARSize, "BARSize", "bar_size"); err != nil {
+		return err
+	}
+	if err := unmarshalJSONField(fields, &legacy.Duration, "Duration", "duration"); err != nil {
+		return err
+	}
+	if err := unmarshalJSONField(fields, &legacy.StartTime, "StartTime", "started_at"); err != nil {
+		return err
+	}
+	if err := unmarshalJSONField(fields, &legacy.Records, "Records", "records"); err != nil {
+		return err
+	}
+	decoded := TraceResult{
+		SchemaVersion: TraceSchemaVersion, BDF: legacy.BDF, BARIndex: legacy.BARIndex,
+		BARBase: legacy.BARBase, BARSize: legacy.BARSize, Duration: legacy.Duration,
+		StartTime: legacy.StartTime, Records: make([]AccessRecord, len(legacy.Records)),
+	}
+	for i, rawRecord := range legacy.Records {
+		var recordFields map[string]json.RawMessage
+		if err := json.Unmarshal(rawRecord, &recordFields); err != nil {
+			return fmt.Errorf("record %d: %w", i, err)
+		}
+		_, hasBARIndex := firstJSONField(recordFields, "BARIndex", "bar_index")
+		if err := json.Unmarshal(rawRecord, &decoded.Records[i]); err != nil {
+			return fmt.Errorf("record %d: %w", i, err)
+		}
+		if !hasBARIndex {
+			decoded.Records[i].BARIndex = decoded.BARIndex
+		}
+		if decoded.Records[i].BDF == "" {
+			decoded.Records[i].BDF = decoded.BDF
+		}
+		if decoded.Records[i].Address == 0 && decoded.BARBase != 0 {
+			if decoded.BARBase > ^uint64(0)-uint64(decoded.Records[i].Offset) {
+				return fmt.Errorf("record %d address overflows", i)
+			}
+			decoded.Records[i].Address = decoded.BARBase + uint64(decoded.Records[i].Offset)
+		}
+	}
+	if err := decoded.validateRecords(false); err != nil {
+		return err
+	}
+	*t = decoded
+	return nil
+}
+
+func (t *TraceResult) validateRecords(requireAddress bool) error {
+	if t.BARIndex < 0 || t.BARIndex > 5 {
+		return fmt.Errorf("invalid trace BAR index %d", t.BARIndex)
+	}
+	if t.BARSize <= 0 {
+		return fmt.Errorf("trace BAR size must be positive")
+	}
+	size := uint64(t.BARSize)
+	if t.BARBase > ^uint64(0)-size {
+		return fmt.Errorf("trace BAR aperture overflows physical address space")
+	}
+	var previous time.Duration
+	for i, record := range t.Records {
+		if record.BDF != t.BDF {
+			return fmt.Errorf("record %d BDF %q does not match trace BDF %q", i, record.BDF, t.BDF)
+		}
+		if record.BARIndex != t.BARIndex {
+			return fmt.Errorf("record %d BAR%d does not match trace BAR%d", i, record.BARIndex, t.BARIndex)
+		}
+		if !validAccessWidth(record.Width) {
+			return fmt.Errorf("record %d: invalid MMIO width %d", i, record.Width)
+		}
+		if uint64(record.Offset)+uint64(record.Width) > size {
+			return fmt.Errorf("record %d access at %#x is outside BAR size %#x", i, record.Offset, t.BARSize)
+		}
+		if record.Offset%uint32(record.Width) != 0 {
+			return fmt.Errorf("record %d access at %#x is misaligned", i, record.Offset)
+		}
+		expectedAddress := t.BARBase + uint64(record.Offset)
+		if requireAddress || (t.BARBase != 0 && record.Address != 0) {
+			if record.Address != expectedAddress {
+				return fmt.Errorf("record %d address %#x does not match BAR offset address %#x", i, record.Address, expectedAddress)
+			}
+		}
+		if record.Timestamp < 0 || record.Timestamp < previous {
+			return fmt.Errorf("record %d timestamp is not monotonic", i)
+		}
+		previous = record.Timestamp
+	}
+	return nil
+}
+
+
+func firstJSONField(fields map[string]json.RawMessage, names ...string) (json.RawMessage, bool) {
+	for _, name := range names {
+		if raw, ok := fields[name]; ok {
+			return raw, true
+		}
+	}
+	return nil, false
+}
+
+func unmarshalJSONField(fields map[string]json.RawMessage, dst any, names ...string) error {
+	raw, ok := firstJSONField(fields, names...)
+	if !ok {
+		return nil
+	}
+	return json.Unmarshal(raw, dst)
+}
+
+func validAccessWidth(width uint8) bool {
+	return width == 1 || width == 2 || width == 4 || width == 8
+}
+
+func valueFitsWidth(value uint64, width uint8) bool {
+	return width == 8 || (validAccessWidth(width) && value < uint64(1)<<(width*8))
+}
+
 // HotRegister is a register with high access count.
 type HotRegister struct {
 	Offset     uint32
 	ReadCount  int
 	WriteCount int
 	TotalCount int
-	LastValue  uint32
-	Values     []uint32 // unique values seen
+	LastValue  uint64
+	Values     []uint64
 }
 
 // PollingLoop is a repeated-read pattern on one register.
@@ -84,8 +449,8 @@ func Analyze(trace *TraceResult) *AccessPattern {
 	type regStats struct {
 		reads     int
 		writes    int
-		values    map[uint32]bool
-		last      uint32
+		values    map[uint64]bool
+		last      uint64
 		readTimes []time.Duration
 	}
 	stats := make(map[uint32]*regStats)
@@ -93,7 +458,7 @@ func Analyze(trace *TraceResult) *AccessPattern {
 	for _, rec := range trace.Records {
 		s, ok := stats[rec.Offset]
 		if !ok {
-			s = &regStats{values: make(map[uint32]bool)}
+			s = &regStats{values: make(map[uint64]bool)}
 			stats[rec.Offset] = s
 		}
 		s.values[rec.Value] = true
@@ -111,7 +476,7 @@ func Analyze(trace *TraceResult) *AccessPattern {
 
 	// build hot-register list
 	for off, s := range stats {
-		vals := make([]uint32, 0, len(s.values))
+		vals := make([]uint64, 0, len(s.values))
 		for v := range s.values {
 			vals = append(vals, v)
 		}
@@ -183,7 +548,7 @@ func FormatReport(pattern *AccessPattern) string {
 	}
 	for i := 0; i < limit; i++ {
 		hr := pattern.HotRegisters[i]
-		fmt.Fprintf(&sb, "  0x%03X  R:%-4d W:%-4d  last=0x%08X  (%d unique values)\n",
+		fmt.Fprintf(&sb, "  0x%03X  R:%-4d W:%-4d  last=0x%016X  (%d unique values)\n",
 			hr.Offset, hr.ReadCount, hr.WriteCount, hr.LastValue, len(hr.Values))
 	}
 
@@ -198,7 +563,7 @@ func FormatReport(pattern *AccessPattern) string {
 	if len(pattern.InitSequence) > 0 {
 		sb.WriteString("\n--- Init Sequence (first writes) ---\n")
 		for i, rec := range pattern.InitSequence {
-			fmt.Fprintf(&sb, "  %2d. [%v] 0x%03X ← 0x%08X\n",
+			fmt.Fprintf(&sb, "  %2d. [%v] 0x%03X ← 0x%016X\n",
 				i+1, rec.Timestamp, rec.Offset, rec.Value)
 		}
 	}

--- a/internal/firmware/barmodel/rules.go
+++ b/internal/firmware/barmodel/rules.go
@@ -1,0 +1,99 @@
+package barmodel
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/behavior"
+)
+
+func ApplyBehaviorRules(model *BARModel, set *behavior.RuleSet) (*BARModel, error) {
+	if set == nil {
+		return model, nil
+	}
+	if err := behavior.Validate(set); err != nil {
+		return nil, err
+	}
+	if model == nil {
+		model = &BARModel{Size: set.BARSize}
+	}
+	if model.Size < set.BARSize {
+		model.Size = set.BARSize
+	}
+	registers := make(map[uint32]int, len(model.Registers))
+	for i := range model.Registers {
+		registers[model.Registers[i].Offset] = i
+	}
+	initialValues := make(map[uint32]uint32, len(set.InitialRegisters))
+	explicitPolicies := make(map[uint32]bool, len(set.InitialRegisters))
+	for _, initial := range set.InitialRegisters {
+		if initial.Width != 4 || initial.Offset%4 != 0 {
+			return nil, fmt.Errorf("initial register at %#x is not supported by 32-bit BAR RTL", initial.Offset)
+		}
+		initialValues[initial.Offset] = uint32(initial.Value)
+		explicitPolicies[initial.Offset] = initial.WritePolicy != nil
+		if index, ok := registers[initial.Offset]; ok {
+			if model.Registers[index].IsFSMDriven || model.Registers[index].IsRW1C {
+				return nil, fmt.Errorf("initial register at %#x conflicts with existing device behavior", initial.Offset)
+			}
+			model.Registers[index].Reset = uint32(initial.Value)
+			if initial.WritePolicy != nil {
+				model.Registers[index].RWMask = uint32(initial.WritePolicy.RWMask)
+				model.Registers[index].W1CMask = uint32(initial.WritePolicy.W1CMask)
+			}
+			continue
+		}
+		registers[initial.Offset] = len(model.Registers)
+		register := BARRegister{
+			Offset: initial.Offset, Width: 4, Reset: uint32(initial.Value), Name: fmt.Sprintf("BEHAVIOR_%08X", initial.Offset),
+		}
+		if initial.WritePolicy != nil {
+			register.RWMask = uint32(initial.WritePolicy.RWMask)
+			register.W1CMask = uint32(initial.WritePolicy.W1CMask)
+		}
+		model.Registers = append(model.Registers, register)
+	}
+	owned := make(map[uint32]struct{})
+	for _, rule := range set.Rules {
+		if rule.Access != behavior.AccessWrite || rule.Width != 4 || rule.Offset%4 != 0 {
+			return nil, fmt.Errorf("rule %q is not supported by 32-bit BAR RTL", rule.ID)
+		}
+		updates := append([]behavior.RegisterUpdate(nil), rule.Updates...)
+		for _, event := range rule.DelayedEvents {
+			updates = append(updates, event.Updates...)
+		}
+		for _, update := range updates {
+			if update.Width != 4 || update.Offset%4 != 0 {
+				return nil, fmt.Errorf("rule %q update at %#x is not supported by 32-bit BAR RTL", rule.ID, update.Offset)
+			}
+			if index, ok := registers[update.Offset]; ok {
+				if _, alreadyOwned := owned[update.Offset]; alreadyOwned {
+					continue
+				}
+				if model.Registers[index].IsFSMDriven || model.Registers[index].IsRW1C {
+					return nil, fmt.Errorf("rule %q update at %#x conflicts with existing device behavior", rule.ID, update.Offset)
+				}
+				if update.Offset == rule.Offset && !explicitPolicies[update.Offset] {
+					model.Registers[index].RWMask = ^uint32(0)
+					model.Registers[index].W1CMask = 0
+				}
+				model.Registers[index].Reset = initialValues[update.Offset]
+				model.Registers[index].IsFSMDriven = true
+				owned[update.Offset] = struct{}{}
+				continue
+			}
+			registers[update.Offset] = len(model.Registers)
+			rwMask := uint32(0)
+			if update.Offset == rule.Offset {
+				rwMask = ^uint32(0)
+			}
+			model.Registers = append(model.Registers, BARRegister{
+				Offset: update.Offset, Width: 4, Reset: initialValues[update.Offset], RWMask: rwMask,
+				Name: fmt.Sprintf("BEHAVIOR_%08X", update.Offset), IsFSMDriven: true,
+			})
+			owned[update.Offset] = struct{}{}
+		}
+	}
+	sort.Slice(model.Registers, func(i, j int) bool { return model.Registers[i].Offset < model.Registers[j].Offset })
+	return model, nil
+}

--- a/internal/firmware/output/behavior_rules_test.go
+++ b/internal/firmware/output/behavior_rules_test.go
@@ -1,0 +1,54 @@
+package output
+
+import (
+	"math"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/board"
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/donor/behavior"
+	"github.com/sercanarga/pcileechgen/internal/firmware"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func TestBuildSVConfig_ConsumesPersistedBehaviorRules(t *testing.T) {
+	rules := &behavior.RuleSet{
+		Version:      behavior.RuleSchemaVersion,
+		BARIndex:     0,
+		BARSize:      0x1000,
+		ClockHz:      100_000_000,
+		InitialState: "idle",
+		Rules: []behavior.Rule{{
+			ID: "enable-ready", State: "idle", Access: behavior.AccessKind("write"),
+			Width: 4, Offset: 0x20, Value: 1, ValueMask: math.MaxUint32,
+			DelayedEvents: []behavior.DelayedEvent{{
+				DelayCycles: 7,
+				Updates: []behavior.RegisterUpdate{{Offset: 0x24, Width: 4, Value: 1, Mask: math.MaxUint32}},
+				NextState: "ready",
+			}},
+			Confidence: 1, Provenance: []string{"test fixture"},
+		}},
+	}
+	ctx := &donor.DeviceContext{
+		Device:        pci.PCIDevice{VendorID: 0x1234, DeviceID: 0x5678, ClassCode: 0xff0000},
+		ConfigSpace:   pci.NewConfigSpace(),
+		BARs:          []pci.BAR{{Index: 0, Size: 0x1000, Type: pci.BARTypeMem32}},
+		BARContents:   map[int][]byte{0: make([]byte, 0x1000)},
+		BehaviorRules: rules,
+	}
+	ids := firmware.DeviceIDs{VendorID: 0x1234, DeviceID: 0x5678, ClassCode: 0xff0000}
+	writer := NewOutputWriter(t.TempDir(), "", 1, 1)
+	cfg, err := writer.buildSVConfig(ctx, ctx.ConfigSpace, ids, 0x12345678, &board.Board{BRAMSize: 0x1000})
+	if err != nil {
+		t.Fatalf("buildSVConfig: %v", err)
+	}
+	if cfg.BehaviorRules == nil {
+		t.Fatal("build discarded persisted behavior rules")
+	}
+	if len(cfg.BehaviorRules.Rules) != 1 || cfg.BehaviorRules.Rules[0].ID != "enable-ready" {
+		t.Fatalf("SV config behavior rules = %+v", cfg.BehaviorRules)
+	}
+	if got := cfg.BehaviorRules.Rules[0].DelayedEvents[0].DelayCycles; got != 7 {
+		t.Fatalf("SV config delay = %d, want 7", got)
+	}
+}

--- a/internal/firmware/output/writer.go
+++ b/internal/firmware/output/writer.go
@@ -491,6 +491,28 @@ func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.
 		bm = &barmodel.BARModel{Size: bar0Size}
 	}
 
+	var compiledRules *svgen.CompiledBehavior
+	if ctx.BehaviorRules != nil {
+		if ownershipErr := svgen.ValidateBehaviorRuleOwnership(ctx.BehaviorRules, devClass); ownershipErr != nil {
+			return nil, ownershipErr
+		}
+		if ctx.BehaviorRules.BARIndex != barIdx {
+			return nil, fmt.Errorf("behavior rules target BAR%d but generated BAR is BAR%d", ctx.BehaviorRules.BARIndex, barIdx)
+		}
+		if ctx.BehaviorRules.BARSize > bar0Size {
+			return nil, fmt.Errorf("behavior BAR size %d exceeds generated BAR size %d", ctx.BehaviorRules.BARSize, bar0Size)
+		}
+		var applyErr error
+		bm, applyErr = barmodel.ApplyBehaviorRules(bm, ctx.BehaviorRules)
+		if applyErr != nil {
+			return nil, fmt.Errorf("apply behavior rules: %w", applyErr)
+		}
+		compiledRules, applyErr = svgen.CompileBehaviorRules(ctx.BehaviorRules, bm)
+		if applyErr != nil {
+			return nil, fmt.Errorf("compile behavior rules: %w", applyErr)
+		}
+	}
+
 	cfg := &svgen.SVGeneratorConfig{
 		DeviceIDs:         ids,
 		DonorCapabilities: extractDonorCapabilities(scrubbedCS),
@@ -502,6 +524,8 @@ func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.
 		PRNGSeeds:         svgen.BuildPRNGSeeds(ids.VendorID, ids.DeviceID, entropy),
 		DeviceClass:       devClass,
 		Bar0Size:          bar0Size,
+		BehaviorRules:     ctx.BehaviorRules,
+		CompiledBehavior:  compiledRules,
 	}
 
 	if devClass == devclass.ClassNVMe {

--- a/internal/firmware/svgen/behavior_rules.go
+++ b/internal/firmware/svgen/behavior_rules.go
@@ -1,0 +1,329 @@
+package svgen
+
+import (
+	"fmt"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/behavior"
+	"github.com/sercanarga/pcileechgen/internal/firmware/barmodel"
+)
+
+const BehaviorRTLClockHz uint64 = 125_000_000
+
+type CompiledBehavior struct {
+	StateBits    int
+	InitialState int
+	States       []string
+	Registers    []CompiledBehaviorRegister
+	Rules        []CompiledBehaviorRule
+	AllEvents    []CompiledBehaviorEvent
+	DueRegisters []CompiledDueRegister
+}
+
+type CompiledBehaviorRegister struct {
+	Offset  uint32
+	Reset   uint32
+	RWMask  uint32
+	W1CMask uint32
+}
+
+type CompiledBehaviorRule struct {
+	Index          int
+	State          int
+	NextState      int
+	Offset         uint32
+	Value          uint32
+	ValueMask      uint32
+	ByteEnableMask uint8
+	Updates        []CompiledBehaviorUpdate
+	DelayedEvents  []CompiledBehaviorEvent
+}
+
+type CompiledBehaviorUpdate struct {
+	Offset uint32
+	Value  uint32
+	Mask   uint32
+	ComposeTriggerWrite bool
+	TriggerRWMask         uint32
+	TriggerW1CMask        uint32
+}
+type CompiledDueRegister struct {
+	Offset        uint32
+	Contributions []CompiledDueContribution
+}
+
+type CompiledDueContribution struct {
+	EventIndex int
+	Value      uint32
+	Mask       uint32
+}
+
+func ValidateBehaviorRuleOwnership(set *behavior.RuleSet, deviceClass string) error {
+	if set == nil || deviceClass != "audio" {
+		return nil
+	}
+	reserved := map[uint32]struct{}{
+		0x0c: {}, 0x24: {}, 0x48: {}, 0x4c: {}, 0x58: {}, 0x5c: {}, 0x60: {}, 0x70: {}, 0x74: {},
+	}
+	for _, initial := range set.InitialRegisters {
+		if _, exists := reserved[initial.Offset]; exists {
+			return fmt.Errorf("initial register at %#x conflicts with audio device behavior", initial.Offset)
+		}
+	}
+	for _, rule := range set.Rules {
+		if _, exists := reserved[rule.Offset]; exists {
+			return fmt.Errorf("rule %q trigger at %#x conflicts with audio device behavior", rule.ID, rule.Offset)
+		}
+		updates := append([]behavior.RegisterUpdate(nil), rule.Updates...)
+		for _, event := range rule.DelayedEvents {
+			updates = append(updates, event.Updates...)
+		}
+		for _, update := range updates {
+			if _, exists := reserved[update.Offset]; exists {
+				return fmt.Errorf("rule %q update at %#x conflicts with audio device behavior", rule.ID, update.Offset)
+			}
+		}
+	}
+	return nil
+}
+
+func prepareBehaviorConfig(cfg *SVGeneratorConfig) (*SVGeneratorConfig, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("SV generator config is nil")
+	}
+	if cfg.BehaviorRules == nil || cfg.CompiledBehavior != nil {
+		return cfg, nil
+	}
+	prepared := *cfg
+	if err := ValidateBehaviorRuleOwnership(prepared.BehaviorRules, prepared.DeviceClass); err != nil {
+		return nil, err
+	}
+	if prepared.BARModel == nil {
+		prepared.BARModel = barmodel.BuildBARModel(nil, prepared.ClassCode, nil)
+	}
+	if cfg.BARModel != nil {
+		modelCopy := *cfg.BARModel
+		modelCopy.Registers = append([]barmodel.BARRegister(nil), cfg.BARModel.Registers...)
+		prepared.BARModel = &modelCopy
+	}
+	model, err := barmodel.ApplyBehaviorRules(prepared.BARModel, prepared.BehaviorRules)
+	if err != nil {
+		return nil, err
+	}
+	prepared.BARModel = model
+	prepared.CompiledBehavior, err = CompileBehaviorRules(prepared.BehaviorRules, model)
+	if err != nil {
+		return nil, err
+	}
+	return &prepared, nil
+}
+
+
+type CompiledBehaviorEvent struct {
+	Index       int
+	DelayCycles uint32
+	NextState   int
+	Updates     []CompiledBehaviorUpdate
+}
+
+func CompileBehaviorRules(set *behavior.RuleSet, model *barmodel.BARModel) (*CompiledBehavior, error) {
+	if set == nil {
+		return nil, nil
+	}
+	if err := behavior.Validate(set); err != nil {
+		return nil, err
+	}
+	if model == nil {
+		return nil, fmt.Errorf("behavior rules require a BAR model")
+	}
+	stateIndex := make(map[string]int)
+	states := make([]string, 0)
+	addState := func(state string) int {
+		if state == "" {
+			return -1
+		}
+		if index, ok := stateIndex[state]; ok {
+			return index
+		}
+		index := len(states)
+		stateIndex[state] = index
+		states = append(states, state)
+		return index
+	}
+	initial := addState(set.InitialState)
+	for _, rule := range set.Rules {
+		addState(rule.State)
+		addState(rule.NextState)
+		for _, event := range rule.DelayedEvents {
+			addState(event.NextState)
+		}
+	}
+	bits := 1
+	for (1 << bits) < len(states) {
+		bits++
+	}
+	compiled := &CompiledBehavior{StateBits: bits, InitialState: initial, States: states}
+	owned := make(map[uint32]struct{})
+	initialValues := make(map[uint32]uint32, len(set.InitialRegisters))
+	for _, initialValue := range set.InitialRegisters {
+		initialValues[initialValue.Offset] = uint32(initialValue.Value)
+	}
+	triggerRWMasks := make(map[uint32]uint32, len(model.Registers))
+	triggerW1CMasks := make(map[uint32]uint32, len(model.Registers))
+	for _, register := range model.Registers {
+		triggerRWMasks[register.Offset] = register.RWMask
+		triggerW1CMasks[register.Offset] = register.W1CMask
+	}
+	for _, initialValue := range set.InitialRegisters {
+		if initialValue.WritePolicy != nil {
+			triggerRWMasks[initialValue.Offset] = uint32(initialValue.WritePolicy.RWMask)
+			triggerW1CMasks[initialValue.Offset] = uint32(initialValue.WritePolicy.W1CMask)
+		}
+	}
+	eventIndex := 0
+	for ruleIndex, rule := range set.Rules {
+		if rule.Access != behavior.AccessWrite || rule.Width != 4 || rule.Offset%4 != 0 {
+			return nil, fmt.Errorf("rule %q is not a supported aligned 32-bit write trigger", rule.ID)
+		}
+		next := stateIndex[rule.State]
+		if rule.NextState != "" {
+			next = stateIndex[rule.NextState]
+		}
+		immediate, err := coalesceUpdates(rule.Updates)
+		if err != nil {
+			return nil, fmt.Errorf("rule %q immediate updates: %w", rule.ID, err)
+		}
+		compiledRule := CompiledBehaviorRule{
+			Index: ruleIndex, State: stateIndex[rule.State], NextState: next,
+			Offset: rule.Offset, Value: uint32(rule.Value), ValueMask: uint32(rule.ValueMask),
+			ByteEnableMask: 0x0f, Updates: immediate,
+		}
+		for updateIndex := range compiledRule.Updates {
+			update := &compiledRule.Updates[updateIndex]
+			if update.Offset == rule.Offset {
+				update.ComposeTriggerWrite = true
+				update.TriggerRWMask = triggerRWMasks[rule.Offset]
+				update.TriggerW1CMask = triggerW1CMasks[rule.Offset]
+			}
+			owned[update.Offset] = struct{}{}
+		}
+		type eventGroup struct {
+			delay     uint32
+			nextState int
+			updates   []behavior.RegisterUpdate
+		}
+		eventGroups := make([]eventGroup, 0, len(rule.DelayedEvents))
+		eventByDelay := make(map[uint32]int)
+		for _, event := range rule.DelayedEvents {
+			delay, scaleErr := scaleDelayCycles(event.DelayCycles, set.ClockHz)
+			if scaleErr != nil {
+				return nil, fmt.Errorf("rule %q: %w", rule.ID, scaleErr)
+			}
+			nextEventState := -1
+			if event.NextState != "" {
+				nextEventState = stateIndex[event.NextState]
+			}
+			if groupIndex, exists := eventByDelay[delay]; exists {
+				group := &eventGroups[groupIndex]
+				if group.nextState >= 0 && nextEventState >= 0 && group.nextState != nextEventState {
+					return nil, fmt.Errorf("rule %q has conflicting states after delay rescaling", rule.ID)
+				}
+				if group.nextState < 0 {
+					group.nextState = nextEventState
+				}
+				group.updates = append(group.updates, event.Updates...)
+				continue
+			}
+			eventByDelay[delay] = len(eventGroups)
+			eventGroups = append(eventGroups, eventGroup{delay: delay, nextState: nextEventState, updates: append([]behavior.RegisterUpdate(nil), event.Updates...)})
+		}
+		for _, group := range eventGroups {
+			updates, mergeErr := coalesceUpdates(group.updates)
+			if mergeErr != nil {
+				return nil, fmt.Errorf("rule %q delayed updates: %w", rule.ID, mergeErr)
+			}
+			compiledEvent := CompiledBehaviorEvent{Index: eventIndex, DelayCycles: group.delay, NextState: group.nextState, Updates: updates}
+			eventIndex++
+			for _, update := range updates {
+				owned[update.Offset] = struct{}{}
+			}
+			compiledRule.DelayedEvents = append(compiledRule.DelayedEvents, compiledEvent)
+			compiled.AllEvents = append(compiled.AllEvents, compiledEvent)
+		}
+		compiled.Rules = append(compiled.Rules, compiledRule)
+	}
+	dueByOffset := make(map[uint32][]CompiledDueContribution)
+	for _, event := range compiled.AllEvents {
+		for _, update := range event.Updates {
+			dueByOffset[update.Offset] = append(dueByOffset[update.Offset], CompiledDueContribution{
+				EventIndex: event.Index, Value: update.Value, Mask: update.Mask,
+			})
+		}
+	}
+	for _, register := range model.Registers {
+		if _, ok := owned[register.Offset]; ok {
+			compiled.Registers = append(compiled.Registers, CompiledBehaviorRegister{
+				Offset: register.Offset, Reset: initialValues[register.Offset], RWMask: register.RWMask, W1CMask: register.W1CMask,
+			})
+			if contributions := dueByOffset[register.Offset]; len(contributions) > 0 {
+				compiled.DueRegisters = append(compiled.DueRegisters, CompiledDueRegister{
+					Offset: register.Offset, Contributions: contributions,
+				})
+			}
+		}
+	}
+	return compiled, nil
+}
+
+func coalesceUpdates(updates []behavior.RegisterUpdate) ([]CompiledBehaviorUpdate, error) {
+	result := make([]CompiledBehaviorUpdate, 0, len(updates))
+	byOffset := make(map[uint32]int)
+	for _, update := range updates {
+		if update.Width != 4 || update.Offset%4 != 0 {
+			return nil, fmt.Errorf("update at %#x is not an aligned 32-bit register update", update.Offset)
+		}
+		if index, exists := byOffset[update.Offset]; exists {
+			previous := &result[index]
+			overlap := previous.Mask & uint32(update.Mask)
+			if ((previous.Value ^ uint32(update.Value)) & overlap) != 0 {
+				return nil, fmt.Errorf("update at %#x has contradictory overlapping masks", update.Offset)
+			}
+			previous.Value = (previous.Value &^ uint32(update.Mask)) | (uint32(update.Value) & uint32(update.Mask))
+			previous.Mask |= uint32(update.Mask)
+			continue
+		}
+		byOffset[update.Offset] = len(result)
+		result = append(result, CompiledBehaviorUpdate{Offset: update.Offset, Value: uint32(update.Value) & uint32(update.Mask), Mask: uint32(update.Mask)})
+	}
+	return result, nil
+}
+
+func scaleDelayCycles(delay uint32, sourceClockHz uint64) (uint32, error) {
+	if sourceClockHz == 0 {
+		return 0, fmt.Errorf("source behavior clock is zero")
+	}
+	if uint64(delay) > ^uint64(0)/BehaviorRTLClockHz {
+		return 0, fmt.Errorf("delay %d overflows RTL clock conversion", delay)
+	}
+	numerator := uint64(delay) * BehaviorRTLClockHz
+	scaled := numerator / sourceClockHz
+	if numerator%sourceClockHz != 0 {
+		scaled++
+	}
+	if scaled == 0 {
+		scaled = 1
+	}
+	if scaled > uint64(behavior.MaxDelayCycles) {
+		return 0, fmt.Errorf("rescaled delay %d exceeds maximum %d", scaled, behavior.MaxDelayCycles)
+	}
+	return uint32(scaled), nil
+}
+
+func byteEnableMask(mask uint32) uint8 {
+	var enables uint8
+	for byteIndex := range 4 {
+		if mask&(0xff<<uint(byteIndex*8)) != 0 {
+			enables |= 1 << uint(byteIndex)
+		}
+	}
+	return enables
+}

--- a/internal/firmware/svgen/behavior_rules_reviewer_test.go
+++ b/internal/firmware/svgen/behavior_rules_reviewer_test.go
@@ -1,0 +1,379 @@
+package svgen
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/behavior"
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+	"github.com/sercanarga/pcileechgen/internal/firmware/barmodel"
+)
+
+func reviewerCompilerModel() *barmodel.BARModel {
+	return &barmodel.BARModel{
+		Size: 0x1000,
+		Registers: []barmodel.BARRegister{
+			{Offset: 0x24, Width: 4, Reset: 0xdeadbeef, Name: "STATUS0"},
+			{Offset: 0x28, Width: 4, Reset: 0xcafebabe, Name: "STATUS1"},
+		},
+	}
+}
+
+func reviewerCompilerRules() *behavior.RuleSet {
+	return &behavior.RuleSet{
+		Version: behavior.RuleSchemaVersion, BARSize: 0x1000,
+		ClockHz: 100_000_000, InitialState: "idle",
+		Rules: []behavior.Rule{{
+			ID: "compose", State: "idle", Access: behavior.AccessWrite, Width: 4,
+			Offset: 0x20, Value: 1, ValueMask: math.MaxUint32,
+			Updates: []behavior.RegisterUpdate{
+				{Offset: 0x24, Width: 4, Value: 0x00000005, Mask: 0x0000000f},
+				{Offset: 0x24, Width: 4, Value: 0x000000a0, Mask: 0x000000f0},
+			},
+			DelayedEvents: []behavior.DelayedEvent{
+				{DelayCycles: 10, Updates: []behavior.RegisterUpdate{
+					{Offset: 0x24, Width: 4, Value: 0x00000300, Mask: 0x00000f00},
+				}},
+				{DelayCycles: 10, Updates: []behavior.RegisterUpdate{
+					{Offset: 0x24, Width: 4, Value: 0x0000c000, Mask: 0x0000f000},
+				}},
+			},
+			Confidence: 1, Provenance: []string{"test"},
+		}},
+	}
+}
+
+func TestCompileBehaviorRulesCoalescesDisjointRegisterUpdates(t *testing.T) {
+	compiled, err := CompileBehaviorRules(reviewerCompilerRules(), reviewerCompilerModel())
+	if err != nil {
+		t.Fatalf("CompileBehaviorRules: %v", err)
+	}
+	if len(compiled.Rules) != 1 || len(compiled.Rules[0].Updates) != 1 {
+		t.Fatalf("compiled immediate updates = %+v, want one coalesced update", compiled.Rules)
+	}
+	immediate := compiled.Rules[0].Updates[0]
+	if immediate.Offset != 0x24 || immediate.Mask != 0xff || immediate.Value != 0xa5 {
+		t.Fatalf("coalesced immediate update = %+v, want offset 0x24 mask 0xff value 0xa5", immediate)
+	}
+	if len(compiled.Rules[0].DelayedEvents) != 1 || len(compiled.Rules[0].DelayedEvents[0].Updates) != 1 {
+		t.Fatalf("compiled delayed updates = %+v, want one coalesced update", compiled.Rules[0].DelayedEvents)
+	}
+	delayed := compiled.Rules[0].DelayedEvents[0].Updates[0]
+	if delayed.Offset != 0x24 || delayed.Mask != 0xff00 || delayed.Value != 0xc300 {
+		t.Fatalf("coalesced delayed update = %+v, want offset 0x24 mask 0xff00 value 0xc300", delayed)
+	}
+}
+
+func TestCompileBehaviorRulesRescalesDelayWithCeilingAndRejectsOverflow(t *testing.T) {
+	set := reviewerCompilerRules()
+	compiled, err := CompileBehaviorRules(set, reviewerCompilerModel())
+	if err != nil {
+		t.Fatalf("CompileBehaviorRules: %v", err)
+	}
+	if got := compiled.Rules[0].DelayedEvents[0].DelayCycles; got != 13 {
+		t.Fatalf("125MHz delay = %d, want ceil(10*125/100)=13", got)
+	}
+
+	set.ClockHz = 1
+	set.Rules[0].DelayedEvents[0].DelayCycles = behavior.MaxDelayCycles
+	if _, err := CompileBehaviorRules(set, reviewerCompilerModel()); err == nil {
+		t.Fatal("expected rescaled delay above hardware bound to be rejected")
+	}
+}
+
+func TestEngineReplayAndCompiledRTLShareInitialRegisterSeeds(t *testing.T) {
+	set := reviewerCompilerRules()
+	set.InitialRegisters = []behavior.RegisterValue{{Offset: 0x24, Width: 4, Value: 0x11223344}}
+	set.Rules[0].Updates = []behavior.RegisterUpdate{
+		{Offset: 0x24, Width: 4, Value: 1, Mask: 1},
+		{Offset: 0x28, Width: 4, Value: 1, Mask: 1},
+	}
+	set.Rules[0].DelayedEvents = nil
+
+	compiled, err := CompileBehaviorRules(set, reviewerCompilerModel())
+	if err != nil {
+		t.Fatalf("CompileBehaviorRules: %v", err)
+	}
+	resets := make(map[uint32]uint32)
+	for _, register := range compiled.Registers {
+		resets[register.Offset] = register.Reset
+	}
+	if resets[0x24] != 0x11223344 || resets[0x28] != 0 {
+		t.Fatalf("compiled resets = %#v, want explicit 0x11223344 and implicit zero", resets)
+	}
+
+	engine, err := behavior.NewEngine(set)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	if got, ok := engine.Register(0x24); !ok || got != 0x11223344 {
+		t.Fatalf("explicit engine seed = %#x, present=%v, want 0x11223344", got, ok)
+	}
+	if got, _ := engine.Register(0x28); got != 0 {
+		t.Fatalf("implicit engine seed = %#x, want zero", got)
+	}
+
+	trace := &mmio.TraceResult{
+		BARIndex: 0, BARSize: 0x1000,
+		Records: []mmio.AccessRecord{
+			{Type: mmio.AccessRead, Width: 4, Offset: 0x24, Value: 0x11223344},
+			{Type: mmio.AccessRead, Width: 4, Offset: 0x28, Value: 0},
+		},
+	}
+	result, err := behavior.Replay(set, trace)
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if len(result.ReadMismatches) != 0 {
+		t.Fatalf("initial reads disagree with compiled reset seeds: %+v", result.ReadMismatches)
+	}
+}
+
+func TestGenerateBehaviorRTLGuardsTriggersOnEventDeadline(t *testing.T) {
+	cfg := testConfig()
+	cfg.BARModel = reviewerCompilerModel()
+	cfg.BehaviorRules = generatedRuleSet(1)
+	generated, err := GenerateBarImplDeviceSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarImplDeviceSV: %v", err)
+	}
+	if !strings.Contains(generated, "behavior_event_due") {
+		t.Fatal("generated RTL has no event deadline signal")
+	}
+	if !strings.Contains(generated, "!behavior_event_due") {
+		t.Fatal("generated RTL does not suppress triggers on an event deadline")
+	}
+}
+
+func TestGenerateBehaviorRTLPreservesFirstPendingDeadlineAndComposesDueUpdates(t *testing.T) {
+	set := &behavior.RuleSet{
+		Version: behavior.RuleSchemaVersion, BARSize: 0x1000,
+		ClockHz: 100_000_000, InitialState: "idle",
+		Rules: []behavior.Rule{
+			{
+				ID: "low", State: "idle", Access: behavior.AccessWrite, Width: 4,
+				Offset: 0x20, Value: 1, ValueMask: math.MaxUint32,
+				DelayedEvents: []behavior.DelayedEvent{{
+					DelayCycles: 5,
+					Updates: []behavior.RegisterUpdate{{Offset: 0x24, Width: 4, Value: 5, Mask: 0x0f}},
+					NextState: "first",
+				}},
+				Confidence: 1, Provenance: []string{"test"},
+			},
+			{
+				ID: "high", State: "idle", Access: behavior.AccessWrite, Width: 4,
+				Offset: 0x28, Value: 1, ValueMask: math.MaxUint32,
+				DelayedEvents: []behavior.DelayedEvent{{
+					DelayCycles: 4,
+					Updates: []behavior.RegisterUpdate{{Offset: 0x24, Width: 4, Value: 0xa0, Mask: 0xf0}},
+					NextState: "second",
+				}},
+				Confidence: 1, Provenance: []string{"test"},
+			},
+		},
+	}
+	compiled, err := CompileBehaviorRules(set, reviewerCompilerModel())
+	if err != nil {
+		t.Fatalf("CompileBehaviorRules: %v", err)
+	}
+	if len(compiled.DueRegisters) != 1 || compiled.DueRegisters[0].Offset != 0x24 ||
+		len(compiled.DueRegisters[0].Contributions) != 2 {
+		t.Fatalf("compiled due-register composition = %+v", compiled.DueRegisters)
+	}
+	secondState := -1
+	for index, state := range compiled.States {
+		if state == "second" {
+			secondState = index
+		}
+	}
+	if len(compiled.AllEvents) != 2 || compiled.AllEvents[1].NextState != secondState {
+		t.Fatalf("compiled static event order = %+v, states=%v", compiled.AllEvents, compiled.States)
+	}
+	cfg := testConfig()
+	cfg.DeviceClass = ""
+	cfg.ClassCode = 0xff0000
+	cfg.BARModel = reviewerCompilerModel()
+	cfg.BehaviorRules = set
+	generated, err := GenerateBarImplDeviceSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarImplDeviceSV: %v", err)
+	}
+	if !strings.Contains(generated, "if (!rule_delay_pending_0)") {
+		t.Fatal("generated RTL rearms an already pending delayed event")
+	}
+	if !strings.Contains(generated, "behavior_due_mask_00000024") ||
+		!strings.Contains(generated, "behavior_due_value_00000024") {
+		t.Fatal("generated RTL has no global due-update composition for register 0x24")
+	}
+	assignment := "if (behavior_due_mask_00000024 != 32'h00000000) reg_0x00000024 <="
+	if strings.Count(generated, assignment) != 1 {
+		t.Fatalf("global delayed register assignment count = %d, want 1", strings.Count(generated, assignment))
+	}
+}
+
+func TestValidateBehaviorRuleOwnershipRejectsClassOwnedInitialRegister(t *testing.T) {
+	set := &behavior.RuleSet{
+		Version: behavior.RuleSchemaVersion, BARSize: 0x1000,
+		ClockHz: 100_000_000, InitialState: "idle",
+		InitialRegisters: []behavior.RegisterValue{{
+			Offset: 0x24, Width: 4, Value: 1,
+		}},
+	}
+	if err := ValidateBehaviorRuleOwnership(set, "audio"); err == nil {
+		t.Fatal("audio-owned register seed should be rejected")
+	}
+}
+
+func TestCompileAndGenerateSameRegisterUpdateUsesTriggerWriteAsBase(t *testing.T) {
+	set := &behavior.RuleSet{
+		Version: behavior.RuleSchemaVersion, BARSize: 0x1000,
+		ClockHz: 100_000_000, InitialState: "idle",
+		Rules: []behavior.Rule{{
+			ID: "compose-self", State: "idle", Access: behavior.AccessWrite, Width: 4,
+			Offset: 0x20, Value: 0x12345678, ValueMask: math.MaxUint32,
+			Updates: []behavior.RegisterUpdate{{
+				Offset: 0x20, Width: 4, Value: 0x0000ab00, Mask: 0x0000ff00,
+			}},
+			Confidence: 1, Provenance: []string{"test"},
+		}},
+	}
+	model := &barmodel.BARModel{
+		Size: 0x1000,
+		Registers: []barmodel.BARRegister{{
+			Offset: 0x20, Width: 4, RWMask: math.MaxUint32, Name: "CONTROL",
+		}},
+	}
+	compiled, err := CompileBehaviorRules(set, model)
+	if err != nil {
+		t.Fatalf("CompileBehaviorRules: %v", err)
+	}
+	if len(compiled.Rules) != 1 || len(compiled.Rules[0].Updates) != 1 ||
+		!compiled.Rules[0].Updates[0].ComposeTriggerWrite {
+		t.Fatalf("compiled same-register update = %+v", compiled.Rules)
+	}
+	cfg := testConfig()
+	cfg.DeviceClass = ""
+	cfg.ClassCode = 0xff0000
+	cfg.BARModel = model
+	cfg.BehaviorRules = set
+	generated, err := GenerateBarImplDeviceSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarImplDeviceSV: %v", err)
+	}
+	if !strings.Contains(generated, "wr_data & ~32'h0000FF00") {
+		t.Fatal("generated same-register update does not compose from trigger write data")
+	}
+}
+
+func TestWritePolicyCompositionMatchesEngineCompilerAndRTL(t *testing.T) {
+	set := &behavior.RuleSet{
+		Version: behavior.RuleSchemaVersion, BARSize: 0x1000,
+		ClockHz: 100_000_000, InitialState: "idle",
+		InitialRegisters: []behavior.RegisterValue{{
+			Offset: 0x20, Width: 4, Value: 0xa5f0cc33,
+			WritePolicy: &behavior.RegisterWritePolicy{RWMask: 0x0000000f, W1CMask: 0x000000f0},
+		}},
+		Rules: []behavior.Rule{{
+			ID: "compose-policy", State: "idle", Access: behavior.AccessWrite, Width: 4,
+			Offset: 0x20, Value: 0x123456a5, ValueMask: math.MaxUint32,
+			Updates: []behavior.RegisterUpdate{{
+				Offset: 0x20, Width: 4, Value: 0x00005a00, Mask: 0x0000ff00,
+			}},
+			Confidence: 1, Provenance: []string{"test"},
+		}},
+	}
+	model := &barmodel.BARModel{
+		Size: 0x1000,
+		Registers: []barmodel.BARRegister{{
+			Offset: 0x20, Width: 4, Reset: 0xa5f0cc33, RWMask: 0x0000000f,
+			W1CMask: 0x000000f0, Name: "CONTROL",
+		}},
+	}
+	compiled, err := CompileBehaviorRules(set, model)
+	if err != nil {
+		t.Fatalf("CompileBehaviorRules: %v", err)
+	}
+	update := compiled.Rules[0].Updates[0]
+	if !update.ComposeTriggerWrite || update.TriggerRWMask != 0x0000000f ||
+		update.TriggerW1CMask != 0x000000f0 {
+		t.Fatalf("compiled write policy = %+v", update)
+	}
+	cfg := testConfig()
+	cfg.DeviceClass = ""
+	cfg.ClassCode = 0xff0000
+	cfg.BARModel = model
+	cfg.BehaviorRules = set
+	generated, err := GenerateBarImplDeviceSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarImplDeviceSV: %v", err)
+	}
+	if !strings.Contains(generated, "behavior_wr_be_mask") ||
+		!strings.Contains(generated, "32'h0000000F") ||
+		!strings.Contains(generated, "32'h000000F0") {
+		t.Fatal("generated RTL does not apply canonical RW/W1C write policy before rule overlay")
+	}
+}
+
+func TestCompileAndGenerateDueValuesMaskEachContribution(t *testing.T) {
+	set := &behavior.RuleSet{
+		Version: behavior.RuleSchemaVersion, BARSize: 0x1000,
+		ClockHz: 100_000_000, InitialState: "idle",
+		InitialRegisters: []behavior.RegisterValue{{Offset: 0x24, Width: 4, Value: 3}},
+		Rules: []behavior.Rule{
+			{
+				ID: "clear-bit0", State: "idle", Access: behavior.AccessWrite, Width: 4,
+				Offset: 0x20, Value: 1, ValueMask: math.MaxUint32,
+				DelayedEvents: []behavior.DelayedEvent{{
+					DelayCycles: 5,
+					Updates: []behavior.RegisterUpdate{{Offset: 0x24, Width: 4, Value: 2, Mask: 1}},
+				}},
+				Confidence: 1, Provenance: []string{"test"},
+			},
+			{
+				ID: "clear-bit1", State: "idle", Access: behavior.AccessWrite, Width: 4,
+				Offset: 0x28, Value: 1, ValueMask: math.MaxUint32,
+				DelayedEvents: []behavior.DelayedEvent{{
+					DelayCycles: 4,
+					Updates: []behavior.RegisterUpdate{{Offset: 0x24, Width: 4, Value: 0, Mask: 2}},
+				}},
+				Confidence: 1, Provenance: []string{"test"},
+			},
+		},
+	}
+	model := &barmodel.BARModel{
+		Size: 0x1000,
+		Registers: []barmodel.BARRegister{{
+			Offset: 0x24, Width: 4, Reset: 3, Name: "STATUS",
+		}},
+	}
+	compiled, err := CompileBehaviorRules(set, model)
+	if err != nil {
+		t.Fatalf("CompileBehaviorRules: %v", err)
+	}
+	if len(compiled.DueRegisters) != 1 || len(compiled.DueRegisters[0].Contributions) != 2 {
+		t.Fatalf("compiled contributions = %+v", compiled.DueRegisters)
+	}
+	for _, contribution := range compiled.DueRegisters[0].Contributions {
+		if contribution.Value != 0 {
+			t.Fatalf("compiled contribution leaked value outside mask: %+v", contribution)
+		}
+	}
+	cfg := testConfig()
+	cfg.DeviceClass = ""
+	cfg.ClassCode = 0xff0000
+	cfg.BARModel = model
+	cfg.BehaviorRules = set
+	generated, err := GenerateBarImplDeviceSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarImplDeviceSV: %v", err)
+	}
+	for _, term := range []string{
+		"({32{rule_event_due_0}} & 32'h00000000)",
+		"({32{rule_event_due_1}} & 32'h00000000)",
+	} {
+		if !strings.Contains(generated, term) {
+			t.Fatalf("generated due value is not contribution-masked: missing %q", term)
+		}
+	}
+}

--- a/internal/firmware/svgen/behavior_rules_test.go
+++ b/internal/firmware/svgen/behavior_rules_test.go
@@ -1,0 +1,66 @@
+package svgen
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/behavior"
+)
+
+func generatedRuleSet(updateValue uint64) *behavior.RuleSet {
+	return &behavior.RuleSet{
+		Version:      behavior.RuleSchemaVersion,
+		BARIndex:     0,
+		BARSize:      0x1000,
+		ClockHz:      100_000_000,
+		InitialState: "idle",
+		Rules: []behavior.Rule{{
+			ID: "enable-ready", State: "idle", Access: behavior.AccessKind("write"),
+			Width: 4, Offset: 0x20, Value: 1, ValueMask: math.MaxUint32,
+			NextState: "waiting",
+			DelayedEvents: []behavior.DelayedEvent{{
+				DelayCycles: 9,
+				Updates: []behavior.RegisterUpdate{{Offset: 0x24, Width: 4, Value: updateValue, Mask: math.MaxUint32}},
+				NextState: "ready",
+			}},
+			Confidence: 1, Provenance: []string{"test fixture"},
+		}},
+	}
+}
+
+func TestGenerateBarImplDeviceSV_RuleChangesAlterGeneratedFSM(t *testing.T) {
+	readyLow := testConfig()
+	readyLow.BehaviorRules = generatedRuleSet(1)
+	lowSV, err := GenerateBarImplDeviceSV(readyLow)
+	if err != nil {
+		t.Fatalf("GenerateBarImplDeviceSV ready-low rule: %v", err)
+	}
+
+	readyHigh := testConfig()
+	readyHigh.BehaviorRules = generatedRuleSet(2)
+	highSV, err := GenerateBarImplDeviceSV(readyHigh)
+	if err != nil {
+		t.Fatalf("GenerateBarImplDeviceSV ready-high rule: %v", err)
+	}
+	if bytes.Equal([]byte(lowSV), []byte(highSV)) {
+		t.Fatal("changing a learned register update did not alter generated RTL")
+	}
+
+	highSVAgain, err := GenerateBarImplDeviceSV(readyHigh)
+	if err != nil {
+		t.Fatalf("GenerateBarImplDeviceSV repeated: %v", err)
+	}
+	if highSV != highSVAgain {
+		t.Fatal("same learned rules generated nondeterministic RTL")
+	}
+}
+
+func TestGenerateBarImplDeviceSV_RejectsUnsupportedRuleWidth(t *testing.T) {
+	cfg := testConfig()
+	cfg.BehaviorRules = generatedRuleSet(1)
+	cfg.BehaviorRules.Rules[0].Width = 8
+	if _, err := GenerateBarImplDeviceSV(cfg); err == nil {
+		t.Fatal("expected explicitly unsupported 8-byte RTL trigger to fail generation")
+	}
+}

--- a/internal/firmware/svgen/generator.go
+++ b/internal/firmware/svgen/generator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sercanarga/pcileechgen/internal/board"
 	"github.com/sercanarga/pcileechgen/internal/firmware"
+	"github.com/sercanarga/pcileechgen/internal/donor/behavior"
 	"github.com/sercanarga/pcileechgen/internal/firmware/barmodel"
 	"github.com/sercanarga/pcileechgen/internal/firmware/nvme"
 )
@@ -38,6 +39,8 @@ type SVGeneratorConfig struct {
 	NVMeDiskWords      int                // NVMe disk-cache depth (words), board-scaled
 	NVMeAdvertisedLBAs uint64             // actual NSZE from donor (0 = use default 2000409264)
 	Bar0Size           int
+	BehaviorRules      *behavior.RuleSet
+	CompiledBehavior   *CompiledBehavior
 }
 
 // NVMeDiskWordsForBRAM36 returns the NVMe disk-cache depth in 32-bit words for
@@ -141,7 +144,11 @@ func renderTemplateDelim(name, leftDelim, rightDelim string, data any) (string, 
 }
 
 func GenerateBarImplDeviceSV(cfg *SVGeneratorConfig) (string, error) {
-	return renderTemplate("bar_impl_device", cfg)
+	prepared, err := prepareBehaviorConfig(cfg)
+	if err != nil {
+		return "", err
+	}
+	return renderTemplate("bar_impl_device", prepared)
 }
 
 func GenerateBarControllerSV(cfg *SVGeneratorConfig) (string, error) {

--- a/internal/firmware/svgen/templates/bar_impl_device.sv.tmpl
+++ b/internal/firmware/svgen/templates/bar_impl_device.sv.tmpl
@@ -60,6 +60,73 @@ module pcileech_bar_impl_device #(
 {{ range .BARModel.Registers }}
     reg [{{ sub (mul .Width 8) 1 }}:0] reg_0x{{ hex08 .Offset }};  // {{ .Name }}
 {{ end }}
+{{ if .CompiledBehavior }}
+    reg [{{ sub .CompiledBehavior.StateBits 1 }}:0] behavior_state;
+    wire [31:0] behavior_wr_be_mask = {wr_be[3], wr_be[3], wr_be[3], wr_be[3], wr_be[3], wr_be[3], wr_be[3], wr_be[3], wr_be[2], wr_be[2], wr_be[2], wr_be[2], wr_be[2], wr_be[2], wr_be[2], wr_be[2], wr_be[1], wr_be[1], wr_be[1], wr_be[1], wr_be[1], wr_be[1], wr_be[1], wr_be[1], wr_be[0], wr_be[0], wr_be[0], wr_be[0], wr_be[0], wr_be[0], wr_be[0], wr_be[0]};
+{{ range .CompiledBehavior.Rules }}{{ range .DelayedEvents }}
+    reg rule_delay_pending_{{ .Index }};
+    reg [19:0] rule_delay_counter_{{ .Index }};
+{{ end }}{{ end }}
+{{ range .CompiledBehavior.AllEvents }}    wire rule_event_due_{{ .Index }} = rule_delay_pending_{{ .Index }} &&
+        ((rule_delay_counter_{{ .Index }} + 1'b1) >= 20'd{{ .DelayCycles }});
+{{ end }}    wire behavior_event_due = 1'b0{{ range .CompiledBehavior.AllEvents }} || rule_event_due_{{ .Index }}{{ end }};
+{{ range .CompiledBehavior.DueRegisters }}    wire [31:0] behavior_due_mask_{{ hex08 .Offset }} = 32'h00000000{{ range .Contributions }} |
+        ({32{rule_event_due_{{ .EventIndex }}}} & 32'h{{ hex08 .Mask }}){{ end }};
+    wire [31:0] behavior_due_value_{{ hex08 .Offset }} = 32'h00000000{{ range .Contributions }} |
+        ({32{rule_event_due_{{ .EventIndex }}}} & 32'h{{ hex08 .Value }}){{ end }};
+{{ end }}
+
+    always @(posedge clk) begin
+        if (rst) begin
+            behavior_state <= {{ .CompiledBehavior.StateBits }}'d{{ .CompiledBehavior.InitialState }};
+{{ range .CompiledBehavior.Registers }}            reg_0x{{ hex08 .Offset }} <= 32'h{{ hex08 .Reset }};
+{{ end }}{{ range .CompiledBehavior.Rules }}{{ range .DelayedEvents }}            rule_delay_pending_{{ .Index }} <= 1'b0;
+            rule_delay_counter_{{ .Index }} <= 20'd0;
+{{ end }}{{ end }}        end else begin
+            if (wr_valid) begin
+                case (wr_offset & 32'hFFFFFFFC)
+{{ range .CompiledBehavior.Registers }}{{ if or (ne .RWMask 0) (ne .W1CMask 0) }}                    32'h{{ hex08 .Offset }}: begin
+                        if (wr_be[0]) reg_0x{{ hex08 .Offset }}[7:0]   <= ((reg_0x{{ hex08 .Offset }}[7:0]   & ~(8'h{{ hex02 (index (rwMaskBytes .RWMask) 0) }} | 8'h{{ hex02 (index (w1cMaskBytes .W1CMask) 0) }})) | (wr_data[7:0]   & 8'h{{ hex02 (index (rwMaskBytes .RWMask) 0) }}) | (reg_0x{{ hex08 .Offset }}[7:0]   & ~wr_data[7:0]   & 8'h{{ hex02 (index (w1cMaskBytes .W1CMask) 0) }}));
+                        if (wr_be[1]) reg_0x{{ hex08 .Offset }}[15:8]  <= ((reg_0x{{ hex08 .Offset }}[15:8]  & ~(8'h{{ hex02 (index (rwMaskBytes .RWMask) 1) }} | 8'h{{ hex02 (index (w1cMaskBytes .W1CMask) 1) }})) | (wr_data[15:8]  & 8'h{{ hex02 (index (rwMaskBytes .RWMask) 1) }}) | (reg_0x{{ hex08 .Offset }}[15:8]  & ~wr_data[15:8]  & 8'h{{ hex02 (index (w1cMaskBytes .W1CMask) 1) }}));
+                        if (wr_be[2]) reg_0x{{ hex08 .Offset }}[23:16] <= ((reg_0x{{ hex08 .Offset }}[23:16] & ~(8'h{{ hex02 (index (rwMaskBytes .RWMask) 2) }} | 8'h{{ hex02 (index (w1cMaskBytes .W1CMask) 2) }})) | (wr_data[23:16] & 8'h{{ hex02 (index (rwMaskBytes .RWMask) 2) }}) | (reg_0x{{ hex08 .Offset }}[23:16] & ~wr_data[23:16] & 8'h{{ hex02 (index (w1cMaskBytes .W1CMask) 2) }}));
+                        if (wr_be[3]) reg_0x{{ hex08 .Offset }}[31:24] <= ((reg_0x{{ hex08 .Offset }}[31:24] & ~(8'h{{ hex02 (index (rwMaskBytes .RWMask) 3) }} | 8'h{{ hex02 (index (w1cMaskBytes .W1CMask) 3) }})) | (wr_data[31:24] & 8'h{{ hex02 (index (rwMaskBytes .RWMask) 3) }}) | (reg_0x{{ hex08 .Offset }}[31:24] & ~wr_data[31:24] & 8'h{{ hex02 (index (w1cMaskBytes .W1CMask) 3) }}));
+                    end
+{{ end }}{{ end }}                    default: begin end
+                endcase
+            end
+{{ range .CompiledBehavior.DueRegisters }}            if (behavior_due_mask_{{ hex08 .Offset }} != 32'h00000000) reg_0x{{ hex08 .Offset }} <=
+                (reg_0x{{ hex08 .Offset }} & ~behavior_due_mask_{{ hex08 .Offset }}) |
+                (behavior_due_value_{{ hex08 .Offset }} & behavior_due_mask_{{ hex08 .Offset }});
+{{ end }}
+{{ range .CompiledBehavior.Rules }}{{ range .DelayedEvents }}            if (rule_delay_pending_{{ .Index }}) begin
+                if ((rule_delay_counter_{{ .Index }} + 1'b1) >= 20'd{{ .DelayCycles }}) begin
+{{ if ge .NextState 0 }}                    behavior_state <= {{ $.CompiledBehavior.StateBits }}'d{{ .NextState }};
+{{ end }}                    rule_delay_pending_{{ .Index }} <= 1'b0;
+                end else begin
+                    rule_delay_counter_{{ .Index }} <= rule_delay_counter_{{ .Index }} + 1'b1;
+                end
+            end
+{{ end }}{{ end }}{{ range .CompiledBehavior.Rules }}            if (!behavior_event_due &&
+                behavior_state == {{ $.CompiledBehavior.StateBits }}'d{{ .State }} &&
+                wr_valid && ((wr_offset & 32'hFFFFFFFC) == 32'h{{ hex08 .Offset }}) &&
+                ((wr_be & 4'h{{ hex02 .ByteEnableMask }}) == 4'h{{ hex02 .ByteEnableMask }}) &&
+                (((wr_data ^ 32'h{{ hex08 .Value }}) & 32'h{{ hex08 .ValueMask }}) == 32'h00000000)) begin
+{{ range .Updates }}{{ if .ComposeTriggerWrite }}{{ if and (eq .TriggerRWMask 0xFFFFFFFF) (eq .TriggerW1CMask 0) }}                reg_0x{{ hex08 .Offset }} <= (wr_data & ~32'h{{ hex08 .Mask }}) | (32'h{{ hex08 .Value }} & 32'h{{ hex08 .Mask }});
+{{ else }}                reg_0x{{ hex08 .Offset }} <= (((reg_0x{{ hex08 .Offset }} & ~(32'h{{ hex08 .TriggerRWMask }} & behavior_wr_be_mask)) |
+                    (wr_data & 32'h{{ hex08 .TriggerRWMask }} & behavior_wr_be_mask)) &
+                    ~(wr_data & 32'h{{ hex08 .TriggerW1CMask }} & behavior_wr_be_mask) &
+                    ~32'h{{ hex08 .Mask }}) | (32'h{{ hex08 .Value }} & 32'h{{ hex08 .Mask }});
+{{ end }}
+{{ else }}                reg_0x{{ hex08 .Offset }} <= (reg_0x{{ hex08 .Offset }} & ~32'h{{ hex08 .Mask }}) | (32'h{{ hex08 .Value }} & 32'h{{ hex08 .Mask }});
+{{ end }}{{ end }}                behavior_state <= {{ $.CompiledBehavior.StateBits }}'d{{ .NextState }};
+{{ range .DelayedEvents }}                if (!rule_delay_pending_{{ .Index }}) begin
+                    rule_delay_pending_{{ .Index }} <= 1'b1;
+                    rule_delay_counter_{{ .Index }} <= 20'd0;
+                end
+{{ end }}            end
+{{ end }}        end
+    end
+{{ end }}
 {{ if eq .DeviceClass "nvme" }}
     // ========================================================================
     // NVMe CC -> CSTS State Machine


### PR DESCRIPTION
## Summary

Turns MMIO traces into versioned, validated, replayable behavior rules and compiles the supported subset into deterministic BAR RTL.

- canonical target-aware MMIO trace schema with BDF, BIR, physical address, BAR-relative offset, width, value, timestamp, and provenance
- strict overflow-safe aperture validation plus legacy trace compatibility without erasing explicit metadata conflicts
- conservative session-local behavior inference with bounded confidence and no inferred destructive actions
- pure software Engine/Replay oracle using logical cycles, reset seeds, write policy, delayed events, and held-out mismatch reporting
- CLI support for `mmio-trace --rules-output` and `build --behavior-rules`
- DeviceContext persistence and output integration
- generated generic BAR FSM for 32-bit aligned trigger/update rules, bounded delays, polling reads, RW/W1C policy, and class-FSM ownership checks

## Correctness details

- inferred rules never invent ordering between unrelated capture/reset sessions
- canonical traces require exact BIR identity; legacy omission is distinguished from explicit BAR0
- nanosecond-to-cycle conversion uses overflow-safe quotient/remainder arithmetic
- live capture preserves kernel mmiotrace timestamp deltas and returns on quiet-capture deadlines
- software and RTL use the same first-pending delayed-event coalescing semantics
- simultaneous due events compose once per register in deterministic order; contradictions are rejected
- trigger writes apply byte enables plus RW/W1C/RO semantics before the rule overlay
- every update value is masked by its own mask, preventing cross-rule bit leakage
- class-owned initial seeds, triggers, and updates are all rejected consistently

## Verification

- `go test -race -count=1 ./...` under Ubuntu WSL2
- generated behavior RTL linted with Verilator, including partial RW/W1C/RO trigger composition and simultaneous-event cases
- regressions for canonical/legacy BIR, huge timestamps, kernel timing, quiet capture, session boundaries, retrigger coalescing, event collisions, reset seed parity, and class ownership
- independent behavioral review followed by repeated targeted closure passes
- zero comments added

## Scope and claims

This is deliberately a bounded observed-behavior system, not a claim of arbitrary donor equivalence. Unsupported widths/unaligned rules are filtered or rejected, unknown inputs use an explicit safe-ignore policy, and single-session inference confidence is capped.

External review used QEMU deterministic device-model guidance, libvfio-user lifecycle/DMA contracts, and published Pretender/P2IM-style peripheral-model research. Inaccessible PCI-SIG text was not guessed.