### PR TITLE
feat: preserve donor BAR topology and BIR routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install Tcl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tcl
+
       - name: Run tests
         run: go test -race ./...
 

--- a/internal/firmware/barmodel/model.go
+++ b/internal/firmware/barmodel/model.go
@@ -4,9 +4,11 @@ package barmodel
 import (
 	"fmt"
 	"log/slog"
+	"sort"
 
 	"github.com/sercanarga/pcileechgen/internal/donor"
 	"github.com/sercanarga/pcileechgen/internal/firmware/devclass"
+	"github.com/sercanarga/pcileechgen/internal/pci"
 	"github.com/sercanarga/pcileechgen/internal/util"
 )
 
@@ -24,8 +26,130 @@ type BARRegister struct {
 
 // BARModel is the complete register map that ends up in the SV template.
 type BARModel struct {
-	Size      int
+	BIR           int
+	Size          int
+	Aperture      uint64
+	Type          string
+	Prefetchable  bool
+	Is64Bit       bool
+	UpperBIR      int
+	ClassSpecific bool
 	Registers []BARRegister // ordered by Offset
+}
+
+func BuildBARModels(
+	bars []pci.BAR,
+	contents map[int][]byte,
+	profiles map[int]*donor.BARProfile,
+	classCode uint32,
+	preferredBIR int,
+) ([]*BARModel, error) {
+	byBIR := make(map[int]pci.BAR, len(bars))
+	for _, bar := range bars {
+		if bar.Index >= 0 && bar.Index < 6 {
+			byBIR[bar.Index] = bar
+		}
+	}
+
+	for bir, data := range contents {
+		if bir < 0 || bir >= 6 {
+			continue
+		}
+		if _, ok := byBIR[bir]; !ok && len(data) > 0 {
+			byBIR[bir] = pci.BAR{Index: bir, Size: uint64(len(data)), Type: pci.BARTypeMem32}
+		}
+	}
+	for bir, profile := range profiles {
+		if bir < 0 || bir >= 6 || profile == nil {
+			continue
+		}
+		if _, ok := byBIR[bir]; !ok && profile.Size > 0 {
+			byBIR[bir] = pci.BAR{Index: bir, Size: uint64(profile.Size), Type: pci.BARTypeMem32}
+		}
+	}
+
+	birs := make([]int, 0, len(byBIR))
+	for bir := range byBIR {
+		birs = append(birs, bir)
+	}
+	sort.Ints(birs)
+
+	models := make([]*BARModel, 0, len(birs))
+	consumed := make(map[int]bool)
+	for _, bir := range birs {
+		if consumed[bir] {
+			continue
+		}
+		bar := byBIR[bir]
+		legacyMemory := bar.Type == "" && (bar.Size > 0 || len(contents[bir]) > 0 || profiles[bir] != nil)
+		if (!bar.IsMemory() && !legacyMemory) || bar.Size == 0 && len(contents[bir]) == 0 &&
+			(profiles[bir] == nil || profiles[bir].Size == 0) {
+			continue
+		}
+
+		if bar.Is64Bit || bar.Type == pci.BARTypeMem64 {
+			if bir == 5 {
+				return nil, fmt.Errorf("64-bit BAR5 has no upper BIR")
+			}
+			upper := byBIR[bir+1]
+			upperPresent := upper.Size > 0 && !upper.IsDisabled()
+			if upperPresent || len(contents[bir+1]) > 0 ||
+				profiles[bir+1] != nil && profiles[bir+1].Size > 0 {
+				return nil, fmt.Errorf("64-bit BAR%d consumes occupied BAR%d", bir, bir+1)
+			}
+		}
+		upperBIR := -1
+		if bar.Is64Bit || bar.Type == pci.BARTypeMem64 {
+			upperBIR = bir + 1
+			if upperBIR < 6 {
+				consumed[upperBIR] = true
+			}
+		}
+
+		data := contents[bir]
+		profile := profiles[bir]
+		var model *BARModel
+		classSpecific := bir == preferredBIR
+		if classSpecific {
+			model = BuildBARModel(data, classCode, profile)
+		} else if profile != nil && len(profile.Probes) > 0 && isProbeDataReliable(profile) {
+			model = SynthesizeBARModel(profile, 0)
+		}
+		if model == nil {
+			model = &BARModel{}
+		}
+
+		aperture := bar.Size
+		if uint64(len(data)) > aperture {
+			aperture = uint64(len(data))
+		}
+		if profile != nil && uint64(profile.Size) > aperture {
+			aperture = uint64(profile.Size)
+		}
+		model.BIR = bir
+		model.Aperture = aperture
+		model.Size = int(aperture)
+		model.Type = bar.Type
+		if model.Type == "" {
+			model.Type = pci.BARTypeMem32
+		}
+		model.Prefetchable = bar.Prefetchable
+		model.Is64Bit = bar.Is64Bit || bar.Type == pci.BARTypeMem64
+		model.UpperBIR = upperBIR
+		model.ClassSpecific = classSpecific && len(model.Registers) > 0
+		validateModel(model)
+		models = append(models, model)
+	}
+	return models, nil
+}
+
+func ModelForBIR(models []*BARModel, bir int) *BARModel {
+	for _, model := range models {
+		if model != nil && model.BIR == bir {
+			return model
+		}
+	}
+	return nil
 }
 
 // BuildBARModel returns a register map from probe data or spec tables.
@@ -68,7 +192,26 @@ func specBARModelForClass(classCode uint32, barData []byte) *BARModel {
 	case baseClass == 0x04 && subClass == 0x03:
 		return buildAudioBARModel(barData)
 	}
-	return nil
+
+	profile := devclass.ProfileForClass(classCode)
+	if profile == nil || len(profile.BARDefaults) == 0 {
+		return nil
+	}
+	regs := make([]BARRegister, 0, len(profile.BARDefaults))
+	for _, d := range profile.BARDefaults {
+		regs = append(regs, BARRegister{
+			Offset:      d.Offset,
+			Width:       d.Width,
+			Reset:       d.Reset,
+			RWMask:      d.RWMask,
+			W1CMask:     d.W1CMask,
+			Name:        d.Name,
+			IsRW1C:      d.IsRW1C,
+			IsFSMDriven: d.IsFSMDriven,
+		})
+	}
+	populateResetValues(regs, barData)
+	return &BARModel{Size: len(barData), Registers: regs}
 }
 
 // specRegAttr carries the W1CMask and IsFSMDriven flags the spec assigns to a
@@ -101,7 +244,7 @@ func specRegisterAttrs(classCode uint32) map[uint32]specRegAttr {
 func validateModel(m *BARModel) {
 	seen := make(map[uint32]string, len(m.Registers))
 	for _, r := range m.Registers {
-		if int(r.Offset) >= m.Size {
+		if m.Size > 0 && int(r.Offset) >= m.Size {
 			slog.Warn("barmodel: register offset beyond BAR size",
 				"reg", r.Name, "offset", fmt.Sprintf("0x%X", r.Offset), "bar_size", m.Size)
 		}

--- a/internal/firmware/barmodel/multibar_test.go
+++ b/internal/firmware/barmodel/multibar_test.go
@@ -1,0 +1,213 @@
+package barmodel
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func TestBuildBARModelsPreservesDonorBIRsAndBuildsEveryMemoryBAR(t *testing.T) {
+	bars := []pci.BAR{
+		{Index: 0, Size: 0x1000, Type: pci.BARTypeMem32},
+		{Index: 2, Size: 0x2000, Type: pci.BARTypeMem32, Prefetchable: true},
+		{Index: 5, Size: 0x4000, Type: pci.BARTypeMem32},
+	}
+	contents := map[int][]byte{
+		0: make([]byte, 0x1000),
+		2: make([]byte, 0x2000),
+		5: make([]byte, 0x4000),
+	}
+
+	models := mustBuildBARModels(t, bars, contents, nil, 0xFF0000, 2)
+	if len(models) != 3 {
+		t.Fatalf("BuildBARModels returned %d models, want one for each of 3 donor memory BARs", len(models))
+	}
+
+	for i, want := range []struct {
+		bir          int
+		size         int
+		prefetchable bool
+	}{{0, 0x1000, false}, {2, 0x2000, true}, {5, 0x4000, false}} {
+		got := models[i]
+		if got.BIR != want.bir {
+			t.Errorf("models[%d].BIR = %d, want donor BIR %d (models must be BIR ordered)", i, got.BIR, want.bir)
+		}
+		if got.Size != want.size {
+			t.Errorf("BAR%d size = 0x%X, want donor aperture 0x%X", want.bir, got.Size, want.size)
+		}
+		if got.Type != pci.BARTypeMem32 {
+			t.Errorf("BAR%d type = %q, want %q", want.bir, got.Type, pci.BARTypeMem32)
+		}
+		if got.Prefetchable != want.prefetchable {
+			t.Errorf("BAR%d Prefetchable = %v, want %v", want.bir, got.Prefetchable, want.prefetchable)
+		}
+	}
+}
+
+func TestBuildBARModelsUsesPreferredClassBARNotLargestBAR(t *testing.T) {
+	bars := []pci.BAR{
+		{Index: 0, Size: 0x4000, Type: pci.BARTypeMem32},
+		{Index: 2, Size: 0x1000, Type: pci.BARTypeMem32},
+	}
+	contents := map[int][]byte{
+		0: make([]byte, 0x4000),
+		2: make([]byte, 0x1000),
+	}
+	profiles := map[int]*donor.BARProfile{
+		0: {
+			BarIndex: 0,
+			Size:     0x4000,
+			Probes: []donor.BARProbeResult{
+				{Offset: 0x100, Original: 0x12345678, RWMask: 0x0000FFFF},
+			},
+		},
+	}
+
+	models := mustBuildBARModels(t, bars, contents, profiles, 0x020000, 2)
+	if len(models) != 2 {
+		t.Fatalf("BuildBARModels returned %d models, want 2", len(models))
+	}
+	byBIR := modelsByBIR(models)
+	if !byBIR[2].ClassSpecific {
+		t.Fatal("preferred BAR2 should be marked class-specific")
+	}
+	if byBIR[0].ClassSpecific {
+		t.Fatal("non-preferred BAR0 must not be marked class-specific")
+	}
+	if !modelHasRegister(byBIR[2], "MAC0_3") {
+		t.Fatal("Ethernet class register model was not assigned to preferred BAR2")
+	}
+	if modelHasRegister(byBIR[0], "MAC0_3") {
+		t.Fatal("Ethernet class register model incorrectly followed the largest BAR instead of preferred BAR2")
+	}
+	if !modelHasOffset(byBIR[0], 0x100) {
+		t.Fatal("non-preferred BAR0 should retain its donor probe-derived register model")
+	}
+}
+
+func TestBuildBARModelsAbsentPreferredBIRDoesNotMoveClassSemantics(t *testing.T) {
+	bars := []pci.BAR{
+		{Index: 0, Type: pci.BARTypeDisabled},
+		{Index: 1, Size: 0x100, Type: pci.BARTypeIO},
+		{Index: 3, Size: 0x2000, Type: pci.BARTypeMem32},
+		{Index: 5, Size: 0x1000, Type: pci.BARTypeMem32},
+	}
+	contents := map[int][]byte{3: make([]byte, 0x2000), 5: make([]byte, 0x1000)}
+
+	models := mustBuildBARModels(t, bars, contents, nil, 0x020000, 2)
+	if len(models) != 2 {
+		t.Fatalf("BuildBARModels returned %d models, want only BAR3 and BAR5", len(models))
+	}
+	if models[0].BIR != 3 || models[1].BIR != 5 {
+		t.Fatalf("model BIRs = [%d %d], want deterministic [3 5]", models[0].BIR, models[1].BIR)
+	}
+	for _, model := range models {
+		if model.ClassSpecific || modelHasRegister(model, "MAC0_3") {
+			t.Fatalf("absent preferred BAR2 must not move Ethernet class semantics onto BAR%d", model.BIR)
+		}
+	}
+}
+
+func TestBuildBARModelsSkipsUpperHalfOf64BitBARPair(t *testing.T) {
+	bars := []pci.BAR{
+		{Index: 0, Size: 0x2000, Type: pci.BARTypeMem64, Is64Bit: true},
+		{Index: 1, Type: pci.BARTypeDisabled},
+		{Index: 2, Size: 0x1000, Type: pci.BARTypeMem32},
+	}
+	contents := map[int][]byte{
+		0: make([]byte, 0x2000),
+		2: make([]byte, 0x1000),
+	}
+
+	models := mustBuildBARModels(t, bars, contents, nil, 0xFF0000, 0)
+	if len(models) != 2 {
+		t.Fatalf("BuildBARModels returned %d models, want BAR0 and BAR2 only", len(models))
+	}
+	if models[0].BIR != 0 || !models[0].Is64Bit {
+		t.Fatalf("first model = %+v, want 64-bit BAR0", models[0])
+	}
+	if models[1].BIR != 2 {
+		t.Fatalf("second model BIR = %d, want 2; BIR1 is consumed by 64-bit BAR0", models[1].BIR)
+	}
+}
+
+func TestBuildBARModelsNoPresentMemoryBARs(t *testing.T) {
+	bars := []pci.BAR{
+		{Index: 0, Type: pci.BARTypeDisabled},
+		{Index: 2, Size: 0x100, Type: pci.BARTypeIO},
+	}
+	contents := map[int][]byte{0: make([]byte, 0x1000), 2: make([]byte, 0x100)}
+
+	if models := mustBuildBARModels(t, bars, contents, nil, 0xFF0000, 0); len(models) != 0 {
+		t.Fatalf("BuildBARModels returned %+v, want no endpoints for disabled/I/O BARs", models)
+	}
+	if models := mustBuildBARModels(t, nil, nil, nil, 0xFF0000, 0); len(models) != 0 {
+		t.Fatalf("BuildBARModels with absent donor BARs returned %+v, want none", models)
+	}
+}
+
+func TestBuildBARModelsRejects64BitBARAtBIR5(t *testing.T) {
+	_, err := BuildBARModels(
+		[]pci.BAR{{Index: 5, Size: 0x1000, Type: pci.BARTypeMem64, Is64Bit: true}},
+		map[int][]byte{5: make([]byte, 0x1000)}, nil, 0xFF0000, 0,
+	)
+	if err == nil || !strings.Contains(err.Error(), "64-bit BAR5 has no upper BIR") {
+		t.Fatalf("BuildBARModels error = %v, want invalid 64-bit BAR5 rejection", err)
+	}
+}
+
+func TestBuildBARModelsRejectsOccupied64BitUpperBIR(t *testing.T) {
+	_, err := BuildBARModels(
+		[]pci.BAR{
+			{Index: 0, Size: 0x2000, Type: pci.BARTypeMem64, Is64Bit: true},
+			{Index: 1, Size: 0x1000, Type: pci.BARTypeMem32},
+		},
+		map[int][]byte{0: make([]byte, 0x2000), 1: make([]byte, 0x1000)}, nil, 0xFF0000, 0,
+	)
+	if err == nil || !strings.Contains(err.Error(), "64-bit BAR0 consumes occupied BAR1") {
+		t.Fatalf("BuildBARModels error = %v, want occupied upper BIR rejection", err)
+	}
+}
+
+func mustBuildBARModels(t *testing.T, bars []pci.BAR, contents map[int][]byte, profiles map[int]*donor.BARProfile, classCode uint32, preferredBIR int) []*BARModel {
+	t.Helper()
+	models, err := BuildBARModels(bars, contents, profiles, classCode, preferredBIR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return models
+}
+
+func modelsByBIR(models []*BARModel) map[int]*BARModel {
+	out := make(map[int]*BARModel, len(models))
+	for _, model := range models {
+		out[model.BIR] = model
+	}
+	return out
+}
+
+func modelHasRegister(model *BARModel, name string) bool {
+	if model == nil {
+		return false
+	}
+	for _, reg := range model.Registers {
+		if reg.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func modelHasOffset(model *BARModel, offset uint32) bool {
+	if model == nil {
+		return false
+	}
+	for _, reg := range model.Registers {
+		if reg.Offset == offset {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/firmware/output/multibar_test.go
+++ b/internal/firmware/output/multibar_test.go
@@ -1,0 +1,379 @@
+package output
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/board"
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/firmware"
+	"github.com/sercanarga/pcileechgen/internal/firmware/barmodel"
+	"github.com/sercanarga/pcileechgen/internal/firmware/svgen"
+	"github.com/sercanarga/pcileechgen/internal/firmware/tclgen"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func TestBuildSVConfigPreservesAllDonorBARModelsAndPreferredBIR(t *testing.T) {
+	ctx := makeDonorContext(0x10EC, 0x8125, 0x020000)
+	ctx.BARs = []pci.BAR{
+		{Index: 0, Size: 0x4000, Type: pci.BARTypeMem32},
+		{Index: 2, Size: 0x1000, Type: pci.BARTypeMem64, Is64Bit: true},
+		{Index: 4, Size: 0x2000, Type: pci.BARTypeMem32, Prefetchable: true},
+	}
+	ctx.BARContents = map[int][]byte{
+		0: make([]byte, 0x4000),
+		2: make([]byte, 0x1000),
+		4: make([]byte, 0x2000),
+	}
+	ow := NewOutputWriter(t.TempDir(), "", 0, 0)
+	ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, nil)
+
+	cfg, err := ow.buildSVConfig(ctx, ctx.ConfigSpace.Clone(), ids, 0x1234, &board.Board{BRAMSize: 0x10000})
+	if err != nil {
+		t.Fatalf("buildSVConfig: %v", err)
+	}
+	if len(cfg.BARModels) != 3 {
+		t.Fatalf("BARModels count = %d, want BAR0, BAR2, and BAR4", len(cfg.BARModels))
+	}
+	for i, wantBIR := range []int{0, 2, 4} {
+		if cfg.BARModels[i].BIR != wantBIR {
+			t.Errorf("BARModels[%d].BIR = %d, want %d", i, cfg.BARModels[i].BIR, wantBIR)
+		}
+	}
+	if cfg.BARModel == nil || cfg.BARModel.BIR != 2 {
+		t.Fatalf("legacy primary BARModel = %+v, want class-preferred Ethernet BAR2", cfg.BARModel)
+	}
+	if !cfg.BARModel.ClassSpecific {
+		t.Fatal("preferred Ethernet BAR2 should own class-specific behavior")
+	}
+	if cfg.MSIXConfig != nil || cfg.HasMSIX {
+		t.Fatalf("device without an MSI-X capability acquired MSI-X endpoint: config=%+v HasMSIX=%v", cfg.MSIXConfig, cfg.HasMSIX)
+	}
+}
+
+func TestBuildSVConfigRejectsOccupied64BitUpperBIR(t *testing.T) {
+	ctx := makeDonorContext(0x10EC, 0x8125, 0x020000)
+	ctx.BARs = []pci.BAR{
+		{Index: 2, Size: 0x1000, Type: pci.BARTypeMem64, Is64Bit: true},
+		{Index: 3, Size: 0x1000, Type: pci.BARTypeMem32},
+	}
+	ctx.BARContents = map[int][]byte{2: make([]byte, 0x1000), 3: make([]byte, 0x1000)}
+	ow := NewOutputWriter(t.TempDir(), "", 0, 0)
+	ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, nil)
+
+	_, err := ow.buildSVConfig(ctx, ctx.ConfigSpace.Clone(), ids, 0x1234, &board.Board{BRAMSize: 0x10000})
+	if err == nil || !strings.Contains(err.Error(), "64-bit BAR2 consumes occupied BAR3") {
+		t.Fatalf("buildSVConfig error = %v, want occupied upper BAR3 rejection", err)
+	}
+}
+
+func TestBuildSVConfigPreservesMSIXBIRsAndOffsets(t *testing.T) {
+	cs := configSpaceWithMSIX(0x1234, 0x5678, 0xFF0000, 2, 0x400, 4, 0x800, 4)
+	ctx := &donor.DeviceContext{
+		Device:      pci.PCIDevice{VendorID: 0x1234, DeviceID: 0x5678, ClassCode: 0xFF0000},
+		ConfigSpace: cs,
+		BARs: []pci.BAR{
+			{Index: 2, Size: 0x2000, Type: pci.BARTypeMem32},
+			{Index: 4, Size: 0x1000, Type: pci.BARTypeMem32},
+		},
+		BARContents: map[int][]byte{
+			2: make([]byte, 0x2000),
+			4: make([]byte, 0x1000),
+		},
+		MSIXData: &donor.MSIXData{
+			TableSize: 4, TableBIR: 2, TableOffset: 0x400,
+			PBABIR: 4, PBAOffset: 0x800,
+		},
+	}
+	scrubbed := cs.Clone()
+	ow := NewOutputWriter(t.TempDir(), "", 0, 0)
+	ids := firmware.ExtractDeviceIDs(cs, nil)
+
+	cfg, err := ow.buildSVConfig(ctx, scrubbed, ids, 0xCAFE, &board.Board{BRAMSize: 0x10000})
+	if err != nil {
+		t.Fatalf("buildSVConfig: %v", err)
+	}
+	if cfg.MSIXConfig == nil {
+		t.Fatal("MSIXConfig is nil")
+	}
+	if got := cfg.MSIXConfig; got.TableBIR != 2 || got.TableOffset != 0x400 || got.PBABIR != 4 || got.PBAOffset != 0x800 {
+		t.Fatalf("MSI-X topology changed: got table BAR%d+0x%X, PBA BAR%d+0x%X", got.TableBIR, got.TableOffset, got.PBABIR, got.PBAOffset)
+	}
+	if got := scrubbed.ReadU32(0x54); got != 0x00000402 {
+		t.Errorf("scrubbed MSI-X table dword = 0x%08X, want offset 0x400 | BIR2", got)
+	}
+	if got := scrubbed.ReadU32(0x58); got != 0x00000804 {
+		t.Errorf("scrubbed MSI-X PBA dword = 0x%08X, want offset 0x800 | BIR4", got)
+	}
+}
+
+func TestBuildSVConfigRelocatesOverlappingMSIXRegionsWithoutChangingBIR(t *testing.T) {
+	cs := configSpaceWithMSIX(0x10EC, 0x8125, 0x020000, 2, 0, 2, 0, 2)
+	ctx := &donor.DeviceContext{
+		Device:      pci.PCIDevice{VendorID: 0x10EC, DeviceID: 0x8125, ClassCode: 0x020000},
+		ConfigSpace: cs,
+		BARs: []pci.BAR{
+			{Index: 2, Size: 0x1000, Type: pci.BARTypeMem32},
+		},
+		BARContents: map[int][]byte{2: make([]byte, 0x1000)},
+		MSIXData: &donor.MSIXData{
+			TableSize: 2, TableBIR: 2, TableOffset: 0,
+			PBABIR: 2, PBAOffset: 0,
+		},
+	}
+	scrubbed := cs.Clone()
+	ow := NewOutputWriter(t.TempDir(), "", 0, 0)
+	ids := firmware.ExtractDeviceIDs(cs, nil)
+
+	cfg, err := ow.buildSVConfig(ctx, scrubbed, ids, 0xCAFE, &board.Board{BRAMSize: 0x10000})
+	if err != nil {
+		t.Fatalf("buildSVConfig: %v", err)
+	}
+	msix := cfg.MSIXConfig
+	if msix == nil {
+		t.Fatal("MSIXConfig is nil")
+	}
+	if msix.TableBIR != 2 || msix.PBABIR != 2 {
+		t.Fatalf("MSI-X relocation changed advertised BIR: table=%d PBA=%d, want both 2", msix.TableBIR, msix.PBABIR)
+	}
+	if msix.TableOffset == 0 || msix.PBAOffset == 0 {
+		t.Fatalf("overlapping donor offsets were not relocated: table=0x%X PBA=0x%X", msix.TableOffset, msix.PBAOffset)
+	}
+	tableEnd := msix.TableOffset + uint32(ctx.MSIXData.TableSize*16)
+	pbaEnd := msix.PBAOffset + 8
+	if msix.TableOffset < pbaEnd && msix.PBAOffset < tableEnd {
+		t.Fatalf("relocated MSI-X table [0x%X,0x%X) overlaps PBA [0x%X,0x%X)",
+			msix.TableOffset, tableEnd, msix.PBAOffset, pbaEnd)
+	}
+	if got, want := scrubbed.ReadU32(0x54), (msix.TableOffset&0xFFFFFFF8)|2; got != want {
+		t.Errorf("table capability dword = 0x%08X, want routed value 0x%08X", got, want)
+	}
+	if got, want := scrubbed.ReadU32(0x58), (msix.PBAOffset&0xFFFFFFF8)|2; got != want {
+		t.Errorf("PBA capability dword = 0x%08X, want routed value 0x%08X", got, want)
+	}
+}
+
+func TestBuildSVConfigRejectsMSIXBIRWithoutMemoryEndpoint(t *testing.T) {
+	cs := configSpaceWithMSIX(0x1234, 0x5678, 0xFF0000, 3, 0x100, 3, 0x200, 1)
+	ctx := &donor.DeviceContext{
+		Device:      pci.PCIDevice{VendorID: 0x1234, DeviceID: 0x5678, ClassCode: 0xFF0000},
+		ConfigSpace: cs,
+		BARs: []pci.BAR{
+			{Index: 2, Size: 0x1000, Type: pci.BARTypeMem32},
+			{Index: 3, Type: pci.BARTypeDisabled},
+		},
+		BARContents: map[int][]byte{2: make([]byte, 0x1000)},
+		MSIXData: &donor.MSIXData{
+			TableSize: 1, TableBIR: 3, TableOffset: 0x100,
+			PBABIR: 3, PBAOffset: 0x200,
+		},
+	}
+	ow := NewOutputWriter(t.TempDir(), "", 0, 0)
+	ids := firmware.ExtractDeviceIDs(cs, nil)
+
+	_, err := ow.buildSVConfig(ctx, cs.Clone(), ids, 0xCAFE, &board.Board{BRAMSize: 0x10000})
+	if err == nil {
+		t.Fatal("buildSVConfig accepted MSI-X regions in absent/disabled BAR3")
+	}
+	if msg := strings.ToLower(err.Error()); !strings.Contains(msg, "bar3") && !strings.Contains(msg, "bir 3") {
+		t.Fatalf("error %q does not identify unsupported MSI-X BIR3", err)
+	}
+}
+
+func TestCoreSVArtifactsHaveNoUnconditionalMSIEndpoint(t *testing.T) {
+	for _, artifact := range coreSVArtifacts {
+		if artifact.filename == "pcileech_bar_impl_msi.sv" {
+			t.Fatal("pcileech_bar_impl_msi.sv must not be generated for every device")
+		}
+	}
+}
+
+func TestGenerateProjectTCLWithConfigPreservesSparseBARTopology(t *testing.T) {
+	cs := fakeConfigSpace(0x1234, 0x5678, 0xFF0000)
+	ctx := &donor.DeviceContext{
+		Device:      pci.PCIDevice{VendorID: 0x1234, DeviceID: 0x5678, ClassCode: 0xFF0000},
+		ConfigSpace: cs,
+		BARs: []pci.BAR{
+			{Index: 0, Size: 0x2000, Type: pci.BARTypeMem64, Is64Bit: true},
+			{Index: 2, Size: 0x1000, Type: pci.BARTypeMem32, Prefetchable: true},
+			{Index: 5, Size: 0x100000, Type: pci.BARTypeMem32},
+		},
+	}
+	bar0 := &barmodel.BARModel{BIR: 0, Size: 0x2000, Aperture: 0x2000, Type: pci.BARTypeMem64, Is64Bit: true, UpperBIR: 1}
+	bar2 := &barmodel.BARModel{BIR: 2, Size: 0x1000, Aperture: 0x1000, Type: pci.BARTypeMem32, Prefetchable: true}
+	bar5 := &barmodel.BARModel{BIR: 5, Size: 0x100000, Aperture: 0x100000, Type: pci.BARTypeMem32}
+	cfg := &svgen.SVGeneratorConfig{
+		DonorBARTopology: true,
+		BARModels:        []*barmodel.BARModel{bar0, bar2, bar5},
+		BARModel:         bar0,
+		MSIXConfig: &svgen.MSIXConfig{
+			NumVectors: 8,
+			TableBIR: 0, TableOffset: 0x400, TableBARSize: 0x2000,
+			PBABIR: 5, PBAOffset: 0x800, PBABARSize: 0x100000,
+		},
+	}
+	b := &board.Board{Name: "Test", FPGAPart: "xc7a35tfgg484-2", PCIeLanes: 1, TopModule: "test_top", BRAMSize: 0x200000}
+
+	tcl := tclgen.GenerateProjectTCLWithConfig(ctx, b, "/tmp/lib", false, cfg)
+	for bir, enabled := range []bool{true, false, true, false, false, true} {
+		want := "CONFIG.Bar" + string(rune('0'+bir)) + "_Enabled "
+		if enabled {
+			want += "true"
+		} else {
+			want += "false"
+		}
+		if !strings.Contains(tcl, want) {
+			t.Errorf("TCL missing %q", want)
+		}
+	}
+	for _, want := range []string{
+		"CONFIG.Bar0_Type            Memory",
+		"CONFIG.Bar0_Scale           Kilobytes",
+		"CONFIG.Bar0_Size            8",
+		"CONFIG.Bar0_64bit           true",
+		"CONFIG.Bar0_Prefetchable    false",
+		"CONFIG.Bar2_Type            Memory",
+		"CONFIG.Bar2_Scale           Kilobytes",
+		"CONFIG.Bar2_Size            4",
+		"CONFIG.Bar2_64bit           false",
+		"CONFIG.Bar2_Prefetchable    true",
+		"CONFIG.Bar5_Type            Memory",
+		"CONFIG.Bar5_Scale           Megabytes",
+		"CONFIG.Bar5_Size            1",
+		"CONFIG.Bar5_Prefetchable    false",
+		"CONFIG.MSIx_Table_BIR           BAR_1:0",
+		"CONFIG.MSIx_Table_Offset        00000400",
+		"CONFIG.MSIx_PBA_BIR             BAR_5",
+		"CONFIG.MSIx_PBA_Offset          00000800",
+	} {
+		if !strings.Contains(tcl, want) {
+			t.Errorf("TCL missing topology property %q", want)
+		}
+	}
+	if strings.Contains(tcl, "CONFIG.Bar5_64bit") {
+		t.Fatal("TCL emits unsupported Bar5_64bit property")
+	}
+}
+
+func TestFinalizedMSIXValuesMatchCOETCLAndRTL(t *testing.T) {
+	cs := configSpaceWithMSIX(0x1234, 0x5678, 0xFF0000, 2, 0x400, 4, 0x800, 4)
+	ctx := &donor.DeviceContext{
+		Device:      pci.PCIDevice{VendorID: 0x1234, DeviceID: 0x5678, ClassCode: 0xFF0000},
+		ConfigSpace: cs,
+		BARs: []pci.BAR{
+			{Index: 2, Size: 0x2000, Type: pci.BARTypeMem32},
+			{Index: 4, Size: 0x1000, Type: pci.BARTypeMem32},
+		},
+		BARContents: map[int][]byte{2: make([]byte, 0x2000), 4: make([]byte, 0x1000)},
+		MSIXData: &donor.MSIXData{
+			TableSize: 4, TableBIR: 2, TableOffset: 0x400,
+			PBABIR: 4, PBAOffset: 0x800,
+		},
+	}
+	b := &board.Board{Name: "Test", FPGAPart: "xc7a35tfgg484-2", PCIeLanes: 1, TopModule: "test_top", BRAMSize: 0x10000}
+	dir := t.TempDir()
+	ow := NewOutputWriter(dir, "/tmp/lib", 1, 1)
+	scrubbed := cs.Clone()
+	ids := firmware.ExtractDeviceIDs(cs, nil)
+	cfg, err := ow.buildSVConfig(ctx, scrubbed, ids, 0x1234, b)
+	if err != nil {
+		t.Fatalf("buildSVConfig: %v", err)
+	}
+	if err := ow.writeConfigSpaceArtifacts(ctx, scrubbed, b); err != nil {
+		t.Fatalf("writeConfigSpaceArtifacts: %v", err)
+	}
+	if err := ow.writeTCLScripts(ctx, b, cfg); err != nil {
+		t.Fatalf("writeTCLScripts: %v", err)
+	}
+	if err := ow.writeCoreSVArtifacts(cfg, scrubbed); err != nil {
+		t.Fatalf("writeCoreSVArtifacts: %v", err)
+	}
+	coe := readTestArtifact(t, filepath.Join(dir, "pcileech_cfgspace.coe"))
+	tcl := readTestArtifact(t, filepath.Join(dir, "vivado_generate_project.tcl"))
+	rtl := readTestArtifact(t, filepath.Join(dir, "pcileech_tlps128_bar_controller.sv"))
+	if got := coeWord(t, coe, 0x54/4); got != "00000402" {
+		t.Errorf("COE MSI-X table dword = %s, want 00000402", got)
+	}
+	if got := coeWord(t, coe, 0x58/4); got != "00000804" {
+		t.Errorf("COE MSI-X PBA dword = %s, want 00000804", got)
+	}
+	for _, want := range []string{"CONFIG.MSIx_Table_BIR           BAR_2", "CONFIG.MSIx_Table_Offset        00000400", "CONFIG.MSIx_PBA_BIR             BAR_4", "CONFIG.MSIx_PBA_Offset          00000800"} {
+		if !strings.Contains(tcl, want) {
+			t.Errorf("TCL missing finalized MSI-X value %q", want)
+		}
+	}
+	for _, want := range []string{".TABLE_BIR      ( 2", ".TABLE_OFFSET   ( 32'h00000400", ".PBA_BIR        ( 4", ".PBA_OFFSET     ( 32'h00000800"} {
+		if !strings.Contains(rtl, want) {
+			t.Errorf("RTL missing finalized MSI-X value %q", want)
+		}
+	}
+}
+
+func readTestArtifact(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func coeWord(t *testing.T, coe string, index int) string {
+	t.Helper()
+	parts := strings.SplitN(coe, "memory_initialization_vector=\n", 2)
+	if len(parts) != 2 {
+		t.Fatal("COE initialization vector missing")
+	}
+	lines := strings.Split(parts[1], "\n")
+	if index < 0 || index >= len(lines) {
+		t.Fatalf("COE word index %d out of range", index)
+	}
+	return strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(lines[index]), ","), ";")
+}
+
+func TestHDLLintHarnessRequiresNamedModernMultibarPass(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	script := readTestArtifact(t, filepath.Join(filepath.Dir(file), "..", "..", "..", "scripts", "hdl-lint.sh"))
+	for _, want := range []string{
+		"LEGACY_BOARDS=(pciescreamer NeTV2_35T NeTV2_100T acorn litefury sp605_ft601)",
+		`case " ${LEGACY_BOARDS[*]} " in`,
+		"SKIP  $cell (explicit legacy board allowlist)",
+		"modern_multibar_pass=0",
+		`if [ "$cell" = "multibar×PCIeSquirrel" ]; then`,
+		"modern_multibar_pass=1",
+		`if [ "$modern_multibar_pass" -ne 1 ]; then`,
+		"FAIL  mandatory modern multibar×PCIeSquirrel cell did not pass",
+		"pcileech_bar_rsp_arbiter.sv",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("HDL harness missing policy token %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"legacy board source lacks IfAXIS128 controller architecture",
+		"legacy board source lacks generated-controller integration modules",
+	} {
+		if strings.Contains(script, forbidden) {
+			t.Errorf("HDL harness retains content-based legacy skip %q", forbidden)
+		}
+	}
+}
+
+
+func configSpaceWithMSIX(vid, did uint16, classCode uint32, tableBIR int, tableOffset uint32, pbaBIR int, pbaOffset uint32, vectors int) *pci.ConfigSpace {
+	cs := fakeConfigSpace(vid, did, classCode)
+	cs.WriteU16(0x06, cs.Status()|0x0010)
+	cs.WriteU8(0x34, 0x50)
+	cs.WriteU8(0x50, pci.CapIDMSIX)
+	cs.WriteU8(0x51, 0)
+	cs.WriteU16(0x52, uint16(vectors-1)&0x07FF)
+	cs.WriteU32(0x54, tableOffset&0xFFFFFFF8|uint32(tableBIR))
+	cs.WriteU32(0x58, pbaOffset&0xFFFFFFF8|uint32(pbaBIR))
+	return cs
+}

--- a/internal/firmware/output/writer.go
+++ b/internal/firmware/output/writer.go
@@ -63,6 +63,14 @@ func (ow *OutputWriter) WriteAll(ctx *donor.DeviceContext, b *board.Board) error
 	}
 
 	scrubbedCS, entropy, overlayMap := ow.scrubAndVary(ctx, b, ids)
+	var svCfg *svgen.SVGeneratorConfig
+	if !ow.StockBar {
+		var err error
+		svCfg, err = ow.buildSVConfig(ctx, scrubbedCS, ids, entropy, b)
+		if err != nil {
+			return fmt.Errorf("SV module generation failed: %w", err)
+		}
+	}
 
 	if err := ow.writeConfigSpaceArtifacts(ctx, scrubbedCS, b); err != nil {
 		return err
@@ -72,7 +80,7 @@ func (ow *OutputWriter) WriteAll(ctx *donor.DeviceContext, b *board.Board) error
 		return err
 	}
 
-	if err := ow.writeTCLScripts(ctx, b); err != nil {
+	if err := ow.writeTCLScripts(ctx, b, svCfg); err != nil {
 		return err
 	}
 
@@ -81,7 +89,7 @@ func (ow *OutputWriter) WriteAll(ctx *donor.DeviceContext, b *board.Board) error
 	}
 
 	if !ow.StockBar {
-		if err := ow.writeSVModules(ctx, scrubbedCS, ids, entropy, b); err != nil {
+		if err := ow.writeSVModules(ctx, scrubbedCS, svCfg); err != nil {
 			return fmt.Errorf("SV module generation failed: %w", err)
 		}
 	} else {
@@ -157,9 +165,13 @@ func (ow *OutputWriter) writeConfigSpaceArtifacts(ctx *donor.DeviceContext, scru
 }
 
 // writeTCLScripts generates Vivado project and build TCL scripts.
-func (ow *OutputWriter) writeTCLScripts(ctx *donor.DeviceContext, b *board.Board) error {
+func (ow *OutputWriter) writeTCLScripts(ctx *donor.DeviceContext, b *board.Board, configs ...*svgen.SVGeneratorConfig) error {
+	var cfg *svgen.SVGeneratorConfig
+	if len(configs) > 0 {
+		cfg = configs[0]
+	}
 	if err := ow.writeFile("vivado_generate_project.tcl",
-		tclgen.GenerateProjectTCL(ctx, b, ow.LibDir, ow.StockBar)); err != nil {
+		tclgen.GenerateProjectTCLWithConfig(ctx, b, ow.LibDir, ow.StockBar, cfg)); err != nil {
 		return fmt.Errorf("failed to write project TCL: %w", err)
 	}
 	if err := ow.writeFile("vivado_build.tcl",
@@ -199,7 +211,6 @@ var barControllerSubModules = []string{
 	"pcileech_tlps128_bar_rdengine",
 	"pcileech_tlps128_bar_wrengine",
 	"pcileech_bar_impl_none",
-	"pcileech_bar_impl_loopaddr",
 	"pcileech_bar_impl_zerowrite4k",
 }
 
@@ -346,7 +357,7 @@ func ListOutputFiles() []string {
 		"src/",
 		"pcileech_bar_impl_device.sv",
 		"pcileech_tlps128_bar_controller.sv",
-		"pcileech_bar_impl_msi.sv",
+		"pcileech_bar_rsp_arbiter.sv",
 		"pcileech_msix_table.sv",
 		"pcileech_nvme_admin_responder.sv",
 		"pcileech_nvme_dma_bridge.sv",
@@ -370,26 +381,18 @@ type svArtifact struct {
 var coreSVArtifacts = []svArtifact{
 	{"pcileech_bar_impl_device.sv", svgen.GenerateBarImplDeviceSV},
 	{"pcileech_tlps128_bar_controller.sv", svgen.GenerateBarControllerSV},
-	{"pcileech_bar_impl_msi.sv", svgen.GenerateBarImplMSISV},
+	{"pcileech_bar_rsp_arbiter.sv", svgen.GenerateBarRspArbiterSV},
 	{"tlp_latency_emulator.sv", svgen.GenerateLatencyEmulatorSV},
 	{"device_config.sv", svgen.GenerateDeviceConfigSV},
 }
 
-// writeSVModules generates device-specific SV and HEX init files.
-func (ow *OutputWriter) writeSVModules(ctx *donor.DeviceContext, scrubbedCS *pci.ConfigSpace, ids firmware.DeviceIDs, entropy uint32, b *board.Board) error {
-	cfg, err := ow.buildSVConfig(ctx, scrubbedCS, ids, entropy, b)
-	if err != nil {
-		return err
-	}
-
+func (ow *OutputWriter) writeSVModules(ctx *donor.DeviceContext, scrubbedCS *pci.ConfigSpace, cfg *svgen.SVGeneratorConfig) error {
 	if err := ow.writeCoreSVArtifacts(cfg, scrubbedCS); err != nil {
 		return err
 	}
-
 	if err := ow.writeConditionalArtifacts(cfg, ctx); err != nil {
 		return err
 	}
-
 	ow.logSVSummary(cfg)
 	return nil
 }
@@ -436,47 +439,77 @@ func extractMSIInfo(cs *pci.ConfigSpace) *svgen.MSIConfig {
 	return nil
 }
 
-// buildSVConfig assembles the SVGeneratorConfig from donor context.
-func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.ConfigSpace, ids firmware.DeviceIDs, entropy uint32, b *board.Board) (*svgen.SVGeneratorConfig, error) {
-	// Use the same BAR index for content data and probe profile to avoid
-	// mismatched register maps (e.g. IO BAR0 profile + MMIO BAR2 data).
-	barIdx := firmware.LargestBarIndex(ctx.BARContents)
-	// NVMe CAP/VS/CC/CSTS live in BAR0; force it even when BAR0 isn't the largest.
-	if ctx.Device.ClassCode == devclass.ClassCodeNVMe {
-		if _, ok := ctx.BARContents[0]; ok {
-			barIdx = 0
-		}
-	}
-	barData := ctx.BARContents[barIdx]
-	var barProfile *donor.BARProfile
-	if ctx.BARProfiles != nil {
-		if p, ok := ctx.BARProfiles[barIdx]; ok {
-			barProfile = p
-		}
-	}
-	slog.Info("BAR selection for SV codegen",
-		"bar_index", barIdx,
-		"bar_size", len(barData),
-		"has_profile", barProfile != nil,
-		"class_code", fmt.Sprintf("0x%06X", ctx.Device.ClassCode),
-	)
-	bm := barmodel.BuildBARModel(barData, ctx.Device.ClassCode, barProfile)
-	slog.Info("BAR model built",
-		"model_nil", bm == nil,
-		"reg_count", func() int {
-			if bm != nil {
-				return len(bm.Registers)
-			}
-			return 0
-		}(),
-	)
+type barInterval struct {
+	start uint64
+	end   uint64
+}
 
+func alignUp(value, alignment uint64) uint64 {
+	if alignment <= 1 {
+		return value
+	}
+	return (value + alignment - 1) &^ (alignment - 1)
+}
+
+func placeBARRegion(model *barmodel.BARModel, preferred, length, alignment uint64, reserved []barInterval) (uint32, error) {
+	if model == nil || model.Size <= 0 {
+		return 0, fmt.Errorf("BAR endpoint is absent")
+	}
+	limit := uint64(model.Size)
+	occupied := append([]barInterval(nil), reserved...)
+	for _, reg := range model.Registers {
+		width := reg.Width
+		if width <= 0 {
+			width = 4
+		}
+		occupied = append(occupied, barInterval{start: uint64(reg.Offset), end: uint64(reg.Offset) + uint64(width)})
+	}
+	fits := func(start uint64) bool {
+		if start%alignment != 0 || start > limit || length > limit-start {
+			return false
+		}
+		end := start + length
+		for _, used := range occupied {
+			if start < used.end && used.start < end {
+				return false
+			}
+		}
+		return start <= uint64(^uint32(0)) && end <= uint64(^uint32(0))+1
+	}
+
+	candidates := []uint64{preferred, 0}
+	for _, used := range occupied {
+		candidates = append(candidates, alignUp(used.end, alignment))
+	}
+	for _, candidate := range candidates {
+		if fits(candidate) {
+			return uint32(candidate), nil
+		}
+	}
+	return 0, fmt.Errorf("BAR%d aperture %#x has no %#x-byte aligned gap for MSI-X region",
+		model.BIR, limit, length)
+}
+
+func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.ConfigSpace, ids firmware.DeviceIDs, entropy uint32, b *board.Board) (*svgen.SVGeneratorConfig, error) {
 	strategy := devclass.StrategyForClassAndVendor(ctx.Device.ClassCode, ids.VendorID)
 	devClass := ""
+	preferredBIR := 0
 	if strategy != nil {
 		devClass = strategy.DeviceClass()
+		if profile := strategy.Profile(); profile != nil {
+			preferredBIR = profile.PreferredBAR
+		}
 	}
-	slog.Info("device class resolution", "class", devClass)
+
+	models, err := barmodel.BuildBARModels(ctx.BARs, ctx.BARContents, ctx.BARProfiles,
+		ctx.Device.ClassCode, preferredBIR)
+	if err != nil {
+		return nil, fmt.Errorf("invalid donor BAR topology: %w", err)
+	}
+	primary := barmodel.ModelForBIR(models, preferredBIR)
+	if primary == nil && len(models) > 0 {
+		primary = models[0]
+	}
 
 	msixTableSize := 0
 	if ctx.MSIXData != nil && ctx.MSIXData.TableSize > 0 {
@@ -484,27 +517,45 @@ func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.
 	}
 	donorBar := firmware.DonorBAR0Demand(ctx, b, msixTableSize)
 	bar0Size := firmware.CappedBAR0Size(ctx, b, msixTableSize)
-	if bm != nil && bm.Size < bar0Size {
-		bm.Size = bar0Size
+	if bar0 := barmodel.ModelForBIR(models, 0); bar0 != nil && bar0.Size < bar0Size {
+		bar0.Size = bar0Size
 	}
-	if bm == nil && bar0Size > board.DefaultBRAMSize {
-		bm = &barmodel.BARModel{Size: bar0Size}
+
+	barData := []byte(nil)
+	if primary != nil {
+		barData = ctx.BARContents[primary.BIR]
 	}
+	slog.Info("BAR topology for SV codegen",
+		"models", len(models),
+		"preferred_bir", preferredBIR,
+		"primary_bir", func() int {
+			if primary != nil {
+				return primary.BIR
+			}
+			return -1
+		}(),
+		"class_specific", primary != nil && primary.ClassSpecific,
+		"class_code", fmt.Sprintf("0x%06X", ctx.Device.ClassCode),
+	)
 
 	cfg := &svgen.SVGeneratorConfig{
 		DeviceIDs:         ids,
 		DonorCapabilities: extractDonorCapabilities(scrubbedCS),
-		BARModel:          bm,
+		BARModels:         models,
+		DonorBARTopology:  true,
+		BARModel:          primary,
 		ClassCode:         ctx.Device.ClassCode,
 		LatencyConfig:     svgen.DefaultLatencyConfig(ctx.Device.ClassCode),
-		HasMSIX:           bm != nil,
 		BuildEntropy:      entropy,
 		PRNGSeeds:         svgen.BuildPRNGSeeds(ids.VendorID, ids.DeviceID, entropy),
 		DeviceClass:       devClass,
 		Bar0Size:          bar0Size,
 	}
+	if primary == nil {
+		cfg.LatencyConfig = nil
+	}
 
-	if devClass == devclass.ClassNVMe {
+	if devClass == devclass.ClassNVMe && cfg.HasClassEndpoint() {
 		var identity *nvme.ControllerIdentity
 		if ctx.NVMeIdentity != nil {
 			identity = &nvme.ControllerIdentity{
@@ -542,19 +593,72 @@ func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.
 	}
 
 	if ctx.MSIXData != nil && ctx.MSIXData.TableSize > 0 {
-		// Pass the full class code: MSIXPlacement detects NVMe via
-		// (class>>8)==0x0108, so the truncated 0x0108 would skip the
-		// doorbell-avoidance guard.
-		tableOff, pbaOffset, _ := firmware.MSIXPlacement(cfg.Bar0Size, ctx.MSIXData.TableSize, ctx.Device.ClassCode, cfg.NVMeDoorbellStride)
+		tableModel := barmodel.ModelForBIR(models, ctx.MSIXData.TableBIR)
+		if tableModel == nil {
+			return nil, fmt.Errorf("MSI-X table advertises BIR %d, but that BIR has no generated memory endpoint",
+				ctx.MSIXData.TableBIR)
+		}
+		pbaModel := barmodel.ModelForBIR(models, ctx.MSIXData.PBABIR)
+		if pbaModel == nil {
+			return nil, fmt.Errorf("MSI-X PBA advertises BIR %d, but that BIR has no generated memory endpoint",
+				ctx.MSIXData.PBABIR)
+		}
+
+		var tableReserved []barInterval
+		if devClass == devclass.ClassNVMe && tableModel.BIR == preferredBIR {
+			stride := uint64(4) << cfg.NVMeDoorbellStride
+			tableReserved = append(tableReserved, barInterval{
+				start: uint64(board.DefaultBRAMSize),
+				end:   uint64(board.DefaultBRAMSize) + 4*stride,
+			})
+		}
+		tableBytes := uint64(ctx.MSIXData.TableSize * 16)
+		tableOff, err := placeBARRegion(tableModel, uint64(ctx.MSIXData.TableOffset),
+			tableBytes, 16, tableReserved)
+		if err != nil {
+			return nil, fmt.Errorf("placing MSI-X table: %w", err)
+		}
+
+		pbaBytes := uint64((ctx.MSIXData.TableSize + 63) / 64 * 8)
+		if pbaBytes < 8 {
+			pbaBytes = 8
+		}
+		var pbaReserved []barInterval
+		if pbaModel.BIR == tableModel.BIR {
+			pbaReserved = append(pbaReserved, barInterval{
+				start: uint64(tableOff),
+				end:   uint64(tableOff) + tableBytes,
+			})
+		}
+		if devClass == devclass.ClassNVMe && pbaModel.BIR == preferredBIR {
+			stride := uint64(4) << cfg.NVMeDoorbellStride
+			pbaReserved = append(pbaReserved, barInterval{
+				start: uint64(board.DefaultBRAMSize),
+				end:   uint64(board.DefaultBRAMSize) + 4*stride,
+			})
+		}
+		pbaOff, err := placeBARRegion(pbaModel, uint64(ctx.MSIXData.PBAOffset),
+			pbaBytes, 8, pbaReserved)
+		if err != nil {
+			return nil, fmt.Errorf("placing MSI-X PBA: %w", err)
+		}
+
 		cfg.MSIXConfig = &svgen.MSIXConfig{
-			NumVectors:  ctx.MSIXData.TableSize,
-			TableOffset: tableOff,
-			PBAOffset:   pbaOffset,
+			NumVectors:   ctx.MSIXData.TableSize,
+			TableBIR:     tableModel.BIR,
+			TableOffset:  tableOff,
+			TableBARSize: uint64(tableModel.Size),
+			PBABIR:       pbaModel.BIR,
+			PBAOffset:    pbaOff,
+			PBABARSize:   uint64(pbaModel.Size),
+		}
+		if tableModel.BIR == pbaModel.BIR {
+			cfg.MSIXConfig.BARSize = uint64(tableModel.Size)
 		}
 		cfg.HasMSIX = true
 		if m := pci.ParseMSIXCap(scrubbedCS); m != nil {
-			scrubbedCS.WriteU32(m.CapOffset+4, tableOff&0xFFFFFFF8)
-			scrubbedCS.WriteU32(m.CapOffset+8, pbaOffset&0xFFFFFFF8)
+			scrubbedCS.WriteU32(m.CapOffset+4, (tableOff&0xFFFFFFF8)|uint32(tableModel.BIR))
+			scrubbedCS.WriteU32(m.CapOffset+8, (pbaOff&0xFFFFFFF8)|uint32(pbaModel.BIR))
 		}
 	}
 
@@ -570,13 +674,6 @@ func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.
 	if issues := ValidateBARSize(donorBar, bram, 0); len(issues) > 0 {
 		if !ow.Force {
 			return nil, fmt.Errorf("%s", issues[0])
-		}
-	}
-	if cfg.MSIXConfig != nil {
-		if issues := ValidateBARSize(donorBar, bram, cfg.MSIXConfig.TableOffset); len(issues) > 0 {
-			if !ow.Force {
-				return nil, fmt.Errorf("%s", issues[0])
-			}
 		}
 	}
 

--- a/internal/firmware/svgen/generator.go
+++ b/internal/firmware/svgen/generator.go
@@ -19,11 +19,21 @@ type MSIConfig struct {
 	Data    uint16 // MSI Message Data
 }
 
+type BARSlot struct {
+	BIR        int
+	Model      *barmodel.BARModel
+	ModuleName string
+	Primary    bool
+}
+
 // SVGeneratorConfig is the input data for all SV template renders.
 type SVGeneratorConfig struct {
 	DeviceIDs          firmware.DeviceIDs
 	DonorCapabilities  DonorCapabilities  // donor capability summary for donor-emulation visibility
+	BARModels          []*barmodel.BARModel
+	DonorBARTopology   bool
 	BARModel           *barmodel.BARModel // nil = generic fallback (uses BRAM-based zerowrite4k)
+	BARModuleName      string
 	ClassCode          uint32
 	LatencyConfig      *LatencyConfig     // TLP response timing (nil = no latency emulator)
 	HasMSIX            bool               // generate MSI-X interrupt controller logic
@@ -38,6 +48,53 @@ type SVGeneratorConfig struct {
 	NVMeDiskWords      int                // NVMe disk-cache depth (words), board-scaled
 	NVMeAdvertisedLBAs uint64             // actual NSZE from donor (0 = use default 2000409264)
 	Bar0Size           int
+}
+
+func (c *SVGeneratorConfig) HasClassEndpoint() bool {
+	if len(c.BARModels) == 0 {
+		return c.BARModel != nil
+	}
+	return c.BARModel != nil && c.BARModel.ClassSpecific
+}
+
+func (c *SVGeneratorConfig) PrimaryBIR() int {
+	if c.BARModel != nil {
+		return c.BARModel.BIR
+	}
+	return 0
+}
+
+func (c *SVGeneratorConfig) BARSlots() []BARSlot {
+	slots := make([]BARSlot, 6)
+	for bir := range slots {
+		slots[bir] = BARSlot{BIR: bir}
+	}
+	if c.BARModel == nil && !c.DonorBARTopology {
+		slots[0].Primary = true
+	}
+	models := c.BARModels
+	if len(models) == 0 && c.BARModel != nil {
+		models = []*barmodel.BARModel{c.BARModel}
+	}
+	for _, model := range models {
+		if model == nil || model.BIR < 0 || model.BIR >= len(slots) {
+			continue
+		}
+		name := fmt.Sprintf("pcileech_bar_impl_device_bar%d", model.BIR)
+		primary := model == c.BARModel
+		if primary {
+			name = "pcileech_bar_impl_device"
+		}
+		slots[model.BIR] = BARSlot{BIR: model.BIR, Model: model, ModuleName: name, Primary: primary}
+	}
+	return slots
+}
+
+func (c *SVGeneratorConfig) BARImplementationModuleName() string {
+	if c.BARModuleName != "" {
+		return c.BARModuleName
+	}
+	return "pcileech_bar_impl_device"
 }
 
 // NVMeDiskWordsForBRAM36 returns the NVMe disk-cache depth in 32-bit words for
@@ -141,11 +198,44 @@ func renderTemplateDelim(name, leftDelim, rightDelim string, data any) (string, 
 }
 
 func GenerateBarImplDeviceSV(cfg *SVGeneratorConfig) (string, error) {
-	return renderTemplate("bar_impl_device", cfg)
+	if len(cfg.BARModels) == 0 {
+		return renderTemplate("bar_impl_device", cfg)
+	}
+
+	var out bytes.Buffer
+	for i, model := range cfg.BARModels {
+		if model == nil {
+			continue
+		}
+		endpoint := *cfg
+		endpoint.BARModels = nil
+		endpoint.BARModel = model
+		if model == cfg.BARModel {
+			endpoint.BARModuleName = "pcileech_bar_impl_device"
+		} else {
+			endpoint.BARModuleName = fmt.Sprintf("pcileech_bar_impl_device_bar%d", model.BIR)
+		}
+		if !model.ClassSpecific {
+			endpoint.DeviceClass = ""
+		}
+		rendered, err := renderTemplate("bar_impl_device", &endpoint)
+		if err != nil {
+			return "", fmt.Errorf("rendering BAR%d endpoint: %w", model.BIR, err)
+		}
+		if i > 0 {
+			out.WriteString("\n")
+		}
+		out.WriteString(rendered)
+	}
+	return out.String(), nil
 }
 
 func GenerateBarControllerSV(cfg *SVGeneratorConfig) (string, error) {
 	return renderTemplate("bar_controller", cfg)
+}
+
+func GenerateBarRspArbiterSV(cfg *SVGeneratorConfig) (string, error) {
+	return renderTemplate("bar_rsp_arbiter", cfg)
 }
 
 func GenerateDeviceConfigSV(cfg *SVGeneratorConfig) (string, error) {

--- a/internal/firmware/svgen/msix_config.go
+++ b/internal/firmware/svgen/msix_config.go
@@ -2,7 +2,20 @@ package svgen
 
 // MSIXConfig parameters for MSI-X SV template.
 type MSIXConfig struct {
-	NumVectors  int
-	TableOffset uint32
-	PBAOffset   uint32
+	NumVectors    int
+	TableBIR      int
+	TableOffset   uint32
+	TableBARSize  uint64
+	PBABIR        int
+	PBAOffset     uint32
+	PBABARSize    uint64
+	BARSize       uint64
+}
+
+func (c *MSIXConfig) TableEnd() uint64 {
+	return uint64(c.TableOffset) + uint64(c.NumVectors)*16
+}
+
+func (c *MSIXConfig) PBAEnd() uint64 {
+	return uint64(c.PBAOffset) + uint64((c.NumVectors+63)/64)*8
 }

--- a/internal/firmware/svgen/multibar_test.go
+++ b/internal/firmware/svgen/multibar_test.go
@@ -1,0 +1,397 @@
+package svgen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/firmware/barmodel"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func TestBARSlotsPreserveSparseTopologyAnd64BitUpperSlot(t *testing.T) {
+	primary := &barmodel.BARModel{
+		BIR: 0, Size: 0x1800, Aperture: 0x1800, Type: pci.BARTypeMem64,
+		Is64Bit: true, UpperBIR: 1, ClassSpecific: true,
+	}
+	secondary := &barmodel.BARModel{
+		BIR: 3, Size: 0x1000, Aperture: 0x1000, Type: pci.BARTypeMem32,
+	}
+	cfg := &SVGeneratorConfig{BARModels: []*barmodel.BARModel{primary, secondary}, BARModel: primary}
+
+	slots := cfg.BARSlots()
+	if len(slots) != 6 {
+		t.Fatalf("BARSlots length = %d, want six physical BAR selectors", len(slots))
+	}
+	if slots[0].Model != primary || !slots[0].Primary || slots[0].ModuleName != "pcileech_bar_impl_device" {
+		t.Fatalf("BAR0 slot = %+v, want primary 64-bit endpoint", slots[0])
+	}
+	if slots[1].Model != nil {
+		t.Fatalf("BAR1 slot = %+v, want no endpoint because 64-bit BAR0 consumes it", slots[1])
+	}
+	if slots[3].Model != secondary || slots[3].Primary || slots[3].ModuleName != "pcileech_bar_impl_device_bar3" {
+		t.Fatalf("BAR3 slot = %+v, want independent secondary endpoint", slots[3])
+	}
+	for _, bir := range []int{2, 4, 5} {
+		if slots[bir].Model != nil {
+			t.Errorf("absent BAR%d unexpectedly has endpoint %+v", bir, slots[bir])
+		}
+	}
+}
+
+func TestGenerateBarImplDeviceSVEmitsOneModulePerPresentBAR(t *testing.T) {
+	primary := &barmodel.BARModel{
+		BIR: 2, Size: 0x1000, Aperture: 0x1000, Type: pci.BARTypeMem32,
+		ClassSpecific: true,
+		Registers: []barmodel.BARRegister{{Offset: 0x00, Width: 4, Name: "PRIMARY", Reset: 0x11223344}},
+	}
+	secondary := &barmodel.BARModel{
+		BIR: 4, Size: 0x2000, Aperture: 0x2000, Type: pci.BARTypeMem32,
+		Registers: []barmodel.BARRegister{{Offset: 0x40, Width: 4, Name: "SECONDARY", Reset: 0x55667788}},
+	}
+	cfg := &SVGeneratorConfig{
+		BARModels: []*barmodel.BARModel{primary, secondary},
+		BARModel: primary,
+		DeviceClass: "ethernet",
+	}
+
+	sv, err := GenerateBarImplDeviceSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarImplDeviceSV: %v", err)
+	}
+	if strings.Count(sv, "module pcileech_bar_impl_device #(") != 1 {
+		t.Error("generated SV must contain exactly one compatibility/primary BAR module")
+	}
+	if strings.Count(sv, "module pcileech_bar_impl_device_bar4 #(") != 1 {
+		t.Error("generated SV must contain an independent module for secondary BAR4")
+	}
+	if !strings.Contains(sv, "reg_0x00000000") || !strings.Contains(sv, "reg_0x00000040") {
+		t.Error("generated endpoint modules do not contain both BAR register maps")
+	}
+}
+
+func TestGenerateBarImplDeviceSVUsesWritableStorageForUnmodeledBAR(t *testing.T) {
+	primary := &barmodel.BARModel{
+		BIR: 2, Size: 0x1000, Aperture: 0x1000, Type: pci.BARTypeMem32,
+		ClassSpecific: true,
+		Registers: []barmodel.BARRegister{{Offset: 0, Width: 4, Name: "PRIMARY"}},
+	}
+	unmodeled := &barmodel.BARModel{
+		BIR: 4, Size: 0x1800, Aperture: 0x1800, Type: pci.BARTypeMem32,
+	}
+	cfg := &SVGeneratorConfig{
+		BARModels: []*barmodel.BARModel{primary, unmodeled},
+		BARModel: primary,
+	}
+
+	sv, err := GenerateBarImplDeviceSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarImplDeviceSV: %v", err)
+	}
+	start := strings.Index(sv, "module pcileech_bar_impl_device_bar4 #(")
+	if start < 0 {
+		t.Fatal("unmodeled BAR4 module missing")
+	}
+	bar4 := sv[start:]
+	for _, want := range []string{
+		"parameter BAR_SIZE = 6144",
+		"localparam BAR_STORAGE_BYTES = (BAR_SIZE > 4096) ? 4096 : BAR_SIZE",
+		"localparam BAR_WORD_ADDR_BITS = (BAR_WORDS > 1) ? $clog2(BAR_WORDS) : 1",
+		"wire [BAR_WORD_ADDR_BITS-1:0] wr_word = wr_addr[BAR_WORD_ADDR_BITS+1:2]",
+		"wire [BAR_WORD_ADDR_BITS-1:0] rd_word = rd_req_addr[BAR_WORD_ADDR_BITS+1:2]",
+		"reg [31:0] bar_mem",
+		"if (wr_valid && (wr_addr < BAR_STORAGE_BYTES))",
+		"if (wr_be[0]) bar_mem[wr_word]",
+		"reg [31:0] rd_data_d1",
+		"rd_req_valid_d1 <= rd_req_valid && (rd_req_addr < BAR_SIZE)",
+	} {
+		if !strings.Contains(bar4, want) {
+			t.Errorf("unmodeled BAR4 lacks narrowed writable pipelined aperture behavior %q", want)
+		}
+	}
+	for _, pattern := range []string{
+		`rd_data_d1\s*<=\s*bar_mem\[rd_word\]`,
+		`rd_rsp_data\s*<=\s*rd_data_d1`,
+	} {
+		if !regexp.MustCompile(pattern).MatchString(bar4) {
+			t.Errorf("unmodeled BAR4 lacks pipelined read behavior matching %q", pattern)
+		}
+	}
+	for _, forbidden := range []string{"bar_mem[rd_req_addr[31:2]]", "bar_mem[wr_addr[31:2]]"} {
+		if strings.Contains(bar4, forbidden) {
+			t.Errorf("fallback BRAM uses over-wide address index %q", forbidden)
+		}
+	}
+	if regexp.MustCompile(`rd_rsp_data\s*<=\s*doutb`).MatchString(bar4) {
+		t.Fatal("fallback read response uses the live request address instead of pipelined request data")
+	}
+}
+
+func TestGenerateBarControllerSVHasNoSyntheticLoopbackOrMSIEndpoints(t *testing.T) {
+	model := &barmodel.BARModel{
+		BIR: 3, Size: 0x1800, Aperture: 0x1800, Type: pci.BARTypeMem32,
+		Registers: []barmodel.BARRegister{{Offset: 0, Width: 4, Name: "REG"}},
+	}
+	cfg := &SVGeneratorConfig{BARModels: []*barmodel.BARModel{model}, BARModel: model}
+
+	sv, err := GenerateBarControllerSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarControllerSV: %v", err)
+	}
+	for _, forbidden := range []string{"pcileech_bar_impl_loopaddr", "pcileech_bar_impl_msi"} {
+		if strings.Contains(sv, forbidden) {
+			t.Errorf("generated controller contains unconditional synthetic endpoint %q", forbidden)
+		}
+	}
+	if !strings.Contains(sv, "pcileech_bar_impl_device") || !strings.Contains(sv, "i_bar3") {
+		t.Error("present donor BAR3 endpoint was not instantiated at BIR3")
+	}
+	for _, bir := range []string{"0", "1", "2", "4", "5"} {
+		if !strings.Contains(sv, "pcileech_bar_impl_none i_bar"+bir) {
+			t.Errorf("absent BAR%s is not explicitly tied to a no-response endpoint", bir)
+		}
+	}
+	if !strings.Contains(sv, "assign intr_req = 1'b0") {
+		t.Error("device without an interrupt endpoint must tie intr_req low")
+	}
+}
+
+func TestGenerateBarControllerSVRejectsOutOfApertureAddressesWithoutWrapping(t *testing.T) {
+	model := &barmodel.BARModel{
+		BIR: 3, Size: 0x1800, Aperture: 0x1800, Type: pci.BARTypeMem32,
+		Registers: []barmodel.BARRegister{{Offset: 0, Width: 4, Name: "REG"}},
+	}
+	cfg := &SVGeneratorConfig{BARModels: []*barmodel.BARModel{model}, BARModel: model}
+
+	sv, err := GenerateBarControllerSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarControllerSV: %v", err)
+	}
+	if strings.Contains(sv, "ADDR_MASK") || regexp.MustCompile(`(?m)wr_addr\s*&\s*32'h`).MatchString(sv) || regexp.MustCompile(`(?m)rd_req_addr\s*&\s*32'h`).MatchString(sv) {
+		t.Fatal("BAR address masking aliases out-of-range requests back into the aperture")
+	}
+	legalCompare := regexp.MustCompile(`(?m)(wr_addr|rd_req_addr)\s*<\s*(32'h00001800|32'd6144|6144)`)
+	if len(legalCompare.FindAllString(sv, -1)) < 2 {
+		t.Fatalf("generated controller lacks explicit read/write addr < 0x1800 aperture checks")
+	}
+}
+
+func TestGenerateBarControllerSVSuppressesOnlyExactMSIXWriteRanges(t *testing.T) {
+	bar2 := &barmodel.BARModel{BIR: 2, Size: 0x2000, Aperture: 0x2000, Type: pci.BARTypeMem32}
+	cfg := &SVGeneratorConfig{
+		BARModels: []*barmodel.BARModel{bar2},
+		BARModel:  bar2,
+		HasMSIX:   true,
+		MSIXConfig: &MSIXConfig{
+			NumVectors: 4,
+			TableBIR: 2, TableOffset: 0x400, TableBARSize: 0x2000,
+			PBABIR: 2, PBAOffset: 0x800, PBABARSize: 0x2000,
+		},
+	}
+
+	sv, err := GenerateBarControllerSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarControllerSV: %v", err)
+	}
+	flat := strings.Join(strings.Fields(sv), " ")
+	for _, want := range []string{
+		"wire msix_wr_table_select = wr_valid && wr_bar[2] && (wr_addr >= 1024) && (wr_addr < 1088);",
+		"wire msix_wr_pba_select = wr_valid && wr_bar[2] && (wr_addr >= 2048) && (wr_addr < 2056);",
+		"wr_valid && wr_bar[2] && bar0_wr_hit && !msix_wr_table_select && !msix_wr_pba_select",
+	} {
+		if !strings.Contains(flat, want) {
+			t.Errorf("generated controller lacks exact MSI-X write decode %q", want)
+		}
+	}
+	baseWrite := func(addr uint32) bool {
+		table := addr >= 0x400 && addr < 0x440
+		pba := addr >= 0x800 && addr < 0x808
+		return addr < 0x2000 && !table && !pba
+	}
+	for _, addr := range []uint32{0, 0x3FC, 0x440, 0x7FC, 0x808, 0x1FFC} {
+		if !baseWrite(addr) {
+			t.Errorf("ordinary BAR2 write at 0x%X was excluded", addr)
+		}
+	}
+	for _, addr := range []uint32{0x400, 0x43C, 0x800, 0x804} {
+		if baseWrite(addr) {
+			t.Errorf("MSI-X write at 0x%X leaked into base endpoint", addr)
+		}
+	}
+}
+
+func TestGenerateBarControllerSVRoutesMSIXRegionsByIndependentBIR(t *testing.T) {
+	bar2 := &barmodel.BARModel{BIR: 2, Size: 0x2000, Aperture: 0x2000, Type: pci.BARTypeMem32}
+	bar4 := &barmodel.BARModel{BIR: 4, Size: 0x1000, Aperture: 0x1000, Type: pci.BARTypeMem32}
+	cfg := &SVGeneratorConfig{
+		BARModels: []*barmodel.BARModel{bar2, bar4},
+		BARModel:  bar2,
+		HasMSIX:   true,
+		MSIXConfig: &MSIXConfig{
+			NumVectors: 4,
+			TableBIR: 2, TableOffset: 0x400, TableBARSize: 0x2000,
+			PBABIR: 4, PBAOffset: 0x800, PBABARSize: 0x1000,
+		},
+	}
+
+	sv, err := GenerateBarControllerSV(cfg)
+	if err != nil {
+		t.Fatalf("GenerateBarControllerSV: %v", err)
+	}
+	for _, want := range []string{
+		"wire msix_wr_table_select = wr_valid && wr_bar[2]",
+		"wire msix_wr_pba_select   = wr_valid && wr_bar[4]",
+		"wire msix_rd_table_select = rd_req_valid && rd_req_bar[2]",
+		"wire msix_rd_pba_select   = rd_req_valid && rd_req_bar[4]",
+	} {
+		if !strings.Contains(sv, want) {
+			t.Errorf("generated controller lacks BIR-qualified MSI-X route %q", want)
+		}
+	}
+	for _, want := range []string{
+		"wr_valid && wr_bar[2] && bar0_wr_hit && !msix_wr_table_select && !msix_wr_pba_select",
+		"wr_valid && wr_bar[4] && (wr_addr < 4096) && !msix_wr_table_select && !msix_wr_pba_select",
+	} {
+		if !strings.Contains(sv, want) {
+			t.Errorf("generated controller endpoint write path lacks MSI-X exclusion %q", want)
+		}
+	}
+	block := systemVerilogInstance(sv, "pcileech_msix_table #(")
+	if block == "" {
+		t.Fatal("MSI-X table instance missing")
+	}
+	for _, want := range []string{
+		".TABLE_BIR", "( 2", "32'h00000400",
+		".PBA_BIR", "( 4", "32'h00000800",
+		".wr_table_select", ".wr_pba_select", ".rd_table_select", ".rd_pba_select",
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("MSI-X instance does not preserve/connect routing token %q", want)
+		}
+	}
+}
+
+func TestBarResponseArbiterRandomizedCollisionScoreboard(t *testing.T) {
+	arbiter, err := GenerateBarRspArbiterSV(&SVGeneratorConfig{})
+	if err != nil {
+		t.Fatalf("GenerateBarRspArbiterSV: %v", err)
+	}
+	verilator, err := exec.LookPath("verilator")
+	if err != nil {
+		t.Skip("verilator not installed")
+	}
+	dir := t.TempDir()
+	arbiterPath := filepath.Join(dir, "pcileech_bar_rsp_arbiter.sv")
+	tbPath := filepath.Join(dir, "tb.sv")
+	if err := os.WriteFile(arbiterPath, []byte(arbiter), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tbPath, []byte(barResponseArbiterTestbench), 0600); err != nil {
+		t.Fatal(err)
+	}
+	objDir := filepath.Join(dir, "obj")
+	cmd := exec.Command(verilator, "--binary", "--timing", "-Wno-fatal", "--top-module", "tb", "--Mdir", objDir, "-o", "sim", arbiterPath, tbPath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("verilator build: %v\n%s", err, output)
+	}
+	sim := filepath.Join(objDir, "sim")
+	if output, err := exec.Command(sim).CombinedOutput(); err != nil {
+		t.Fatalf("arbiter simulation: %v\n%s", err, output)
+	}
+}
+
+
+const barResponseArbiterTestbench = "`timescale 1ns/1ps\n" +
+	"module tb;\n" +
+	"reg clk = 0;\n" +
+	"reg rst = 1;\n" +
+	"reg [6:0] in_valid = 0;\n" +
+	"reg [87:0] in_ctx [0:6];\n" +
+	"reg [31:0] in_data [0:6];\n" +
+	"wire [6:0] in_ready;\n" +
+	"wire out_valid;\n" +
+	"wire [87:0] out_ctx;\n" +
+	"wire [31:0] out_data;\n" +
+	"reg expected_valid [0:8191];\n" +
+	"reg seen [0:8191];\n" +
+	"reg [31:0] expected_data [0:8191];\n" +
+	"integer next_id = 0;\n" +
+	"integer accepted = 0;\n" +
+	"integer received = 0;\n" +
+	"reg saw_backpressure = 0;\n" +
+	"reg saw_collision = 0;\n" +
+	"integer cycle;\n" +
+	"integer source;\n" +
+	"integer id;\n" +
+	"reg [31:0] rng = 32'h51A7C3E9;\n" +
+	"always #1 clk = ~clk;\n" +
+	"pcileech_bar_rsp_arbiter dut(.clk(clk), .rst(rst), .in_valid(in_valid), .in_ctx(in_ctx), .in_data(in_data), .in_ready(in_ready), .out_valid(out_valid), .out_ctx(out_ctx), .out_data(out_data));\n" +
+	"task sample;\n" +
+	"integer s;\n" +
+	"integer accepted_mask;\n" +
+	"begin\n" +
+	"accepted_mask = 0;\n" +
+	"for (s = 0; s < 7; s = s + 1) begin\n" +
+	"if (in_valid[s] && in_ready[s]) begin\n" +
+	"id = in_ctx[s][31:0];\n" +
+	"expected_valid[id] = 1;\n" +
+	"expected_data[id] = in_data[s];\n" +
+	"accepted = accepted + 1;\n" +
+	"accepted_mask = accepted_mask | (1 << s);\n" +
+	"end\n" +
+	"if (in_valid[s] && !in_ready[s]) saw_backpressure = 1;\n" +
+	"end\n" +
+	"if ((accepted_mask & 1) != 0 && (accepted_mask & 8) != 0) saw_collision = 1;\n" +
+	"if (out_valid) begin\n" +
+	"id = out_ctx[31:0];\n" +
+	"if (id < 0 || id >= 8192 || !expected_valid[id] || seen[id]) $fatal(1, \"unexpected or duplicate response id=%0d\", id);\n" +
+	"if (out_data !== expected_data[id]) $fatal(1, \"data mismatch id=%0d got=%08x want=%08x\", id, out_data, expected_data[id]);\n" +
+	"seen[id] = 1;\n" +
+	"received = received + 1;\n" +
+	"end\n" +
+	"end\n" +
+	"endtask\n" +
+	"initial begin\n" +
+	"for (source = 0; source < 7; source = source + 1) begin in_ctx[source] = 0; in_data[source] = 0; end\n" +
+	"for (id = 0; id < 8192; id = id + 1) begin expected_valid[id] = 0; seen[id] = 0; expected_data[id] = 0; end\n" +
+	"repeat (4) @(posedge clk);\n" +
+	"rst = 0;\n" +
+	"for (cycle = 0; cycle < 1200; cycle = cycle + 1) begin\n" +
+	"@(negedge clk);\n" +
+	"for (source = 0; source < 7; source = source + 1) begin\n" +
+	"if (!(in_valid[source] && !in_ready[source])) begin\n" +
+	"rng = {rng[30:0], rng[31] ^ rng[21] ^ rng[1] ^ rng[0]};\n" +
+	"if (rng[2:0] != 0 && next_id < 8192) begin\n" +
+	"in_valid[source] = 1;\n" +
+	"in_ctx[source] = {56'd0, next_id[31:0]};\n" +
+	"in_data[source] = 32'hA5000000 ^ next_id ^ (source << 20);\n" +
+	"next_id = next_id + 1;\n" +
+	"end else in_valid[source] = 0;\n" +
+	"end\n" +
+	"end\n" +
+	"@(posedge clk); sample();\n" +
+	"end\n" +
+	"@(negedge clk); in_valid = 0;\n" +
+	"for (cycle = 0; cycle < 10000 && received < accepted; cycle = cycle + 1) begin @(posedge clk); sample(); end\n" +
+	"if (received != accepted) $fatal(1, \"lost responses accepted=%0d received=%0d\", accepted, received);\n" +
+	"if (!saw_collision) $fatal(1, \"no primary-secondary collision exercised\");\n" +
+	"if (!saw_backpressure) $fatal(1, \"no input backpressure exercised\");\n" +
+	"$finish;\n" +
+	"end\n" +
+	"endmodule\n"
+
+
+func systemVerilogInstance(sv, start string) string {
+	begin := strings.Index(sv, start)
+	if begin < 0 {
+		return ""
+	}
+	end := strings.Index(sv[begin:], "\n    );")
+	if end < 0 {
+		return sv[begin:]
+	}
+	return sv[begin : begin+end+len("\n    );")]
+}

--- a/internal/firmware/svgen/templates/bar_controller.sv.tmpl
+++ b/internal/firmware/svgen/templates/bar_controller.sv.tmpl
@@ -8,6 +8,7 @@
 
 `timescale 1ns / 1ps
 `include "pcileech_header.svh"
+`default_nettype none
 
 module pcileech_tlps128_bar_controller(
     input                   rst,
@@ -58,10 +59,14 @@ module pcileech_tlps128_bar_controller(
     wire [31:0] rd_rsp_data;
     wire        rd_rsp_valid;
 
+    wire [31:0] wr_addr_bar0     = wr_addr;
+    wire [31:0] rd_req_addr_bar0 = rd_req_addr;
 {{ if .BARModel }}
-    localparam [31:0] BAR0_ADDR_MASK = 32'h{{ printf "%08X" (sub .BARModel.Size 1) }}; // BAR0 aperture mask (Bar0Size)
-    wire [31:0] wr_addr_bar0     = wr_addr     & BAR0_ADDR_MASK;
-    wire [31:0] rd_req_addr_bar0 = rd_req_addr & BAR0_ADDR_MASK;
+    wire        bar0_wr_hit      = wr_addr < {{ .BARModel.Size }};
+    wire        bar0_rd_hit      = rd_req_addr < {{ .BARModel.Size }};
+{{ else }}
+    wire        bar0_wr_hit      = wr_addr < {{ .Bar0Size }};
+    wire        bar0_rd_hit      = rd_req_addr < {{ .Bar0Size }};
 {{ end }}
 
 
@@ -267,6 +272,16 @@ module pcileech_tlps128_bar_controller(
     wire bar0_buf_write = (bar0_spill_valid && !bar0_buf_full) ||
                           (!bar0_spill_valid && bar0_raw_valid && !bar0_buf_full);
 {{ end }}
+    wire [87:0] bar_base_ctx[7];
+    wire [31:0] bar_base_data[7];
+    wire [6:0]  bar_base_valid;
+    wire [87:0] bar_rsp_ctx[7];
+    wire [31:0] bar_rsp_data[7];
+    wire [6:0]  bar_rsp_valid;
+    assign bar_base_ctx[6]   = 88'h0;
+    assign bar_base_data[6]  = 32'h0;
+    assign bar_base_valid[6] = 1'b0;
+
 {{ if or .LatencyConfig .MSIXConfig }}
     // BAR0 into the read mux. NVMe bypasses the latency emulator so CC.EN<->
     // CSTS.RDY polling sees fresh reads (a stale CSTS=0 fails ControllerEnable).
@@ -285,21 +300,26 @@ module pcileech_tlps128_bar_controller(
     assign bar0_base_valid = bar0_emu_valid;
 {{ end }}
 {{ end }}
+{{ if and .BARModel (or .LatencyConfig .MSIXConfig) }}
+    assign bar_base_ctx[{{ .BARModel.BIR }}]   = bar0_base_ctx;
+    assign bar_base_data[{{ .BARModel.BIR }}]  = bar0_base_data;
+    assign bar_base_valid[{{ .BARModel.BIR }}] = bar0_base_valid;
+{{ end }}
 
 {{ if .MSIXConfig }}
     wire [87:0] msix_rsp_ctx;
     wire [31:0] msix_rsp_data;
     wire        msix_rsp_valid;
+    wire [2:0]  msix_rsp_bir;
     wire        msix_addr_hit;
-{{ if eq .DeviceClass "nvme" }}
-    // NVMe responder <-> MSI-X table (per-vector select) and <-> BRAM disk cache.
+{{ end }}
+{{ if and (eq .DeviceClass "nvme") .NVMeIdentify }}
     wire [15:0] nvme_msix_vector_select;
     wire [63:0] nvme_msix_vector_addr;
     wire [31:0] nvme_msix_vector_data;
     wire        nvme_msix_vector_masked;
     wire        nvme_msix_pba_set_valid;
     wire [15:0] nvme_msix_pba_set_vector;
-
     wire        nvme_disk_req_valid;
     wire        nvme_disk_req_write;
     wire        nvme_disk_req_flush;
@@ -311,44 +331,40 @@ module pcileech_tlps128_bar_controller(
     wire        nvme_disk_req_hit;
     wire        nvme_disk_busy;
     wire        nvme_disk_error;
+{{ if not .MSIXConfig }}    assign nvme_msix_vector_addr   = 64'h0;
+    assign nvme_msix_vector_data   = 32'h0;
+    assign nvme_msix_vector_masked = 1'b1;
+{{ end }}{{ end }}
+
+
+{{ range .BARSlots }}
+    assign bar_rsp_ctx[{{ .BIR }}]   = bar_base_ctx[{{ .BIR }}];
+    assign bar_rsp_data[{{ .BIR }}]  = bar_base_data[{{ .BIR }}];
+    assign bar_rsp_valid[{{ .BIR }}] = bar_base_valid[{{ .BIR }}];
 {{ end }}
+{{ if .MSIXConfig }}    assign bar_rsp_ctx[6]   = msix_rsp_ctx;
+    assign bar_rsp_data[6]  = msix_rsp_data;
+    assign bar_rsp_valid[6] = msix_rsp_valid;
+{{ else }}    assign bar_rsp_ctx[6]   = 88'h0;
+    assign bar_rsp_data[6]  = 32'h0;
+    assign bar_rsp_valid[6] = 1'b0;
 {{ end }}
+    wire [6:0] bar_rsp_ready;
+    pcileech_bar_rsp_arbiter i_bar_rsp_arbiter(
+        .clk        ( clk           ),
+        .rst        ( rst           ),
+        .in_valid   ( bar_rsp_valid ),
+        .in_ctx     ( bar_rsp_ctx   ),
+        .in_data    ( bar_rsp_data  ),
+        .in_ready   ( bar_rsp_ready ),
+        .out_valid  ( rd_rsp_valid  ),
+        .out_ctx    ( rd_rsp_ctx    ),
+        .out_data   ( rd_rsp_data   )
+    );
 
-    wire [87:0] bar_rsp_ctx[7];
-    wire [31:0] bar_rsp_data[7];
-    wire        bar_rsp_valid[7];
+{{ if or .BARModel (not .DonorBARTopology) }}
 
-{{ if .MSIXConfig }}
-    // MSI-X table read wins, else BAR0 base (raw for NVMe, emu otherwise).
-    assign bar_rsp_ctx[0]   = msix_rsp_valid ? msix_rsp_ctx   : bar0_base_ctx;
-    assign bar_rsp_data[0]  = msix_rsp_valid ? msix_rsp_data  : bar0_base_data;
-    assign bar_rsp_valid[0] = msix_rsp_valid || bar0_base_valid;
-{{ else if .LatencyConfig }}
-    assign bar_rsp_ctx[0]   = bar0_base_ctx;
-    assign bar_rsp_data[0]  = bar0_base_data;
-    assign bar_rsp_valid[0] = bar0_base_valid;
-{{ end }}
-
-    // response mux
-    assign rd_rsp_ctx = bar_rsp_valid[0] ? bar_rsp_ctx[0] :
-                        bar_rsp_valid[1] ? bar_rsp_ctx[1] :
-                        bar_rsp_valid[2] ? bar_rsp_ctx[2] :
-                        bar_rsp_valid[3] ? bar_rsp_ctx[3] :
-                        bar_rsp_valid[4] ? bar_rsp_ctx[4] :
-                        bar_rsp_valid[5] ? bar_rsp_ctx[5] :
-                        bar_rsp_valid[6] ? bar_rsp_ctx[6] : 0;
-    assign rd_rsp_data = bar_rsp_valid[0] ? bar_rsp_data[0] :
-                        bar_rsp_valid[1] ? bar_rsp_data[1] :
-                        bar_rsp_valid[2] ? bar_rsp_data[2] :
-                        bar_rsp_valid[3] ? bar_rsp_data[3] :
-                        bar_rsp_valid[4] ? bar_rsp_data[4] :
-                        bar_rsp_valid[5] ? bar_rsp_data[5] :
-                        bar_rsp_valid[6] ? bar_rsp_data[6] : 0;
-    assign rd_rsp_valid = bar_rsp_valid[0] || bar_rsp_valid[1] || bar_rsp_valid[2] || bar_rsp_valid[3] || bar_rsp_valid[4] || bar_rsp_valid[5] || bar_rsp_valid[6];
-
-    // BAR0: {{ if .BARModel }}device-specific{{ else }}generic zerowrite4k{{ end }}
-
-{{ if and (eq .DeviceClass "nvme") .BARModel }}
+{{ if and (eq .DeviceClass "nvme") .HasClassEndpoint }}
     // NVMe register wires -- from bar_impl_device to admin responder
     wire [31:0] nvme_reg_cc;
     wire [31:0] nvme_reg_aqa;
@@ -361,20 +377,20 @@ module pcileech_tlps128_bar_controller(
 
 {{ if .BARModel }}
     pcileech_bar_impl_device #(
-        .BAR_SIZE       ( {{ .BARModel.Size }} ) // var Bar0Size
-    ) i_bar0(
+        .BAR_SIZE       ( {{ .BARModel.Size }} )
+    ) i_bar{{ .BARModel.BIR }}(
 {{ else }}
     pcileech_bar_impl_zerowrite4k i_bar0(
 {{ end }}
         .rst            ( rst                           ),
         .clk            ( clk                           ),
-        .wr_addr        ( {{ if .BARModel }}wr_addr_bar0{{ else }}wr_addr{{ end }}                       ),
+        .wr_addr        ( {{ if .BARModel }}wr_addr_bar0{{ else }}wr_addr{{ end }} ),
         .wr_be          ( wr_be                         ),
         .wr_data        ( wr_data                       ),
-        .wr_valid       ( wr_valid && wr_bar[0]         ),
+        .wr_valid       ( wr_valid && wr_bar[{{ if .BARModel }}{{ .BARModel.BIR }}{{ else }}0{{ end }}]{{ if .BARModel }} && bar0_wr_hit{{ end }}{{ if .MSIXConfig }} && !msix_wr_table_select && !msix_wr_pba_select{{ end }} ),
         .rd_req_ctx     ( rd_req_ctx                    ),
-        .rd_req_addr    ( {{ if .BARModel }}rd_req_addr_bar0{{ else }}rd_req_addr{{ end }}                   ),
-        .rd_req_valid   ( rd_req_valid && rd_req_bar[0]{{ if .MSIXConfig }} && !msix_addr_hit{{ end }} ),
+        .rd_req_addr    ( {{ if .BARModel }}rd_req_addr_bar0{{ else }}rd_req_addr{{ end }} ),
+        .rd_req_valid   ( rd_req_valid && rd_req_bar[{{ if .BARModel }}{{ .BARModel.BIR }}{{ else }}0{{ end }}]{{ if .BARModel }} && bar0_rd_hit{{ end }}{{ if .MSIXConfig }} && !msix_addr_hit{{ end }} ),
 {{ if .LatencyConfig }}
         .rd_rsp_ctx     ( bar0_raw_ctx                  ),
         .rd_rsp_data    ( bar0_raw_data                 ),
@@ -384,11 +400,11 @@ module pcileech_tlps128_bar_controller(
         .rd_rsp_data    ( bar0_base_data                ),
         .rd_rsp_valid   ( bar0_base_valid               )
 {{ else }}
-        .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
-        .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
+        .rd_rsp_ctx     ( bar_base_ctx[{{ if .BARModel }}{{ .BARModel.BIR }}{{ else }}0{{ end }}]   ),
+        .rd_rsp_data    ( bar_base_data[{{ if .BARModel }}{{ .BARModel.BIR }}{{ else }}0{{ end }}]  ),
+        .rd_rsp_valid   ( bar_base_valid[{{ if .BARModel }}{{ .BARModel.BIR }}{{ else }}0{{ end }}] )
 {{ end }}
-{{ if and (eq .DeviceClass "nvme") .BARModel }}        ,
+{{ if and (eq .DeviceClass "nvme") .HasClassEndpoint }}        ,
         .nvme_cc        ( nvme_reg_cc                   ),
         .nvme_aqa       ( nvme_reg_aqa                  ),
         .nvme_asq_lo    ( nvme_reg_asq_lo               ),
@@ -396,7 +412,7 @@ module pcileech_tlps128_bar_controller(
         .nvme_acq_lo    ( nvme_reg_acq_lo               ),
         .nvme_acq_hi    ( nvme_reg_acq_hi               ),
         .nvme_csts      ( nvme_reg_csts                 )
-{{ end }}{{ if and (eq .DeviceClass "audio") .BARModel }}        ,
+{{ end }}{{ if and (eq .DeviceClass "audio") .HasClassEndpoint }}        ,
         // HDA RIRB DMA bridge ports
         .dma_req_valid   ( hda_dma_req_valid             ),
         .dma_resp_lo     ( hda_dma_resp_lo               ),
@@ -412,6 +428,7 @@ module pcileech_tlps128_bar_controller(
         .crst_falling    ( hda_crst_falling              )
 {{ end }}
     );
+{{ end }}
 
 {{ if .LatencyConfig }}
     tlp_latency_emulator i_latency_emu(
@@ -436,8 +453,8 @@ module pcileech_tlps128_bar_controller(
         .rsp_ctx        ( bar0_emu_ctx                  ),
         .rsp_data       ( bar0_emu_data                 ),
 {{ end }}
-        .rsp_ready      ( bar0_emu_ready                ),
-        .wr_valid       ( wr_valid && wr_bar[0]         ),
+        .rsp_ready      ( {{ if eq .DeviceClass "nvme" }}bar0_emu_ready{{ else }}bar_rsp_ready[{{ if .BARModel }}{{ .BARModel.BIR }}{{ else }}0{{ end }}]{{ end }} ),
+        .wr_valid       ( wr_valid && wr_bar[{{ if .BARModel }}{{ .BARModel.BIR }}{{ else }}0{{ end }}]{{ if .BARModel }} && bar0_wr_hit{{ end }}{{ if .MSIXConfig }} && !msix_wr_table_select && !msix_wr_pba_select{{ end }} ),
         .wr_addr        ( {{ if .BARModel }}wr_addr_bar0{{ else }}wr_addr{{ end }} ),
         .wr_ack         ( bar0_wr_ack                   ),
         .busy           ( bar0_emu_busy                 )
@@ -523,24 +540,44 @@ module pcileech_tlps128_bar_controller(
         end
     end
 
+    wire msix_wr_table_select = wr_valid && wr_bar[{{ .MSIXConfig.TableBIR }}] &&
+                                (wr_addr >= {{ .MSIXConfig.TableOffset }}) &&
+                                (wr_addr < {{ .MSIXConfig.TableEnd }});
+    wire msix_wr_pba_select   = wr_valid && wr_bar[{{ .MSIXConfig.PBABIR }}] &&
+                                (wr_addr >= {{ .MSIXConfig.PBAOffset }}) &&
+                                (wr_addr < {{ .MSIXConfig.PBAEnd }});
+    wire msix_rd_table_select = rd_req_valid && rd_req_bar[{{ .MSIXConfig.TableBIR }}] &&
+                                (rd_req_addr >= {{ .MSIXConfig.TableOffset }}) &&
+                                (rd_req_addr < {{ .MSIXConfig.TableEnd }});
+    wire msix_rd_pba_select   = rd_req_valid && rd_req_bar[{{ .MSIXConfig.PBABIR }}] &&
+                                (rd_req_addr >= {{ .MSIXConfig.PBAOffset }}) &&
+                                (rd_req_addr < {{ .MSIXConfig.PBAEnd }});
+
     pcileech_msix_table #(
         .NUM_VECTORS    ( {{ .MSIXConfig.NumVectors }}  ),
+        .TABLE_BIR      ( {{ .MSIXConfig.TableBIR }}     ),
         .TABLE_OFFSET   ( 32'h{{ printf "%08X" .MSIXConfig.TableOffset }} ),
+        .PBA_BIR        ( {{ .MSIXConfig.PBABIR }}       ),
         .PBA_OFFSET     ( 32'h{{ printf "%08X" .MSIXConfig.PBAOffset }}   )
     ) i_msix_table(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
-        .wr_addr        ( {{ if .BARModel }}wr_addr_bar0{{ else }}wr_addr{{ end }}                       ),
+        .wr_addr        ( wr_addr                       ),
         .wr_data        ( wr_data                       ),
         .wr_be          ( wr_be                         ),
-        .wr_valid       ( wr_valid && wr_bar[0]         ),
+        .wr_valid       ( wr_valid                      ),
+        .wr_table_select( msix_wr_table_select          ),
+        .wr_pba_select  ( msix_wr_pba_select            ),
         .rd_req_ctx     ( rd_req_ctx                    ),
-        .rd_req_addr    ( {{ if .BARModel }}rd_req_addr_bar0{{ else }}rd_req_addr{{ end }}                   ),
-        .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
+        .rd_req_addr    ( rd_req_addr                   ),
+        .rd_req_valid   ( msix_rd_table_select || msix_rd_pba_select ),
+        .rd_table_select( msix_rd_table_select          ),
+        .rd_pba_select  ( msix_rd_pba_select            ),
         .rd_rsp_ctx     ( msix_rsp_ctx                  ),
         .rd_rsp_data    ( msix_rsp_data                 ),
         .rd_rsp_valid   ( msix_rsp_valid                ),
-{{ if eq .DeviceClass "nvme" }}        // per-vector read for the NVMe responder (admin=0, IO queue=its IV)
+        .rd_rsp_bir     ( msix_rsp_bir                  ),
+{{ if and (eq .DeviceClass "nvme") .NVMeIdentify }}
         .vector_select  ( nvme_msix_vector_select       ),
         .vector_addr    ( nvme_msix_vector_addr         ),
         .vector_data    ( nvme_msix_vector_data         ),
@@ -557,7 +594,7 @@ module pcileech_tlps128_bar_controller(
     );
 {{ end }}
 
-{{ if and (eq .DeviceClass "audio") .BARModel }}
+{{ if and (eq .DeviceClass "audio") .HasClassEndpoint }}
     // ========================================================================
     // HDA RIRB DMA Bridge
     // Writes fake RIRB responses to system memory so hdaudio.sys can read
@@ -624,7 +661,7 @@ module pcileech_tlps128_bar_controller(
 
 {{ end }}
 
-{{ if eq .DeviceClass "nvme" }}
+{{ if and (eq .DeviceClass "nvme") .NVMeIdentify }}
     wire        nvme_msix_trigger;
 
 {{ end }}
@@ -642,7 +679,7 @@ module pcileech_tlps128_bar_controller(
 
     // doorbell page: bit[2]=SQ/CQ, bits[13:3]=QID
     wire [31:0] nvme_db_base  = 32'h{{ printf "%08X" .NVMeSQ0DoorbellOffset }};
-    wire        nvme_db_wr    = wr_valid && wr_bar[0] &&
+    wire        nvme_db_wr    = wr_valid && wr_bar[{{ .PrimaryBIR }}] && bar0_wr_hit &&
                                 (wr_addr_bar0 >= nvme_db_base) &&
                                 (wr_addr_bar0 <  nvme_db_base + 32'h00001000);
     wire [31:0] nvme_db_off   = wr_addr_bar0 - nvme_db_base;
@@ -651,7 +688,7 @@ module pcileech_tlps128_bar_controller(
     wire [15:0] nvme_db_val   = wr_data[15:0];
 
     // CC register write -> enable/disable strobes
-    wire        nvme_cc_wr         = wr_valid && wr_bar[0] &&
+    wire        nvme_cc_wr         = wr_valid && wr_bar[{{ .PrimaryBIR }}] && bar0_wr_hit &&
                                      ((wr_addr_bar0 & 32'hFFFFFFFC) == 32'h00000014);
     wire        nvme_cc_enable_wr  = nvme_cc_wr && wr_data[0];
     wire        nvme_cc_disable_wr = nvme_cc_wr && !wr_data[0];
@@ -871,7 +908,7 @@ module pcileech_tlps128_bar_controller(
     assign tlps_rdeng.tready = tlps_out.tready;
 {{ end }}
 
-{{ if and (eq .DeviceClass "audio") .BARModel }}{{ if not (and (eq .DeviceClass "nvme") .NVMeIdentify) }}
+{{ if and (eq .DeviceClass "audio") .HasClassEndpoint }}{{ if not (and (eq .DeviceClass "nvme") .NVMeIdentify) }}
     // HDA-only build: mux HDA DMA TLPs with rdengine BAR responses
     //
     // fairness: after 8 consecutive DMA TLP words a 1-cycle gap is forced so
@@ -899,7 +936,7 @@ module pcileech_tlps128_bar_controller(
 {{ end }}{{
  end }}
 
-{{ if not (or (and (eq .DeviceClass "nvme") .NVMeIdentify) (and (eq .DeviceClass "audio") .BARModel)) }}
+{{ if not (or (and (eq .DeviceClass "nvme") .NVMeIdentify) (and (eq .DeviceClass "audio") .HasClassEndpoint)) }}
     // no DMA bridge: rdengine output goes straight to tlps_out
     assign tlps_out.tdata    = tlps_rdeng.tdata;
     assign tlps_out.tkeepdw  = tlps_rdeng.tkeepdw;
@@ -910,62 +947,43 @@ module pcileech_tlps128_bar_controller(
     assign tlps_rdeng.tready = tlps_out.tready;
 {{ end }}
 
-    // BAR1: address loopback
-    pcileech_bar_impl_loopaddr i_bar1(
+{{ range .BARSlots }}{{ if not .Primary }}
+{{ if .Model }}
+    {{ .ModuleName }} #(
+        .BAR_SIZE       ( {{ .Model.Size }} )
+    ) i_bar{{ .BIR }}(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
         .wr_be          ( wr_be                         ),
         .wr_data        ( wr_data                       ),
-        .wr_valid       ( wr_valid && wr_bar[1]         ),
+        .wr_valid       ( wr_valid && wr_bar[{{ .BIR }}] && (wr_addr < {{ .Model.Size }}){{ if $.MSIXConfig }} && !msix_wr_table_select && !msix_wr_pba_select{{ end }} ),
         .rd_req_ctx     ( rd_req_ctx                    ),
         .rd_req_addr    ( rd_req_addr                   ),
-        .rd_req_valid   ( rd_req_valid && rd_req_bar[1] ),
-        .rd_rsp_ctx     ( bar_rsp_ctx[1]                ),
-        .rd_rsp_data    ( bar_rsp_data[1]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[1]              )
+        .rd_req_valid   ( rd_req_valid && rd_req_bar[{{ .BIR }}] && (rd_req_addr < {{ .Model.Size }}){{ if $.MSIXConfig }} && !msix_addr_hit{{ end }} ),
+        .rd_rsp_ctx     ( bar_base_ctx[{{ .BIR }}]      ),
+        .rd_rsp_data    ( bar_base_data[{{ .BIR }}]     ),
+        .rd_rsp_valid   ( bar_base_valid[{{ .BIR }}]    )
     );
-
-    // BAR2: MSI doorbell interrupt - write to offset 0x00 triggers MSI
-    wire        bar2_intr_req;
-
-    pcileech_bar_impl_msi i_bar2(
+{{ else }}
+    pcileech_bar_impl_none i_bar{{ .BIR }}(
         .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
         .wr_be          ( wr_be                         ),
         .wr_data        ( wr_data                       ),
-        .wr_valid       ( wr_valid && wr_bar[2]         ),
+        .wr_valid       ( wr_valid && wr_bar[{{ .BIR }}] ),
         .rd_req_ctx     ( rd_req_ctx                    ),
         .rd_req_addr    ( rd_req_addr                   ),
-        .rd_req_valid   ( rd_req_valid && rd_req_bar[2] ),
-        .rd_rsp_ctx     ( bar_rsp_ctx[2]                ),
-        .rd_rsp_data    ( bar_rsp_data[2]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[2]              ),
-        .intr_req       ( bar2_intr_req                 )
+        .rd_req_valid   ( rd_req_valid && rd_req_bar[{{ .BIR }}] ),
+        .rd_rsp_ctx     ( bar_base_ctx[{{ .BIR }}]      ),
+        .rd_rsp_data    ( bar_base_data[{{ .BIR }}]     ),
+        .rd_rsp_valid   ( bar_base_valid[{{ .BIR }}]    ),
+        .intr_req       (                               )
     );
+{{ end }}{{ end }}{{ end }}
 
-    // BAR3-6: unimplemented
-    genvar gi;
-    generate
-        for (gi = 3; gi < 7; gi = gi + 1) begin : gen_bar_none
-            pcileech_bar_impl_none i_bar_none(
-                .rst            ( rst                           ),
-                .clk            ( clk                           ),
-                .wr_addr        ( wr_addr                       ),
-                .wr_be          ( wr_be                         ),
-                .wr_data        ( wr_data                       ),
-                .wr_valid       ( wr_valid && wr_bar[gi]        ),
-                .rd_req_ctx     ( rd_req_ctx                    ),
-                .rd_req_addr    ( rd_req_addr                   ),
-                .rd_req_valid   ( rd_req_valid && rd_req_bar[gi]),
-                .rd_rsp_ctx     ( bar_rsp_ctx[gi]               ),
-                .rd_rsp_data    ( bar_rsp_data[gi]              ),
-                .rd_rsp_valid   ( bar_rsp_valid[gi]             )
-            );
-        end
-    endgenerate
-
-    assign intr_req = bar2_intr_req{{ if eq .DeviceClass "audio" }} | hda_intr_req{{ end }}{{ if eq .DeviceClass "nvme" }} | nvme_msix_trigger{{ end }};
+    assign intr_req = 1'b0{{ if and (eq .DeviceClass "audio") .HasClassEndpoint }} | hda_intr_req{{ end }}{{ if and (eq .DeviceClass "nvme") .NVMeIdentify }} | nvme_msix_trigger{{ end }};
 
 endmodule
+`default_nettype wire

--- a/internal/firmware/svgen/templates/bar_impl_device.sv.tmpl
+++ b/internal/firmware/svgen/templates/bar_impl_device.sv.tmpl
@@ -7,9 +7,9 @@
 {{ end }}//
 
 `timescale 1ns / 1ps
-{{ if .BARModel }}
-module pcileech_bar_impl_device #(
-    parameter BAR_SIZE = {{ .BARModel.Size }}  // variable Bar0Size from barmodel/compute
+{{ if and .BARModel .BARModel.Registers }}
+module {{ .BARImplementationModuleName }} #(
+    parameter BAR_SIZE = {{ .BARModel.Size }}
 )(
     input               rst,
     input               clk,
@@ -52,9 +52,10 @@ module pcileech_bar_impl_device #(
     output wire [31:0]  nvme_csts
 {{ end }});
 
-    localparam [31:0] BAR_ADDR_MASK = BAR_SIZE - 1;
-    wire [31:0] wr_offset     = wr_addr     & BAR_ADDR_MASK;
-    wire [31:0] rd_req_offset = rd_req_addr & BAR_ADDR_MASK;
+    wire wr_in_range = (wr_addr < BAR_SIZE);
+    wire rd_in_range = (rd_req_addr < BAR_SIZE);
+    wire [31:0] wr_offset     = wr_addr;
+    wire [31:0] rd_req_offset = rd_req_addr;
 
     // registers
 {{ range .BARModel.Registers }}
@@ -1042,7 +1043,7 @@ module pcileech_bar_impl_device #(
         if (rst) begin
 {{ range .BARModel.Registers }}{{ if not .IsFSMDriven }}            reg_0x{{ hex08 .Offset }} <= {{ mul .Width 8 }}'h{{ hex08 .Reset }};
 {{ end }}{{ end }}        end
-        else if (wr_valid) begin
+        else if (wr_valid && wr_in_range) begin
             case (wr_offset & 32'hFFFFFFFC)
 {{ range .BARModel.Registers }}{{ if and (ne .W1CMask 0) (not .IsRW1C) (not .IsFSMDriven) }}                32'h{{ hex08 (alignedOffset .Offset) }}: begin
                     // W1C bits clear where wr_data is 1; RW bits take wr_data; RO bits hold.
@@ -1098,9 +1099,9 @@ module pcileech_bar_impl_device #(
 
     always @(posedge clk) begin
         rd_req_ctx_d1   <= rd_req_ctx;
-        rd_req_valid_d1 <= rd_req_valid;
+        rd_req_valid_d1 <= rd_req_valid && rd_in_range;
 
-        if (rd_req_valid) begin
+        if (rd_req_valid && rd_in_range) begin
             case (rd_req_offset & 32'hFFFFFFFC)
 {{ range .BARModel.Registers }}{{ if and (eq .Offset 0x24) (eq $.DeviceClass "audio") }}                32'h{{ hex08 (alignedOffset .Offset) }}: rd_data_d1 <= {reg_0x00000060[0], reg_0x00000060[0], 30'h0};  // INTSTS: GIS=CIS=INTFL
 {{ else if and (eq .Offset 0x48) (eq $.DeviceClass "audio") }}                32'h{{ hex08 (alignedOffset .Offset) }}: rd_data_d1 <= {reg_0x00000048[31:24], reg_0x00000048[23:16], 8'h00, reg_0x00000048[7:0]};  // live CORBRP + CORBWP
@@ -1122,8 +1123,8 @@ module pcileech_bar_impl_device #(
 
 {{ else }}
 // No learned register map - fallback to BRAM-based storage (supports variable Bar0Size + computed MSIX).
-module pcileech_bar_impl_device #(
-    parameter BAR_SIZE = {{ .Bar0Size }}
+module {{ .BARImplementationModuleName }} #(
+    parameter BAR_SIZE = {{ if .BARModel }}{{ .BARModel.Size }}{{ else }}{{ .Bar0Size }}{{ end }}
 )(
     input               rst,
     input               clk,
@@ -1142,36 +1143,41 @@ module pcileech_bar_impl_device #(
     output reg          rd_rsp_valid
 );
 
+    localparam BAR_STORAGE_BYTES = (BAR_SIZE > 4096) ? 4096 : BAR_SIZE;
+    localparam BAR_WORDS = (BAR_STORAGE_BYTES >= 4) ? (BAR_STORAGE_BYTES / 4) : 1;
+    localparam BAR_WORD_ADDR_BITS = (BAR_WORDS > 1) ? $clog2(BAR_WORDS) : 1;
+    reg [31:0] bar_mem [0:BAR_WORDS-1];
+    wire [BAR_WORD_ADDR_BITS-1:0] wr_word = wr_addr[BAR_WORD_ADDR_BITS+1:2];
+    wire [BAR_WORD_ADDR_BITS-1:0] rd_word = rd_req_addr[BAR_WORD_ADDR_BITS+1:2];
     reg [87:0] rd_req_ctx_d1;
-    reg        rd_req_valid_d1;
-    wire [31:0] doutb;
+    reg rd_req_valid_d1;
+    reg [31:0] rd_data_d1;
+    integer i;
+
+    initial for (i = 0; i < BAR_WORDS; i = i + 1) bar_mem[i] = 32'h00000000;
 
     always @(posedge clk) begin
-        rd_req_ctx_d1   <= rd_req_ctx;
-        rd_req_valid_d1 <= rd_req_valid;
-        rd_rsp_ctx      <= rd_req_ctx_d1;
-        rd_rsp_valid    <= rd_req_valid_d1;
-        rd_rsp_data     <= doutb;
+        rd_req_ctx_d1 <= rd_req_ctx;
+        rd_req_valid_d1 <= rd_req_valid && (rd_req_addr < BAR_SIZE);
+        if (rd_req_valid && (rd_req_addr < BAR_STORAGE_BYTES))
+            rd_data_d1 <= bar_mem[rd_word];
+        else
+            rd_data_d1     <= 32'h0;
+        rd_rsp_ctx <= rd_req_ctx_d1;
+        rd_rsp_valid <= rd_req_valid_d1;
+        rd_rsp_data <= rd_data_d1;
     end
 
-    localparam BAR_WORDS = (BAR_SIZE > 0) ? (BAR_SIZE / 4) : 1024;
-    reg [31:0] bar_mem [0:BAR_WORDS-1];
-    wire [31:0] bar_addr_mask = BAR_SIZE - 1;
-    wire [31:0] wa = wr_addr & bar_addr_mask;
-    wire [31:0] ra = rd_req_addr & bar_addr_mask;
-    integer i;
-    initial for (i = 0; i < BAR_WORDS; i = i + 1) bar_mem[i] = 32'h00000000;
     always @(posedge clk) begin
-        if (wr_valid) begin
-            if (wa[1:0] == 2'b00) begin
-                if (wr_be[0]) bar_mem[wa[31:2]][7:0]   <= wr_data[7:0];
-                if (wr_be[1]) bar_mem[wa[31:2]][15:8]  <= wr_data[15:8];
-                if (wr_be[2]) bar_mem[wa[31:2]][23:16] <= wr_data[23:16];
-                if (wr_be[3]) bar_mem[wa[31:2]][31:24] <= wr_data[31:24];
+        if (wr_valid && (wr_addr < BAR_STORAGE_BYTES)) begin
+            if (wr_addr[1:0] == 2'b00) begin
+                if (wr_be[0]) bar_mem[wr_word][7:0]   <= wr_data[7:0];
+                if (wr_be[1]) bar_mem[wr_word][15:8]  <= wr_data[15:8];
+                if (wr_be[2]) bar_mem[wr_word][23:16] <= wr_data[23:16];
+                if (wr_be[3]) bar_mem[wr_word][31:24] <= wr_data[31:24];
             end
         end
     end
-    assign doutb = bar_mem[ra[31:2]];
 
 {{ end }}
 endmodule

--- a/internal/firmware/svgen/templates/bar_rsp_arbiter.sv.tmpl
+++ b/internal/firmware/svgen/templates/bar_rsp_arbiter.sv.tmpl
@@ -1,0 +1,79 @@
+`timescale 1ns / 1ps
+`default_nettype none
+
+module pcileech_bar_rsp_arbiter (
+    input  wire          clk,
+    input  wire          rst,
+    input  wire [6:0]    in_valid,
+    input  wire [87:0]   in_ctx [0:6],
+    input  wire [31:0]   in_data [0:6],
+    output wire [6:0]    in_ready,
+    output wire          out_valid,
+    output wire [87:0]   out_ctx,
+    output wire [31:0]   out_data
+);
+    localparam integer FIFO_DEPTH = 32;
+    reg [87:0] ctx_mem [0:6][0:FIFO_DEPTH-1];
+    reg [31:0] data_mem [0:6][0:FIFO_DEPTH-1];
+    reg [4:0] wr_ptr [0:6];
+    reg [4:0] rd_ptr [0:6];
+    reg [5:0] count [0:6];
+    reg [2:0] rr_ptr;
+    reg [2:0] selected;
+    reg selected_valid;
+    wire [6:0] push = in_valid & in_ready;
+    genvar g;
+    generate
+        for (g = 0; g < 7; g = g + 1) begin : g_ready
+            assign in_ready[g] = count[g] < 6'd32;
+        end
+    endgenerate
+    integer scan;
+    reg [3:0] index;
+    always @* begin
+        selected = 3'd0;
+        selected_valid = 1'b0;
+        for (scan = 0; scan < 7; scan = scan + 1) begin
+            index = {1'b0, rr_ptr} + scan[3:0];
+            if (index >= 4'd7)
+                index = index - 4'd7;
+            if (!selected_valid && count[index[2:0]] != 0) begin
+                selected = index[2:0];
+                selected_valid = 1'b1;
+            end
+        end
+    end
+    assign out_valid = selected_valid;
+    assign out_ctx = selected_valid ? ctx_mem[selected][rd_ptr[selected]] : 88'h0;
+    assign out_data = selected_valid ? data_mem[selected][rd_ptr[selected]] : 32'h0;
+    integer k;
+    always @(posedge clk) begin
+        if (rst) begin
+            rr_ptr <= 3'd0;
+            for (k = 0; k < 7; k = k + 1) begin
+                wr_ptr[k] <= 5'd0;
+                rd_ptr[k] <= 5'd0;
+                count[k] <= 6'd0;
+            end
+        end else begin
+            for (k = 0; k < 7; k = k + 1) begin
+                if (push[k]) begin
+                    ctx_mem[k][wr_ptr[k]] <= in_ctx[k];
+                    data_mem[k][wr_ptr[k]] <= in_data[k];
+                    wr_ptr[k] <= wr_ptr[k] + 5'd1;
+                end
+                if (selected_valid && selected == k[2:0])
+                    rd_ptr[k] <= rd_ptr[k] + 5'd1;
+                case ({push[k], selected_valid && selected == k[2:0]})
+                    2'b10: count[k] <= count[k] + 6'd1;
+                    2'b01: count[k] <= count[k] - 6'd1;
+                    default: count[k] <= count[k];
+                endcase
+            end
+            if (selected_valid)
+                rr_ptr <= selected == 3'd6 ? 3'd0 : selected + 3'd1;
+        end
+    end
+endmodule
+
+`default_nettype wire

--- a/internal/firmware/svgen/templates/device_config.sv.tmpl
+++ b/internal/firmware/svgen/templates/device_config.sv.tmpl
@@ -38,12 +38,17 @@ package device_config;
     localparam CLASS_BASE       = 8'h{{ hex02 (classBase .ClassCode) }};
     localparam CLASS_SUB        = 8'h{{ hex02 (classSub .ClassCode) }};
     localparam CLASS_PROGIF     = 8'h{{ hex02 (classProgIF .ClassCode) }};
-{{ if .BARModel }}
-    // BAR0 is device-specific ({{ .Bar0Size }} bytes varsize, {{ len .BARModel.Registers }} registers)
+{{ if .BARModels }}
+{{ range .BARModels }}
+    localparam BAR{{ .BIR }}_PRESENT     = 1;
+    localparam BAR{{ .BIR }}_SIZE        = {{ .Size }};
+    localparam BAR{{ .BIR }}_REGS        = {{ len .Registers }};
+{{ end }}{{ else if .BARModel }}
+    localparam BAR0_PRESENT     = 1;
     localparam BAR0_SIZE        = {{ .Bar0Size }};
     localparam BAR0_REGS        = {{ len .BARModel.Registers }};
 {{ else }}
-    // BAR0 uses generic zerowrite (stock 4KB) or sized impl for computed Bar0Size+MSIX
+    localparam BAR0_PRESENT     = 0;
     localparam BAR0_SIZE        = {{ .Bar0Size }};
     localparam BAR0_REGS        = 0;
 {{ end }}
@@ -57,6 +62,8 @@ package device_config;
     localparam MSIX_NUM_VECTORS = {{ .MSIXConfig.NumVectors }};
     localparam MSIX_TABLE_OFF   = 32'h{{ printf "%08X" .MSIXConfig.TableOffset }};
     localparam MSIX_PBA_OFF     = 32'h{{ printf "%08X" .MSIXConfig.PBAOffset }};
+    localparam MSIX_TABLE_BIR   = {{ .MSIXConfig.TableBIR }};
+    localparam MSIX_PBA_BIR     = {{ .MSIXConfig.PBABIR }};
 {{ end }}
     // Feature flags
     localparam HAS_NVME_FSM     = {{ if eq .DeviceClass "nvme" }}1{{ else }}0{{ end }};

--- a/internal/firmware/svgen/templates/msix_table.sv.tmpl
+++ b/internal/firmware/svgen/templates/msix_table.sv.tmpl
@@ -8,10 +8,11 @@
 
 module pcileech_msix_table #(
     parameter NUM_VECTORS    = {{ .MSIXConfig.NumVectors }},
+    parameter TABLE_BIR      = {{ .MSIXConfig.TableBIR }},
     parameter TABLE_OFFSET   = 32'h{{ printf "%08X" .MSIXConfig.TableOffset }},
+    parameter PBA_BIR        = {{ .MSIXConfig.PBABIR }},
     parameter PBA_OFFSET     = 32'h{{ printf "%08X" .MSIXConfig.PBAOffset }},
-    parameter TABLE_ENTRIES  = NUM_VECTORS * 4, // DWORDs
-    parameter BAR_SIZE       = {{ .Bar0Size }}
+    parameter TABLE_ENTRIES  = NUM_VECTORS * 4
 )(
     input               rst,
     input               clk,
@@ -21,15 +22,20 @@ module pcileech_msix_table #(
     input [31:0]        wr_data,
     input [3:0]         wr_be,
     input               wr_valid,
+    input               wr_table_select,
+    input               wr_pba_select,
 
     // BAR read interface
     input [87:0]        rd_req_ctx,
     input [31:0]        rd_req_addr,
     input               rd_req_valid,
+    input               rd_table_select,
+    input               rd_pba_select,
 
     output reg [87:0]   rd_rsp_ctx,
     output reg [31:0]   rd_rsp_data,
     output reg          rd_rsp_valid,
+    output reg [2:0]    rd_rsp_bir,
 
     // Indexed vector read for the NVMe responder: admin completions use vector
     // 0, the I/O queue uses its programmed IV.  Registered (1-cycle latency) so
@@ -47,21 +53,18 @@ module pcileech_msix_table #(
     output              addr_hit  // request targets MSI-X region
 );
 
-    // address decode
-    localparam [31:0] BAR_ADDR_MASK = BAR_SIZE - 1;
     localparam TABLE_END = TABLE_OFFSET + NUM_VECTORS * 16;
     localparam PBA_SIZE  = ((NUM_VECTORS + 63) / 64) * 8;
     localparam PBA_END   = PBA_OFFSET + PBA_SIZE;
 
-    wire [31:0] wr_offset     = wr_addr     & BAR_ADDR_MASK;
-    wire [31:0] rd_req_offset = rd_req_addr & BAR_ADDR_MASK;
+    wire [31:0] wr_offset     = wr_addr;
+    wire [31:0] rd_req_offset = rd_req_addr;
 
-    wire is_table = (rd_req_offset >= TABLE_OFFSET) && (rd_req_offset < TABLE_END);
-    wire is_pba   = (rd_req_offset >= PBA_OFFSET) && (rd_req_offset < PBA_END);
+    wire is_table = rd_table_select && (rd_req_offset >= TABLE_OFFSET) && (rd_req_offset < TABLE_END);
+    wire is_pba   = rd_pba_select && (rd_req_offset >= PBA_OFFSET) && (rd_req_offset < PBA_END);
     assign addr_hit = rd_req_valid && (is_table || is_pba);
 
-    wire wr_is_table = (wr_offset >= TABLE_OFFSET) && (wr_offset < TABLE_END);
-
+    wire wr_is_table = wr_table_select && (wr_offset >= TABLE_OFFSET) && (wr_offset < TABLE_END);
     reg [31:0] msix_table_ram [0:TABLE_ENTRIES-1];
 
     initial begin
@@ -86,6 +89,7 @@ module pcileech_msix_table #(
 
     // PBA - all cleared initially
     reg [31:0] msix_pba [0:((NUM_VECTORS+31)/32)-1];
+    wire _unused_wr_pba_select = wr_pba_select;
 
     integer k;
     initial begin
@@ -113,10 +117,12 @@ module pcileech_msix_table #(
     reg [87:0] rd_ctx_d1;
     reg        rd_valid_d1;
     reg [31:0] rd_data_d1;
+    reg [2:0]  rd_bir_d1;
 
     always @(posedge clk) begin
         rd_ctx_d1   <= rd_req_ctx;
         rd_valid_d1 <= addr_hit;
+        rd_bir_d1     <= is_table ? TABLE_BIR[2:0] : PBA_BIR[2:0];
 
         if (addr_hit) begin
             if (is_table)
@@ -134,6 +140,7 @@ module pcileech_msix_table #(
         rd_rsp_ctx   <= rd_ctx_d1;
         rd_rsp_valid <= rd_valid_d1;
         rd_rsp_data  <= rd_data_d1;
+        rd_rsp_bir   <= rd_bir_d1;
     end
 
 endmodule

--- a/internal/firmware/tclgen/msi.go
+++ b/internal/firmware/tclgen/msi.go
@@ -51,8 +51,8 @@ func msiVectorsToTCL(vectors int) string {
 // For 32-bit BAR: "BAR_0"
 // For 64-bit BAR0 (BIR=0 and 64-bit): "BAR_1:0" (64-bit format expected by the IP).
 func barBIRToTCL(bir int, is64bit bool) string {
-	if bir == 0 && is64bit {
-		return "BAR_1:0"
+	if is64bit && bir >= 0 && bir < 5 {
+		return fmt.Sprintf("BAR_%d:%d", bir+1, bir)
 	}
 	return fmt.Sprintf("BAR_%d", bir)
 }

--- a/internal/firmware/tclgen/tclgen.go
+++ b/internal/firmware/tclgen/tclgen.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"github.com/sercanarga/pcileechgen/internal/board"
@@ -165,17 +166,19 @@ func generateProjectTCL(ctx *donor.DeviceContext, b *board.Board, libDir string,
 	}
 	srcAbs, _ := filepath.Abs(b.SrcPath(libDir))
 	ipAbs, _ := filepath.Abs(b.IPPath(libDir))
+	srcAbs = tclPath(srcAbs)
+	ipAbs = tclPath(ipAbs)
 	data := projectTCLData{
 		BoardName: b.Name, FPGAPart: b.FPGAPart, SrcPath: srcAbs, IPPath: ipAbs,
 		TopModule: b.TopModule, DeviceID: fmt.Sprintf("%04X", ctx.Device.DeviceID),
-		VendorID: fmt.Sprintf("%04X", ctx.Device.VendorID),
-		RevisionID: fmt.Sprintf("%02X", ctx.Device.RevisionID),
+		VendorID:       fmt.Sprintf("%04X", ctx.Device.VendorID),
+		RevisionID:     fmt.Sprintf("%02X", ctx.Device.RevisionID),
 		SubsysVendorID: fmt.Sprintf("%04X", ctx.Device.SubsysVendorID),
 		SubsysDeviceID: fmt.Sprintf("%04X", ctx.Device.SubsysDeviceID),
-		ClassCodeBase: fmt.Sprintf("%02X", (ctx.Device.ClassCode>>16)&0xFF),
-		ClassCodeSub: fmt.Sprintf("%02X", (ctx.Device.ClassCode>>8)&0xFF),
-		ClassCodeIntf: fmt.Sprintf("%02X", ctx.Device.ClassCode&0xFF),
-		LinkSpeed: linkSpeedToTCL(linkSpeed), LinkWidth: linkWidthToTCL(linkWidth),
+		ClassCodeBase:  fmt.Sprintf("%02X", (ctx.Device.ClassCode>>16)&0xFF),
+		ClassCodeSub:   fmt.Sprintf("%02X", (ctx.Device.ClassCode>>8)&0xFF),
+		ClassCodeIntf:  fmt.Sprintf("%02X", ctx.Device.ClassCode&0xFF),
+		LinkSpeed:      linkSpeedToTCL(linkSpeed), LinkWidth: linkWidthToTCL(linkWidth),
 		TrgtLinkSpeed: linkSpeedToTrgt(linkSpeed), Bar0Enabled: bar0.Enabled,
 		Bar0Size: bar0.Size, Bar0Scale: bar0.Scale, Bar064bit: bar0.Is64bit,
 		Bar0ByteSize: bar0Size, StockBar: stockBar, ImportVFiles: b.ImportVFiles,
@@ -202,6 +205,10 @@ func generateProjectTCL(ctx *donor.DeviceContext, b *board.Board, libDir string,
 		panic(fmt.Sprintf("project TCL template error: %v", err))
 	}
 	return buf.String()
+}
+
+func tclPath(path string) string {
+	return strings.ReplaceAll(path, `\`, "/")
 }
 
 // GenerateBuildTCL generates the Vivado build/synthesis TCL script.

--- a/internal/firmware/tclgen/tclgen.go
+++ b/internal/firmware/tclgen/tclgen.go
@@ -2,7 +2,6 @@ package tclgen
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"path/filepath"
 	"text/template"
@@ -11,7 +10,7 @@ import (
 	"github.com/sercanarga/pcileechgen/internal/donor"
 	"github.com/sercanarga/pcileechgen/internal/firmware"
 	"github.com/sercanarga/pcileechgen/internal/firmware/devclass"
-	"github.com/sercanarga/pcileechgen/internal/firmware/nvme"
+	"github.com/sercanarga/pcileechgen/internal/firmware/svgen"
 )
 
 // projectTCLData holds template data for Vivado project generation.
@@ -42,6 +41,7 @@ type projectTCLData struct {
 	Bar0ByteSize int
 	StockBar     bool
 	ImportVFiles bool
+	BARs         []barTCLConfig
 
 	DSNEnabled       bool
 	MSICapVectorsStr string
@@ -75,6 +75,15 @@ type bar0Config struct {
 	Is64bit bool
 }
 
+type barTCLConfig struct {
+	Index        int
+	Enabled      bool
+	Scale        string
+	Size         string
+	Is64bit      bool
+	Prefetchable bool
+}
+
 func buildBAR0Config(bar0Size int, ctx *donor.DeviceContext) bar0Config {
 	scale, size := barSizeToTCL(uint64(bar0Size))
 	is64 := false
@@ -90,8 +99,7 @@ func buildBAR0Config(bar0Size int, ctx *donor.DeviceContext) bar0Config {
 				}
 			}
 		} else if ctx.ConfigSpace != nil {
-			raw := ctx.ConfigSpace.BAR(0)
-			is64 = (raw & 0x06) == 0x04
+			is64 = (ctx.ConfigSpace.BAR(0) & 0x06) == 0x04
 		} else {
 			p := devclass.ProfileForClass(ctx.Device.ClassCode)
 			if p != nil {
@@ -99,91 +107,96 @@ func buildBAR0Config(bar0Size int, ctx *donor.DeviceContext) bar0Config {
 			}
 		}
 	}
-	return bar0Config{
-		Enabled: true,
-		Scale:   scale,
-		Size:    size,
-		Is64bit: is64,
-	}
+	return bar0Config{Enabled: true, Scale: scale, Size: size, Is64bit: is64}
 }
 
-// GenerateProjectTCL generates the Vivado project creation TCL script.
-// stockBar: when true, forces the stock zerowrite4k BRAM COE path in the
-// generated TCL (no donor content patch into bram_bar_zero4k), while still
-// reporting the correct (donor-demanded) Bar0ByteSize for PCIe IP BAR sizing
-// and other config. This matches --stock-bar CLI semantics.
 func GenerateProjectTCL(ctx *donor.DeviceContext, b *board.Board, libDir string, stockBar bool) string {
-	ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, ctx.ExtCapabilities)
+	return generateProjectTCL(ctx, b, libDir, stockBar, nil)
+}
 
-	// Use the board's max link speed for the Xilinx IP core.
-	// The donor's current speed depends on the slot it was captured in,
-	// not the device's capability. The FPGA should advertise its full
-	// capability so the root complex negotiates the highest common speed.
+func GenerateProjectTCLWithConfig(ctx *donor.DeviceContext, b *board.Board, libDir string, stockBar bool, cfg *svgen.SVGeneratorConfig) string {
+	return generateProjectTCL(ctx, b, libDir, stockBar, cfg)
+}
+
+func configBARIs64(cfg *svgen.SVGeneratorConfig, bir int) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, model := range cfg.BARModels {
+		if model != nil && model.BIR == bir {
+			return model.Is64Bit
+		}
+	}
+	return false
+}
+
+func generateProjectTCL(ctx *donor.DeviceContext, b *board.Board, libDir string, stockBar bool, cfg *svgen.SVGeneratorConfig) string {
+	ids := firmware.ExtractDeviceIDs(ctx.ConfigSpace, ctx.ExtCapabilities)
 	linkWidth := clampLinkWidth(ids.LinkWidth, b.PCIeLanes)
 	linkSpeed := b.MaxLinkSpeedOrDefault()
-
 	msixTableSize := 0
 	if ctx.MSIXData != nil && ctx.MSIXData.TableSize > 0 {
 		msixTableSize = ctx.MSIXData.TableSize
 	}
-	// IMPORTANT: use *DonorBAR0Demand* (uncapped) here, not CappedBAR0Size.
-	// This ensures the PCIe IP gets configured with the donor's actual BAR0
-	// size (Bar0_Size/Scale), and Bar0ByteSize reports the correct value
-	// (used for bram coe patch decision). --stock-bar (and force oversized
-	// on small-BRAM boards) still report the donor size, but force the
-	// zerowrite4k path for the bram IP.
 	bar0Size := firmware.DonorBAR0Demand(ctx, b, msixTableSize)
 	bar0 := buildBAR0Config(bar0Size, ctx)
-
-	msiVectors := extractMSIVectors(ctx)
-
+	bars := make([]barTCLConfig, 6)
+	for i := range bars {
+		bars[i].Index = i
+	}
+	if cfg != nil && cfg.DonorBARTopology {
+		for _, model := range cfg.BARModels {
+			if model == nil || model.BIR < 0 || model.BIR >= len(bars) {
+				continue
+			}
+			scale, size := barSizeToTCL(uint64(model.Size))
+			bars[model.BIR] = barTCLConfig{
+				Index: model.BIR, Enabled: true, Scale: scale, Size: size,
+				Is64bit: model.Is64Bit, Prefetchable: model.Prefetchable,
+			}
+			if model.BIR == 0 {
+				bar0Size = model.Size
+				bar0 = buildBAR0Config(bar0Size, ctx)
+				bar0.Is64bit = model.Is64Bit
+			}
+		}
+	} else {
+		bars[0] = barTCLConfig{Index: 0, Enabled: bar0.Enabled, Scale: bar0.Scale, Size: bar0.Size, Is64bit: bar0.Is64bit}
+	}
 	srcAbs, _ := filepath.Abs(b.SrcPath(libDir))
 	ipAbs, _ := filepath.Abs(b.IPPath(libDir))
-
 	data := projectTCLData{
-		BoardName:        b.Name,
-		FPGAPart:         b.FPGAPart,
-		SrcPath:          srcAbs,
-		IPPath:           ipAbs,
-		TopModule:        b.TopModule,
-		DeviceID:         fmt.Sprintf("%04X", ctx.Device.DeviceID),
-		VendorID:         fmt.Sprintf("%04X", ctx.Device.VendorID),
-		RevisionID:       fmt.Sprintf("%02X", ctx.Device.RevisionID),
-		SubsysVendorID:   fmt.Sprintf("%04X", ctx.Device.SubsysVendorID),
-		SubsysDeviceID:   fmt.Sprintf("%04X", ctx.Device.SubsysDeviceID),
-		ClassCodeBase:    fmt.Sprintf("%02X", (ctx.Device.ClassCode>>16)&0xFF),
-		ClassCodeSub:     fmt.Sprintf("%02X", (ctx.Device.ClassCode>>8)&0xFF),
-		ClassCodeIntf:    fmt.Sprintf("%02X", ctx.Device.ClassCode&0xFF),
-		LinkSpeed:        linkSpeedToTCL(linkSpeed),
-		LinkWidth:        linkWidthToTCL(linkWidth),
-		TrgtLinkSpeed:    linkSpeedToTrgt(linkSpeed),
-		Bar0Enabled:      bar0.Enabled,
-		Bar0Size:         bar0.Size,
-		Bar0Scale:        bar0.Scale,
-		Bar064bit:        bar0.Is64bit,
-		Bar0ByteSize:     bar0Size,
-		StockBar:         stockBar,
-		ImportVFiles:     b.ImportVFiles,
-		DSNEnabled:       ids.HasDSN,
-		MSICapVectorsStr: msiVectorsToTCL(msiVectors),
+		BoardName: b.Name, FPGAPart: b.FPGAPart, SrcPath: srcAbs, IPPath: ipAbs,
+		TopModule: b.TopModule, DeviceID: fmt.Sprintf("%04X", ctx.Device.DeviceID),
+		VendorID: fmt.Sprintf("%04X", ctx.Device.VendorID),
+		RevisionID: fmt.Sprintf("%02X", ctx.Device.RevisionID),
+		SubsysVendorID: fmt.Sprintf("%04X", ctx.Device.SubsysVendorID),
+		SubsysDeviceID: fmt.Sprintf("%04X", ctx.Device.SubsysDeviceID),
+		ClassCodeBase: fmt.Sprintf("%02X", (ctx.Device.ClassCode>>16)&0xFF),
+		ClassCodeSub: fmt.Sprintf("%02X", (ctx.Device.ClassCode>>8)&0xFF),
+		ClassCodeIntf: fmt.Sprintf("%02X", ctx.Device.ClassCode&0xFF),
+		LinkSpeed: linkSpeedToTCL(linkSpeed), LinkWidth: linkWidthToTCL(linkWidth),
+		TrgtLinkSpeed: linkSpeedToTrgt(linkSpeed), Bar0Enabled: bar0.Enabled,
+		Bar0Size: bar0.Size, Bar0Scale: bar0.Scale, Bar064bit: bar0.Is64bit,
+		Bar0ByteSize: bar0Size, StockBar: stockBar, ImportVFiles: b.ImportVFiles,
+		BARs: bars, DSNEnabled: ids.HasDSN,
+		MSICapVectorsStr: msiVectorsToTCL(extractMSIVectors(ctx)),
 	}
-
-	if ctx.MSIXData != nil && ctx.MSIXData.TableSize > 0 {
+	if cfg != nil && cfg.MSIXConfig != nil {
+		data.MSIXEnabled = true
+		data.MSIXTableSize = cfg.MSIXConfig.NumVectors - 1
+		data.MSIXTableBIR = barBIRToTCL(cfg.MSIXConfig.TableBIR, configBARIs64(cfg, cfg.MSIXConfig.TableBIR))
+		data.MSIXTableOffset = fmt.Sprintf("%08X", cfg.MSIXConfig.TableOffset)
+		data.MSIXPBABIR = barBIRToTCL(cfg.MSIXConfig.PBABIR, configBARIs64(cfg, cfg.MSIXConfig.PBABIR))
+		data.MSIXPBAOffset = fmt.Sprintf("%08X", cfg.MSIXConfig.PBAOffset)
+	} else if ctx.MSIXData != nil && ctx.MSIXData.TableSize > 0 {
 		data.MSIXEnabled = true
 		data.MSIXTableSize = ctx.MSIXData.TableSize - 1
-		bir := ctx.MSIXData.TableBIR
-		is64 := bar0.Is64bit && bir == 0
-		data.MSIXTableBIR = barBIRToTCL(bir, is64)
-		dstrd := uint32(0)
-		if bar0d := firmware.LargestBar(ctx.BARContents); len(bar0d) >= 8 {
-			dstrd = nvme.DoorbellStrideFromCAP(binary.LittleEndian.Uint32(bar0d[4:8]))
-		}
-		tableOff, pbaOffset, _ := firmware.MSIXPlacement(bar0Size, ctx.MSIXData.TableSize, ctx.Device.ClassCode, dstrd)
-		data.MSIXTableOffset = fmt.Sprintf("%08X", tableOff)
-		data.MSIXPBABIR = barBIRToTCL(bir, is64)
-		data.MSIXPBAOffset = fmt.Sprintf("%08X", pbaOffset)
+		data.MSIXTableBIR = barBIRToTCL(ctx.MSIXData.TableBIR, bar0.Is64bit && ctx.MSIXData.TableBIR == 0)
+		data.MSIXTableOffset = fmt.Sprintf("%08X", ctx.MSIXData.TableOffset)
+		data.MSIXPBABIR = barBIRToTCL(ctx.MSIXData.PBABIR, bar0.Is64bit && ctx.MSIXData.PBABIR == 0)
+		data.MSIXPBAOffset = fmt.Sprintf("%08X", ctx.MSIXData.PBAOffset)
 	}
-
 	var buf bytes.Buffer
 	if err := projectTCLTmpl.ExecuteTemplate(&buf, "project.tcl.tmpl", data); err != nil {
 		panic(fmt.Sprintf("project TCL template error: %v", err))

--- a/internal/firmware/tclgen/tclgen_test.go
+++ b/internal/firmware/tclgen/tclgen_test.go
@@ -1,11 +1,17 @@
 package tclgen
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/sercanarga/pcileechgen/internal/board"
 	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/firmware/barmodel"
+	"github.com/sercanarga/pcileechgen/internal/firmware/svgen"
 	"github.com/sercanarga/pcileechgen/internal/pci"
 )
 
@@ -62,6 +68,68 @@ func TestGenerateProjectTCL(t *testing.T) {
 	}
 	if !strings.Contains(tcl, "set v_files") {
 		t.Error("TCL must define `set v_files` even when empty (concat references it)")
+	}
+}
+
+func TestTclPathNormalizesWindowsSeparators(t *testing.T) {
+	if got, want := tclPath(`C:\Users\Admin\pcileech-fpga\board\ip`), `C:/Users/Admin/pcileech-fpga/board/ip`; got != want {
+		t.Fatalf("tclPath = %q, want %q", got, want)
+	}
+}
+
+func TestGeneratedMultiBARTCLSourcesInTclsh(t *testing.T) {
+	tclsh, err := exec.LookPath("tclsh")
+	if err != nil {
+		t.Skip("tclsh is required to execute generated Tcl")
+	}
+
+	cs := pci.NewConfigSpace()
+	cs.Size = pci.ConfigSpaceSize
+	ctx := &donor.DeviceContext{
+		Device:      pci.PCIDevice{VendorID: 0x1234, DeviceID: 0x5678, ClassCode: 0xFF0000},
+		ConfigSpace: cs,
+		BARs: []pci.BAR{
+			{Index: 0, Size: 0x2000, Type: pci.BARTypeMem64, Is64Bit: true},
+			{Index: 2, Size: 0x1000, Type: pci.BARTypeMem32, Prefetchable: true},
+			{Index: 5, Size: 0x100000, Type: pci.BARTypeMem32},
+		},
+	}
+	bar0 := &barmodel.BARModel{BIR: 0, Size: 0x2000, Type: pci.BARTypeMem64, Is64Bit: true}
+	bar2 := &barmodel.BARModel{BIR: 2, Size: 0x1000, Type: pci.BARTypeMem32, Prefetchable: true}
+	bar5 := &barmodel.BARModel{BIR: 5, Size: 0x100000, Type: pci.BARTypeMem32}
+	cfg := &svgen.SVGeneratorConfig{
+		DonorBARTopology: true,
+		BARModels:        []*barmodel.BARModel{bar0, bar2, bar5},
+		BARModel:         bar0,
+	}
+	b := &board.Board{Name: "TclSyntax", FPGAPart: "xc7a35tfgg484-2", PCIeLanes: 1, TopModule: "test_top"}
+	generated := GenerateProjectTCLWithConfig(ctx, b, t.TempDir(), false, cfg)
+	tclPath := filepath.Join(t.TempDir(), "vivado_generate_project.tcl")
+	if err := os.WriteFile(tclPath, []byte(generated), 0644); err != nil {
+		t.Fatal(err)
+	}
+	harnessPath := filepath.Join(t.TempDir(), "source_generated.tcl")
+	harness := `proc create_project args {}
+proc get_property args { return "." }
+proc current_project args { return "project" }
+proc set_property args {}
+proc get_filesets args { return "sources_1" }
+proc create_fileset args {}
+proc import_files args { return "" }
+proc get_files args { return "" }
+proc remove_files args {}
+proc get_ips args { return "pcie_7x_0" }
+proc upgrade_ip args {}
+proc create_run args {}
+proc get_runs args { return "run" }
+proc current_run args {}
+` + fmt.Sprintf("source {%s}\n", filepath.ToSlash(tclPath))
+	if err := os.WriteFile(harnessPath, []byte(harness), 0644); err != nil {
+		t.Fatal(err)
+	}
+	output, err := exec.Command(tclsh, harnessPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("tclsh rejected generated multi-BAR Tcl: %v\n%s", err, output)
 	}
 }
 

--- a/internal/firmware/tclgen/templates/project.tcl.tmpl
+++ b/internal/firmware/tclgen/templates/project.tcl.tmpl
@@ -151,16 +151,17 @@ if { $pcie_ip != "" } {
     CONFIG.Link_Speed           {{.LinkSpeed}} \
     CONFIG.Trgt_Link_Speed      {{.TrgtLinkSpeed}} \
   ] $pcie_ip
-{{if .Bar0Enabled}}
-  # BAR0
-  set_property -dict [list \
-    CONFIG.Bar0_Enabled         true \
-    CONFIG.Bar0_Type            Memory \
-    CONFIG.Bar0_Scale           {{.Bar0Scale}} \
-    CONFIG.Bar0_Size            {{.Bar0Size}} \
-    CONFIG.Bar0_64bit {{if .Bar064bit}}true{{else}}false{{end}} \
-  ] $pcie_ip
+{{range .BARs}}
+  set_property CONFIG.Bar{{.Index}}_Enabled {{if .Enabled}}true{{else}}false{{end}} $pcie_ip
+{{if .Enabled}}  set_property -dict [list \
+    CONFIG.Bar{{.Index}}_Type            Memory \
+    CONFIG.Bar{{.Index}}_Scale           {{.Scale}} \
+    CONFIG.Bar{{.Index}}_Size            {{.Size}} \
+{{if lt .Index 5}}    CONFIG.Bar{{.Index}}_64bit           {{if .Is64bit}}true{{else}}false{{end}} \
 {{end}}
+    CONFIG.Bar{{.Index}}_Prefetchable    {{if .Prefetchable}}true{{else}}false{{end}} \
+  ] $pcie_ip
+{{end}}{{end}}
   # Enable or disable DSN based on donor device
   set_property -dict [list \
     CONFIG.DSN_Enabled {{if .DSNEnabled}}true{{else}}false{{end}} \

--- a/internal/firmware/tclgen/templates/project.tcl.tmpl
+++ b/internal/firmware/tclgen/templates/project.tcl.tmpl
@@ -158,8 +158,7 @@ if { $pcie_ip != "" } {
     CONFIG.Bar{{.Index}}_Scale           {{.Scale}} \
     CONFIG.Bar{{.Index}}_Size            {{.Size}} \
 {{if lt .Index 5}}    CONFIG.Bar{{.Index}}_64bit           {{if .Is64bit}}true{{else}}false{{end}} \
-{{end}}
-    CONFIG.Bar{{.Index}}_Prefetchable    {{if .Prefetchable}}true{{else}}false{{end}} \
+{{end}}    CONFIG.Bar{{.Index}}_Prefetchable    {{if .Prefetchable}}true{{else}}false{{end}} \
   ] $pcie_ip
 {{end}}{{end}}
   # Enable or disable DSN based on donor device

--- a/scripts/hdl-lint.sh
+++ b/scripts/hdl-lint.sh
@@ -10,6 +10,7 @@ require verilator
 require ./bin/pcileechgen
 
 FIXTURES=(testdata/donors/*.json)
+LEGACY_BOARDS=(pciescreamer NeTV2_35T NeTV2_100T acorn litefury sp605_ft601)
 # Board names come from the CLI so the matrix stays in sync with board.go.
 # (NR>2 skips the two-line table header; bash 3.2 compat via while-read.)
 BOARDS=()
@@ -23,12 +24,12 @@ if [ "${#BOARDS[@]}" -eq 0 ]; then
 fi
 
 # whitelist of svgen output files (primitives like pcileech_fifo.sv are blackboxed)
-SVGEN_PATTERN='pcileech_bar_impl_device.sv|pcileech_tlps128_bar_controller.sv|pcileech_bar_impl_msi.sv|tlp_latency_emulator.sv|device_config.sv|pcileech_msix_table.sv|pcileech_nvme_admin_responder.sv|pcileech_nvme_dma_bridge.sv|pcileech_hda_rirb_dma.sv|pcileech_hda_msi.sv'
+SVGEN_PATTERN='pcileech_bar_impl_device.sv|pcileech_tlps128_bar_controller.sv|pcileech_bar_rsp_arbiter.sv|pcileech_tlps128_bar_rdengine.sv|pcileech_tlps128_bar_wrengine.sv|pcileech_bar_impl_none.sv|pcileech_bar_impl_zerowrite4k.sv|tlp_latency_emulator.sv|device_config.sv|pcileech_msix_table.sv|pcileech_nvme_admin_responder.sv|pcileech_nvme_dma_bridge.sv|pcileech_bram_disk.sv|pcileech_hda_rirb_dma.sv|pcileech_hda_msi.sv'
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-total=0; pass=0; skip=0; fail=0
+total=0; pass=0; skip=0; fail=0; modern_multibar_pass=0
 
 for fixture in "${FIXTURES[@]}"; do
   class="$(basename "$fixture" .json)"
@@ -36,6 +37,13 @@ for fixture in "${FIXTURES[@]}"; do
     total=$((total+1))
     cell="${class}×${board}"
     out="$TMP/$class/$board"
+    case " ${LEGACY_BOARDS[*]} " in
+      *" $board "*)
+        echo "SKIP  $cell (explicit legacy board allowlist)"
+        skip=$((skip+1))
+        continue
+        ;;
+    esac
     mkdir -p "$out"
 
     build_log="$out/build.log"
@@ -61,12 +69,15 @@ for fixture in "${FIXTURES[@]}"; do
     fi
 
     lint_log="$out/verilator.log"
-    if verilator --lint-only -Wno-fatal --top-module pcileech_bar_impl_device \
+    if verilator --lint-only -Wno-fatal --top-module pcileech_tlps128_bar_controller \
           +incdir+"$out/src" \
           "${sv_files[@]}" testdata/stubs/blackbox.sv \
           >"$lint_log" 2>&1; then
       echo "PASS  $cell"
       pass=$((pass+1))
+      if [ "$cell" = "multibar×PCIeSquirrel" ]; then
+        modern_multibar_pass=1
+      fi
     else
       echo "FAIL  $cell (see $lint_log)"
       cat "$lint_log" >&2
@@ -75,5 +86,9 @@ for fixture in "${FIXTURES[@]}"; do
   done
 done
 
+if [ "$modern_multibar_pass" -ne 1 ]; then
+  echo "FAIL  mandatory modern multibar×PCIeSquirrel cell did not pass" >&2
+  fail=$((fail+1))
+fi
 echo "HDL lint: total=$total pass=$pass skip=$skip fail=$fail"
 [ "$fail" -eq 0 ]

--- a/testdata/donors/multibar.json
+++ b/testdata/donors/multibar.json
@@ -1,0 +1,133 @@
+{
+  "collected_at": "2026-01-01T00:00:00Z",
+  "tool_version": "b4ab213-7-ga15c776",
+  "hostname": "ci-multibar",
+  "device": {
+    "bdf": {
+      "Domain": 0,
+      "Bus": 3,
+      "Device": 0,
+      "Function": 0
+    },
+    "vendor_id": 4660,
+    "device_id": 22136,
+    "subsys_vendor_id": 0,
+    "subsys_device_id": 0,
+    "revision_id": 0,
+    "class_code": 0,
+    "header_type": 0
+  },
+  "config_space_hex": [
+    "56781234",
+    "00100000",
+    "00000001",
+    "00000000",
+    "f7000000",
+    "00000000",
+    "f7100000",
+    "00000000",
+    "00000000",
+    "f7200000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000040",
+    "00000000",
+    "00000000",
+    "00034801",
+    "00000008",
+    "00005405",
+    "00000000",
+    "00000000",
+    "00020010",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000",
+    "00000000"
+  ],
+  "config_space_size": 256,
+  "bars": [
+    {
+      "index": 0,
+      "raw_value": 4143972352,
+      "address": 4143972352,
+      "size": 4096,
+      "type": "mem32",
+      "prefetchable": false,
+      "is_64bit": false
+    },
+    {
+      "index": 2,
+      "raw_value": 4145020928,
+      "address": 4145020928,
+      "size": 4096,
+      "type": "mem32",
+      "prefetchable": false,
+      "is_64bit": false
+    },
+    {
+      "index": 5,
+      "raw_value": 4146069504,
+      "address": 4146069504,
+      "size": 4096,
+      "type": "mem32",
+      "prefetchable": false,
+      "is_64bit": false
+    }
+  ],
+  "capabilities": [
+    {
+      "id": 1,
+      "offset": 64,
+      "data": "AUgDAAgAAAA="
+    },
+    {
+      "id": 5,
+      "offset": 72,
+      "data": "BVQAAAAAAAAAAAAA"
+    },
+    {
+      "id": 16,
+      "offset": 84,
+      "data": "EAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+    }
+  ]
+}

--- a/testdata/stubs/blackbox.sv
+++ b/testdata/stubs/blackbox.sv
@@ -13,3 +13,44 @@ module pcileech_fifo (
     input  wire        rst
 );
 endmodule
+
+module fifo_134_134_clk1_bar_rdrsp (
+    input  wire         srst,
+    input  wire         clk,
+    input  wire [133:0] din,
+    input  wire         wr_en,
+    input  wire         rd_en,
+    output wire [133:0] dout,
+    output wire         full,
+    output wire         empty,
+    output wire         prog_empty,
+    output wire         valid
+);
+endmodule
+
+module fifo_141_141_clk1_bar_wr (
+    input  wire         srst,
+    input  wire         clk,
+    input  wire [140:0] din,
+    input  wire         wr_en,
+    input  wire         rd_en,
+    output wire [140:0] dout,
+    output wire         full,
+    output wire         empty,
+    output wire         prog_empty,
+    output wire         valid
+);
+endmodule
+
+module fifo_74_74_clk1_bar_rd1 (
+    input  wire        srst,
+    input  wire        clk,
+    input  wire [73:0] din,
+    input  wire        wr_en,
+    input  wire        rd_en,
+    output wire [73:0] dout,
+    output wire        full,
+    output wire        empty,
+    output wire        valid
+);
+endmodule


### PR DESCRIPTION
## Summary

Replaces the single-BAR/BAR0 assumption with canonical six-slot donor topology and true per-BIR RTL/Tcl routing.

- models all implemented donor BARs with explicit BIR, aperture, 32/64-bit type, prefetchability, and bounded backing behavior
- validates 64-bit pairing, rejects BAR5 mem64 and occupied upper slots, and preserves disabled/absent slots
- routes reads/writes to the correct generated endpoint for BAR0–BAR5
- programs all supported 7-series hard-IP BAR properties without emitting unsupported `Bar5_64bit`
- makes class-specific preferred BIR meaningful instead of forcing behavior into BAR0
- preserves independent MSI-X Table/PBA BIRs and exact non-overlapping ranges
- finalizes one canonical topology/MSI-X layout before COE, Tcl, RTL, and manifest emission
- adds a buffered fair seven-source BAR response arbiter so delayed primary and secondary responses cannot collide/drop
- bounds unmodeled fallback storage to a sparse 4 KiB window with correct pipelined reads

## Correctness details

- ordinary base-BAR writes outside MSI-X Table/PBA ranges remain functional on shared BIRs
- in-range MSI-X writes are excluded from the base endpoint and reach the table logic only
- 64-bit lower/upper hard-IP configuration and consumed slots remain coherent
- response arbitration preserves every ctx/data pair exactly once under randomized collision and backpressure
- implicit NVMe interconnect nets were removed and exact widths declared
- legacy board architectures are skipped only through an explicit allowlist; missing integration modules on modern boards fail

## Verification

- `go test -race -count=1 ./...` under Ubuntu WSL2
- generated HDL matrix: 170 cells, 104 pass, 66 explicit legacy/incompatible skips, 0 fail
- mandatory `multibar × PCIeSquirrel` modern-controller elaboration pass
- randomized executable Verilator scoreboard for seven response sources
- focused NVMe/controller elaboration and multi-BAR artifact consistency tests
- independent FPGA review and final targeted closure review
- zero comments added

## Scope

This PR preserves real topology and routing; it does not claim functional emulation for arbitrary large BAR contents. Unknown/unmodeled apertures use an explicit bounded window rather than pretending the whole aperture is backed by FPGA RAM.