### PR TITLE
add donor analysis and initialization sessions

### DIFF
--- a/README
+++ b/README
@@ -99,6 +99,26 @@ COMMANDS
     pcileechgen mmio-trace --trace-file first.log --compare-trace second.log \
       --bar-base 0xf7800000 --bar-index 2 --bar-size 4096
 
+  Capture a checksummed initialization session:
+    sudo pcileechgen mmio-trace --bdf 0000:03:00.0 --bar-index 2 \
+      --bar-size 4096 --session-dir captures/run-01 --scenario trace
+
+  Capture a driver unbind/bind or interface down/up transition:
+    sudo pcileechgen mmio-trace --bdf 0000:03:00.0 --bar-index 2 \
+      --session-dir captures/rebind-01 --scenario unbind-bind
+    sudo pcileechgen mmio-trace --bdf 0000:03:00.0 --bar-index 2 \
+      --session-dir captures/link-01 --scenario interface-up
+
+  Analyze repeated sessions:
+    pcileechgen mmio-trace \
+      --compare-session captures/run-01,captures/run-02,captures/run-03
+
+  Session captures include before/after config space, PCI resources, interrupt
+  snapshots, access width/byte-enable metadata, raw trace JSON, and a SHA256
+  manifest. Disruptive scenarios refuse the active default-route NIC unless
+  --force-session is explicitly supplied. Run them only on authorized lab
+  hardware from a recoverable local console.
+
 
 FEATURES
 --------

--- a/README
+++ b/README
@@ -90,6 +90,15 @@ COMMANDS
     pcileechgen mmio-trace --trace-file mmiotrace.txt --bar-base 0xf7800000 \
       --bar-index 2 --bar-size 4096 --class-code 0x010802 --json
 
+  Donor analysis and capability-chain validation:
+    pcileechgen validate --json device_context.json --output-dir pcileech_datastore \
+      --report-json donor_report.json
+
+  Compare repeated MMIO captures to identify stable, changing, initialization,
+  and read-after-write registers:
+    pcileechgen mmio-trace --trace-file first.log --compare-trace second.log \
+      --bar-base 0xf7800000 --bar-index 2 --bar-size 4096
+
 
 FEATURES
 --------

--- a/cmd/pcileechgen/donor_report.go
+++ b/cmd/pcileechgen/donor_report.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"math/bits"
+
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/firmware/codegen"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+type donorReport struct {
+	Identity     donorReportIdentity     `json:"identity"`
+	ConfigSpace  donorReportConfigSpace  `json:"config_space"`
+	Capabilities []donorReportCapability `json:"capabilities"`
+	BARs         []donorReportBAR        `json:"bars"`
+	Issues       []string                `json:"issues,omitempty"`
+}
+
+type donorReportIdentity struct {
+	BDF       string `json:"bdf"`
+	VendorID  string `json:"vendor_id"`
+	DeviceID  string `json:"device_id"`
+	Revision  string `json:"revision"`
+	ClassCode string `json:"class_code"`
+	Class     string `json:"class"`
+}
+
+type donorReportConfigSpace struct {
+	Bytes        int `json:"bytes"`
+	WritableBits int `json:"writable_bits"`
+	ReadOnlyBits int `json:"read_only_bits"`
+}
+
+type donorReportCapability struct {
+	Kind    string `json:"kind"`
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Offset  int    `json:"offset"`
+	Version uint8  `json:"version,omitempty"`
+}
+
+type donorReportBAR struct {
+	Index        int    `json:"index"`
+	Type         string `json:"type"`
+	Size         uint64 `json:"size"`
+	Prefetchable bool   `json:"prefetchable"`
+	Is64Bit      bool   `json:"is_64bit"`
+}
+
+func buildDonorReport(ctx *donor.DeviceContext) donorReport {
+	r := donorReport{
+		Identity: donorReportIdentity{
+			BDF: ctx.Device.BDF.String(), VendorID: fmt.Sprintf("%04x", ctx.Device.VendorID),
+			DeviceID: fmt.Sprintf("%04x", ctx.Device.DeviceID), Revision: fmt.Sprintf("%02x", ctx.Device.RevisionID),
+			ClassCode: fmt.Sprintf("%06x", ctx.Device.ClassCode), Class: ctx.Device.ClassDescription(),
+		},
+	}
+	if ctx.ConfigSpace == nil {
+		r.Issues = []string{"configuration space is nil"}
+		return r
+	}
+
+	masks := codegen.GenerateWritemask(ctx.ConfigSpace)
+	for _, mask := range masks {
+		r.ConfigSpace.WritableBits += bits.OnesCount32(mask)
+	}
+	r.ConfigSpace.Bytes = ctx.ConfigSpace.Size
+	r.ConfigSpace.ReadOnlyBits = ctx.ConfigSpace.Size*8 - r.ConfigSpace.WritableBits
+	r.Issues = append(pci.ValidateCapabilityChains(ctx.ConfigSpace), donor.ValidateDeviceLayout(ctx)...)
+
+	for _, cap := range ctx.Capabilities {
+		r.Capabilities = append(r.Capabilities, donorReportCapability{Kind: "standard", ID: fmt.Sprintf("%02x", cap.ID), Name: pci.CapabilityName(cap.ID), Offset: cap.Offset})
+	}
+	for _, cap := range ctx.ExtCapabilities {
+		r.Capabilities = append(r.Capabilities, donorReportCapability{Kind: "extended", ID: fmt.Sprintf("%04x", cap.ID), Name: pci.ExtCapabilityName(cap.ID), Offset: cap.Offset, Version: cap.Version})
+	}
+	for _, bar := range ctx.BARs {
+		r.BARs = append(r.BARs, donorReportBAR{Index: bar.Index, Type: bar.Type, Size: bar.Size, Prefetchable: bar.Prefetchable, Is64Bit: bar.Is64Bit})
+	}
+	return r
+}
+
+func printDonorReport(w io.Writer, r donorReport) {
+	fmt.Fprintln(w, "Donor analysis")
+	fmt.Fprintf(w, "  Identity:       %s:%s rev %s, class %s (%s)\n", r.Identity.VendorID, r.Identity.DeviceID, r.Identity.Revision, r.Identity.ClassCode, r.Identity.Class)
+	fmt.Fprintf(w, "  Config space:   %d bytes\n", r.ConfigSpace.Bytes)
+	fmt.Fprintf(w, "  Writable bits:  %d\n", r.ConfigSpace.WritableBits)
+	fmt.Fprintf(w, "  Read-only bits: %d\n", r.ConfigSpace.ReadOnlyBits)
+	for _, cap := range r.Capabilities {
+		fmt.Fprintf(w, "  Capability:     0x%03x %s (%s)\n", cap.Offset, cap.Name, cap.Kind)
+	}
+	for _, bar := range r.BARs {
+		fmt.Fprintf(w, "  BAR%d:           %s, %d bytes, 64-bit=%t, prefetchable=%t\n", bar.Index, bar.Type, bar.Size, bar.Is64Bit, bar.Prefetchable)
+	}
+	for _, issue := range r.Issues {
+		fmt.Fprintf(w, "  Issue:          %s\n", issue)
+	}
+	fmt.Fprintln(w)
+}

--- a/cmd/pcileechgen/donor_report_test.go
+++ b/cmd/pcileechgen/donor_report_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func TestBuildDonorReportIncludesIdentityCapabilitiesBARsAndMasks(t *testing.T) {
+	cs := pci.NewConfigSpace()
+	cs.WriteU16(0x06, 0x0010)
+	cs.WriteU8(0x34, 0x40)
+	cs.WriteU8(0x40, pci.CapIDPowerManagement)
+	ctx := &donor.DeviceContext{
+		Device:       pci.PCIDevice{BDF: pci.BDF{Bus: 2}, VendorID: 0x10ec, DeviceID: 0x8168, RevisionID: 0x15, ClassCode: 0x020000},
+		ConfigSpace:  cs,
+		Capabilities: pci.ParseCapabilities(cs),
+		BARs:         []pci.BAR{{Index: 0, Type: pci.BARTypeMem64, Size: 4096, Is64Bit: true}},
+	}
+
+	report := buildDonorReport(ctx)
+	if report.Identity.VendorID != "10ec" || report.Identity.ClassCode != "020000" {
+		t.Fatalf("identity = %+v", report.Identity)
+	}
+	if len(report.Capabilities) != 1 || report.Capabilities[0].Name != "Power Management" {
+		t.Fatalf("capabilities = %+v", report.Capabilities)
+	}
+	if len(report.BARs) != 1 || report.BARs[0].Size != 4096 {
+		t.Fatalf("bars = %+v", report.BARs)
+	}
+	if report.ConfigSpace.Bytes != pci.ConfigSpaceSize || report.ConfigSpace.WritableBits == 0 {
+		t.Fatalf("config space = %+v", report.ConfigSpace)
+	}
+}
+
+func TestPrintDonorReportShowsCapabilityIssues(t *testing.T) {
+	cs := pci.NewConfigSpace()
+	cs.WriteU16(0x06, 0x0010)
+	cs.WriteU8(0x34, 0x40)
+	cs.WriteU8(0x40, pci.CapIDPowerManagement)
+	cs.WriteU8(0x41, 0x40)
+	ctx := &donor.DeviceContext{ConfigSpace: cs}
+
+	var out bytes.Buffer
+	printDonorReport(&out, buildDonorReport(ctx))
+	text := out.String()
+	for _, want := range []string{"Donor analysis", "Writable bits:", "standard capability loop at 0x040"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("report missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestBuildDonorReportLimitsMasksToCapturedConfigSpace(t *testing.T) {
+	cs := pci.NewConfigSpace()
+	cs.Size = pci.ConfigSpaceLegacySize
+
+	report := buildDonorReport(&donor.DeviceContext{ConfigSpace: cs})
+
+	if report.ConfigSpace.WritableBits+report.ConfigSpace.ReadOnlyBits != pci.ConfigSpaceLegacySize*8 {
+		t.Fatalf("mask bits = %+v, want %d total", report.ConfigSpace, pci.ConfigSpaceLegacySize*8)
+	}
+}

--- a/cmd/pcileechgen/mmio_session.go
+++ b/cmd/pcileechgen/mmio_session.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/color"
+	"github.com/sercanarga/pcileechgen/internal/donor"
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+	"github.com/sercanarga/pcileechgen/internal/donor/session"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+	"golang.org/x/sys/unix"
+)
+
+type linuxSessionSource struct {
+	reader   *donor.SysfsReader
+	bdf      pci.BDF
+	opts     mmioTraceOptions
+	barBase  uint64
+	scenario session.Scenario
+	force    bool
+	driver   string
+	kernel   string
+}
+
+func newLinuxSessionSource(bdf pci.BDF, opts mmioTraceOptions, barBase uint64, scenario session.Scenario, force bool) *linuxSessionSource {
+	kernel, _ := os.ReadFile("/proc/sys/kernel/osrelease")
+	return &linuxSessionSource{reader: donor.NewSysfsReader(), bdf: bdf, opts: opts, barBase: barBase, scenario: scenario, force: force, kernel: strings.TrimSpace(string(kernel))}
+}
+
+func (s *linuxSessionSource) Device() (*pci.PCIDevice, error) {
+	device, err := s.reader.ReadDeviceInfo(s.bdf)
+	if err == nil {
+		s.driver = device.Driver
+	}
+	return device, err
+}
+
+func (s *linuxSessionSource) Config() (*pci.ConfigSpace, error) {
+	return s.reader.ReadConfigSpace(s.bdf)
+}
+
+func (s *linuxSessionSource) BARs() ([]pci.BAR, error) {
+	return s.reader.ReadResourceFile(s.bdf)
+}
+
+func (s *linuxSessionSource) Resources() ([]byte, error) {
+	return os.ReadFile(filepath.Join("/sys/bus/pci/devices", s.bdf.String(), "resource"))
+}
+
+func (s *linuxSessionSource) Interrupts() ([]byte, error) {
+	return os.ReadFile("/proc/interrupts")
+}
+
+func (s *linuxSessionSource) Trace() (*mmio.TraceResult, error) {
+	if s.scenario == session.ScenarioTrace {
+		return loadMMIOTrace(s.opts, s.barBase)
+	}
+	if s.opts.traceFile != "" {
+		return nil, fmt.Errorf("--scenario %s requires live tracing", s.scenario)
+	}
+	controller := session.NewLinuxDriverController()
+	switch s.scenario {
+	case session.ScenarioUnbindBind:
+		var trace *mmio.TraceResult
+		err := controller.RunUnbindBindCapture(s.bdf.String(), s.force, func(bind func() error) error {
+			var err error
+			trace, err = s.captureTraceWithAction(bind)
+			return err
+		})
+		return trace, err
+	case session.ScenarioInterfaceUp:
+		if err := controller.CheckSafe(s.bdf.String(), s.force); err != nil {
+			return nil, err
+		}
+		interfaces, err := controller.Interfaces(s.bdf.String())
+		if err != nil {
+			return nil, err
+		}
+		sort.Strings(interfaces)
+		if len(interfaces) != 1 {
+			return nil, fmt.Errorf("interface-up scenario requires exactly one network interface, found %d", len(interfaces))
+		}
+		flags, err := interfaceFlags(interfaces[0])
+		if err != nil {
+			return nil, err
+		}
+		if err := setInterfaceFlags(interfaces[0], flags&^uint16(unix.IFF_UP)); err != nil {
+			return nil, err
+		}
+		defer func() { _ = setInterfaceFlags(interfaces[0], flags) }()
+		return s.captureTraceWithAction(func() error {
+			return setInterfaceFlags(interfaces[0], flags|uint16(unix.IFF_UP))
+		})
+	default:
+		return nil, fmt.Errorf("unsupported capture scenario %q", s.scenario)
+	}
+}
+
+func (s *linuxSessionSource) captureTraceWithAction(action func() error) (*mmio.TraceResult, error) {
+	type result struct {
+		trace *mmio.TraceResult
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		trace, err := loadMMIOTrace(s.opts, s.barBase)
+		done <- result{trace: trace, err: err}
+	}()
+	time.Sleep(100 * time.Millisecond)
+	actionErr := action()
+	captured := <-done
+	if actionErr != nil {
+		return nil, actionErr
+	}
+	return captured.trace, captured.err
+}
+
+func interfaceFlags(name string) (uint16, error) {
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, 0)
+	if err != nil {
+		return 0, fmt.Errorf("open interface control socket: %w", err)
+	}
+	defer unix.Close(fd)
+	request, err := unix.NewIfreq(name)
+	if err != nil {
+		return 0, err
+	}
+	if err := unix.IoctlIfreq(fd, unix.SIOCGIFFLAGS, request); err != nil {
+		return 0, fmt.Errorf("read flags for %s: %w", name, err)
+	}
+	return request.Uint16(), nil
+}
+
+func setInterfaceFlags(name string, flags uint16) error {
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, 0)
+	if err != nil {
+		return fmt.Errorf("open interface control socket: %w", err)
+	}
+	defer unix.Close(fd)
+	request, err := unix.NewIfreq(name)
+	if err != nil {
+		return err
+	}
+	request.SetUint16(flags)
+	if err := unix.IoctlIfreq(fd, unix.SIOCSIFFLAGS, request); err != nil {
+		return fmt.Errorf("set flags for %s: %w", name, err)
+	}
+	return nil
+}
+
+func (s *linuxSessionSource) Driver() string { return s.driver }
+func (s *linuxSessionSource) Kernel() string { return s.kernel }
+
+func runSessionAnalysis(out io.Writer, dirs []string, jsonOutput bool) error {
+	captures := make([]session.CaptureData, 0, len(dirs))
+	for _, dir := range dirs {
+		capture, err := session.LoadCapture(dir)
+		if err != nil {
+			return fmt.Errorf("load session %q: %w", dir, err)
+		}
+		captures = append(captures, capture)
+	}
+	analysis := session.AnalyzeInitialization(captures)
+	if jsonOutput {
+		encoder := json.NewEncoder(out)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(analysis); err != nil {
+			return fmt.Errorf("render session analysis: %w", err)
+		}
+		return nil
+	}
+	printInitializationAnalysis(out, analysis)
+	return nil
+}
+
+func printInitializationAnalysis(out io.Writer, analysis session.Analysis) {
+	fmt.Fprintln(out, color.Header("Initialization Session Analysis"))
+	fmt.Fprintf(out, "Sessions: %d | phases: %d | registers: %d\n\n", analysis.SessionCount, len(analysis.Phases), len(analysis.Registers))
+	fmt.Fprintln(out, "Offset      Reads  Writes  Class       Confidence  Effect")
+	for _, register := range analysis.Registers {
+		fmt.Fprintf(out, "0x%08x  %-6d %-7d %-11s %-11s %s\n", register.Offset, register.Reads, register.Writes, register.Classification, register.Confidence, register.WriteEffect)
+	}
+	if len(analysis.Dependencies) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Observed write/poll dependencies:")
+		for _, dependency := range analysis.Dependencies {
+			fmt.Fprintf(out, "  0x%08x -> 0x%08x (%d sessions)\n", dependency.WriteOffset, dependency.ReadOffset, dependency.Occurrences)
+		}
+	}
+	if len(analysis.ConfigChanges) > 0 {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Configuration changes:")
+		for _, change := range analysis.ConfigChanges {
+			fmt.Fprintf(out, "  0x%03x: 0x%08x -> 0x%08x (mask 0x%08x)\n", change.Offset, change.Before, change.After, change.Mask)
+		}
+	}
+}

--- a/cmd/pcileechgen/mmio_session_test.go
+++ b/cmd/pcileechgen/mmio_session_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/session"
+)
+
+func TestPrintInitializationAnalysisShowsEvidenceAndCoverage(t *testing.T) {
+	analysis := session.Analysis{
+		SessionCount: 2,
+		Phases: []session.Phase{{Session: 0, Index: 0, Kind: "command-poll", Records: 5}},
+		Registers: []session.RegisterEvidence{{Offset: 0x37, Reads: 1, Writes: 1, Classification: "read-write", Confidence: session.ConfidenceObserved, WriteEffect: session.WriteEffectSelfClearing}},
+		Dependencies: []session.Dependency{{WriteOffset: 0x37, ReadOffset: 0x3e, Occurrences: 2}},
+	}
+	var out bytes.Buffer
+
+	printInitializationAnalysis(&out, analysis)
+
+	text := out.String()
+	for _, want := range []string{"Initialization Session Analysis", "Sessions: 2", "0x00000037", "self-clearing", "0x00000037 -> 0x0000003e"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+}

--- a/cmd/pcileechgen/mmio_trace.go
+++ b/cmd/pcileechgen/mmio_trace.go
@@ -17,15 +17,16 @@ import (
 )
 
 type mmioTraceOptions struct {
-	bdf        string
-	duration   time.Duration
-	barIndex   int
-	barSize    int
-	barBase    string
-	classCode  string
-	jsonOutput bool
-	outputFile string
-	traceFile  string
+	bdf               string
+	duration          time.Duration
+	barIndex          int
+	barSize           int
+	barBase           string
+	classCode         string
+	jsonOutput        bool
+	outputFile        string
+	traceFile         string
+	compareTraceFiles []string
 }
 
 var mmioTraceOpts mmioTraceOptions
@@ -69,6 +70,17 @@ Example:
 		if err != nil {
 			return err
 		}
+		traces := []*mmio.TraceResult{trace}
+		for _, path := range mmioTraceOpts.compareTraceFiles {
+			opts := mmioTraceOpts
+			opts.traceFile = path
+			other, err := loadMMIOTrace(opts, barBase)
+			if err != nil {
+				return err
+			}
+			traces = append(traces, other)
+		}
+		comparison := mmio.CompareTraces(traces)
 
 		pattern := mmio.Analyze(trace)
 		profile := behavior.FromMMIOTrace(trace, classCode)
@@ -80,6 +92,7 @@ Example:
 				"analysis":         pattern,
 				"behavior_profile": profile,
 				"timing_histogram": timing,
+				"comparison":       comparison,
 			}
 			enc := json.NewEncoder(cmd.OutOrStdout())
 			enc.SetIndent("", "  ")
@@ -88,6 +101,9 @@ Example:
 			}
 		} else {
 			printMMIOTraceReport(cmd.OutOrStdout(), trace, pattern, profile, timing)
+			if len(mmioTraceOpts.compareTraceFiles) > 0 {
+				printMMIOTraceComparison(cmd.OutOrStdout(), comparison)
+			}
 		}
 
 		if mmioTraceOpts.outputFile != "" {
@@ -201,6 +217,15 @@ func printMMIOTraceReport(out io.Writer, trace *mmio.TraceResult, pattern *mmio.
 	fmt.Fprintf(out, "Max cycles: %d\n", timing.MaxCycles)
 }
 
+func printMMIOTraceComparison(out io.Writer, comparison []mmio.RegisterComparison) {
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, color.Header("MMIO Trace Comparison"))
+	fmt.Fprintln(out, "Offset     Reads  Writes  Classification")
+	for _, reg := range comparison {
+		fmt.Fprintf(out, "0x%08x %-6d %-7d %s\n", reg.Offset, reg.Reads, reg.Writes, reg.Classification)
+	}
+}
+
 func init() {
 	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.bdf, "bdf", "", "device BDF address (e.g. 0000:03:00.0)")
 	mmioTraceCmd.Flags().DurationVar(&mmioTraceOpts.duration, "duration", 5*time.Second, "trace length (e.g. 5s, 1m)")
@@ -210,6 +235,7 @@ func init() {
 	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.classCode, "class-code", "", "PCI class code in hex (e.g. 0x010802)")
 	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.outputFile, "output", "", "save raw trace JSON to file")
 	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.traceFile, "trace-file", "", "analyze an existing mmiotrace text file instead of capturing live")
+	mmioTraceCmd.Flags().StringSliceVar(&mmioTraceOpts.compareTraceFiles, "compare-trace", nil, "additional mmiotrace text file to compare (repeatable)")
 	mmioTraceCmd.Flags().BoolVar(&mmioTraceOpts.jsonOutput, "json", false, "emit machine-readable report")
 	rootCmd.AddCommand(mmioTraceCmd)
 }

--- a/cmd/pcileechgen/mmio_trace.go
+++ b/cmd/pcileechgen/mmio_trace.go
@@ -12,21 +12,26 @@ import (
 	"github.com/sercanarga/pcileechgen/internal/color"
 	"github.com/sercanarga/pcileechgen/internal/donor/behavior"
 	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+	"github.com/sercanarga/pcileechgen/internal/donor/session"
 	"github.com/sercanarga/pcileechgen/internal/pci"
 	"github.com/spf13/cobra"
 )
 
 type mmioTraceOptions struct {
-	bdf               string
-	duration          time.Duration
-	barIndex          int
-	barSize           int
-	barBase           string
-	classCode         string
-	jsonOutput        bool
-	outputFile        string
-	traceFile         string
-	compareTraceFiles []string
+	bdf                string
+	duration           time.Duration
+	barIndex           int
+	barSize            int
+	barBase            string
+	classCode          string
+	jsonOutput         bool
+	outputFile         string
+	traceFile          string
+	compareTraceFiles  []string
+	sessionDir         string
+	scenario           string
+	forceSession       bool
+	compareSessionDirs []string
 }
 
 var mmioTraceOpts mmioTraceOptions
@@ -41,6 +46,9 @@ Example:
   pcileechgen mmio-trace --bdf 03:00.0 --bar-size 4096 --class-code 0x010802
   pcileechgen mmio-trace --trace-file mmiotrace.txt --bar-base 0xf7800000 --bar-index 2 --json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(mmioTraceOpts.compareSessionDirs) > 0 {
+			return runSessionAnalysis(cmd.OutOrStdout(), mmioTraceOpts.compareSessionDirs, mmioTraceOpts.jsonOutput)
+		}
 		if mmioTraceOpts.traceFile == "" {
 			if _, err := pci.ParseBDF(mmioTraceOpts.bdf); err != nil {
 				return fmt.Errorf("invalid BDF %q: %w", mmioTraceOpts.bdf, err)
@@ -64,6 +72,23 @@ Example:
 		barBase, err := parseTraceBARBase(mmioTraceOpts.barBase)
 		if err != nil {
 			return err
+		}
+		if mmioTraceOpts.sessionDir != "" {
+			bdf, parseErr := pci.ParseBDF(mmioTraceOpts.bdf)
+			if parseErr != nil {
+				return fmt.Errorf("--session-dir requires a valid --bdf: %w", parseErr)
+			}
+			scenario := session.Scenario(mmioTraceOpts.scenario)
+			if scenario != session.ScenarioTrace && scenario != session.ScenarioUnbindBind && scenario != session.ScenarioInterfaceUp {
+				return fmt.Errorf("--scenario must be trace, unbind-bind, or interface-up")
+			}
+			source := newLinuxSessionSource(bdf, mmioTraceOpts, barBase, scenario, mmioTraceOpts.forceSession)
+			manifest, captureErr := session.Capture(mmioTraceOpts.sessionDir, scenario, source)
+			if captureErr != nil {
+				return captureErr
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "saved initialization session to %s (%d artifacts)\n", mmioTraceOpts.sessionDir, len(manifest.Artifacts))
+			return nil
 		}
 
 		trace, err := loadMMIOTrace(mmioTraceOpts, barBase)
@@ -236,6 +261,10 @@ func init() {
 	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.outputFile, "output", "", "save raw trace JSON to file")
 	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.traceFile, "trace-file", "", "analyze an existing mmiotrace text file instead of capturing live")
 	mmioTraceCmd.Flags().StringSliceVar(&mmioTraceOpts.compareTraceFiles, "compare-trace", nil, "additional mmiotrace text file to compare (repeatable)")
+	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.sessionDir, "session-dir", "", "save a checksummed initialization capture session")
+	mmioTraceCmd.Flags().StringVar(&mmioTraceOpts.scenario, "scenario", string(session.ScenarioTrace), "capture scenario: trace, unbind-bind, or interface-up")
+	mmioTraceCmd.Flags().BoolVar(&mmioTraceOpts.forceSession, "force-session", false, "allow disruptive capture on an active default-route NIC")
+	mmioTraceCmd.Flags().StringSliceVar(&mmioTraceOpts.compareSessionDirs, "compare-session", nil, "initialization session directory to analyze (repeatable)")
 	mmioTraceCmd.Flags().BoolVar(&mmioTraceOpts.jsonOutput, "json", false, "emit machine-readable report")
 	rootCmd.AddCommand(mmioTraceCmd)
 }

--- a/cmd/pcileechgen/validate.go
+++ b/cmd/pcileechgen/validate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,6 +21,7 @@ import (
 var validateJSONPath string
 var validateOutputDir string
 var validateBoard string
+var validateReportJSON string
 
 // validator bundles state for a single validation run.
 type validator struct {
@@ -50,6 +52,17 @@ Example:
 		}
 		fmt.Printf("Loaded donor context: %s\n\n",
 			color.Bold(fmt.Sprintf("%04x:%04x (rev %02x)", ctx.Device.VendorID, ctx.Device.DeviceID, ctx.Device.RevisionID)))
+		report := buildDonorReport(ctx)
+		printDonorReport(os.Stdout, report)
+		if validateReportJSON != "" {
+			data, marshalErr := json.MarshalIndent(report, "", "  ")
+			if marshalErr != nil {
+				return fmt.Errorf("encoding donor report: %w", marshalErr)
+			}
+			if writeErr := os.WriteFile(validateReportJSON, append(data, '\n'), 0o644); writeErr != nil {
+				return fmt.Errorf("writing donor report: %w", writeErr)
+			}
+		}
 
 		var b *board.Board
 		if validateBoard != "" {
@@ -89,6 +102,7 @@ Example:
 		v.validateIdentity()
 		v.validateOutputFiles()
 		v.validateSVIDs()
+		v.validateCapabilityChains()
 		v.validateFormats()
 
 		// Print results
@@ -225,6 +239,12 @@ func (v *validator) validateSVIDs() {
 	}
 }
 
+// validateCapabilityChains checks donor capability links, BARs, and MSI-X placement.
+func (v *validator) validateCapabilityChains() {
+	v.result.Failed = append(v.result.Failed, pci.ValidateCapabilityChains(v.ctx.ConfigSpace)...)
+	v.result.Failed = append(v.result.Failed, donor.ValidateDeviceLayout(v.ctx)...)
+}
+
 // validateFormats checks COE file format validity.
 func (v *validator) validateFormats() {
 	for _, coeName := range []string{"pcileech_cfgspace.coe", "pcileech_cfgspace_writemask.coe", "pcileech_bar_zero4k.coe"} {
@@ -243,6 +263,7 @@ func init() {
 	validateCmd.Flags().StringVar(&validateJSONPath, "json", "", "path to device_context.json (required)")
 	validateCmd.Flags().StringVar(&validateOutputDir, "output-dir", ".", "path to firmware output directory")
 	validateCmd.Flags().StringVar(&validateBoard, "board", "", "target FPGA board (for exact build-matching validation)")
+	validateCmd.Flags().StringVar(&validateReportJSON, "report-json", "", "write donor analysis report as JSON")
 	_ = validateCmd.MarkFlagRequired("json")
 	rootCmd.AddCommand(validateCmd)
 }

--- a/cmd/pcileechgen/validate_test.go
+++ b/cmd/pcileechgen/validate_test.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/sercanarga/pcileechgen/internal/donor"
 	"github.com/sercanarga/pcileechgen/internal/firmware/codegen"
 	"github.com/sercanarga/pcileechgen/internal/firmware/output"
 	"github.com/sercanarga/pcileechgen/internal/pci"
@@ -37,5 +38,23 @@ func TestValidateCOEFiles_ConfigSpaceMismatchFails(t *testing.T) {
 	}
 	if len(v.result.Warnings) != 0 {
 		t.Fatalf("warnings = %v, want none", v.result.Warnings)
+	}
+}
+
+func TestValidateCapabilityChainsFailsMalformedDonor(t *testing.T) {
+	cs := pci.NewConfigSpace()
+	cs.WriteU16(0x06, 0x0010)
+	cs.WriteU8(0x34, 0x40)
+	cs.WriteU8(0x40, pci.CapIDPowerManagement)
+	cs.WriteU8(0x41, 0x40)
+	v := &validator{
+		ctx:    &donor.DeviceContext{ConfigSpace: cs},
+		result: &output.ValidationResult{},
+	}
+
+	v.validateCapabilityChains()
+
+	if !slices.Contains(v.result.Failed, "standard capability loop at 0x040") {
+		t.Fatalf("failed validations = %v", v.result.Failed)
 	}
 }

--- a/internal/donor/mmio/compare.go
+++ b/internal/donor/mmio/compare.go
@@ -1,0 +1,75 @@
+package mmio
+
+import "sort"
+
+// RegisterClass describes behavior observed across MMIO traces.
+type RegisterClass string
+
+const (
+	RegisterStable              RegisterClass = "stable constant"
+	RegisterChanging            RegisterClass = "changing"
+	RegisterReadAfterWrite      RegisterClass = "read after write"
+	RegisterInitializationWrite RegisterClass = "initialization write"
+)
+
+// RegisterComparison summarizes one register across multiple traces.
+type RegisterComparison struct {
+	Offset         uint32        `json:"offset"`
+	Reads          int           `json:"reads"`
+	Writes         int           `json:"writes"`
+	Values         []uint32      `json:"values"`
+	Classification RegisterClass `json:"classification"`
+}
+
+// CompareTraces classifies register behavior observed across trace captures.
+func CompareTraces(traces []*TraceResult) []RegisterComparison {
+	type aggregate struct {
+		reads          int
+		writes         int
+		readAfterWrite bool
+		values         map[uint32]struct{}
+	}
+	byOffset := make(map[uint32]*aggregate)
+	for _, trace := range traces {
+		if trace == nil {
+			continue
+		}
+		written := make(map[uint32]bool)
+		for _, record := range trace.Records {
+			a := byOffset[record.Offset]
+			if a == nil {
+				a = &aggregate{values: make(map[uint32]struct{})}
+				byOffset[record.Offset] = a
+			}
+			a.values[record.Value] = struct{}{}
+			if record.Type == AccessWrite {
+				a.writes++
+				written[record.Offset] = true
+			} else {
+				a.reads++
+				a.readAfterWrite = a.readAfterWrite || written[record.Offset]
+			}
+		}
+	}
+
+	result := make([]RegisterComparison, 0, len(byOffset))
+	for offset, a := range byOffset {
+		values := make([]uint32, 0, len(a.values))
+		for value := range a.values {
+			values = append(values, value)
+		}
+		sort.Slice(values, func(i, j int) bool { return values[i] < values[j] })
+		class := RegisterStable
+		switch {
+		case a.readAfterWrite:
+			class = RegisterReadAfterWrite
+		case a.writes > 0 && a.reads == 0:
+			class = RegisterInitializationWrite
+		case len(values) > 1:
+			class = RegisterChanging
+		}
+		result = append(result, RegisterComparison{Offset: offset, Reads: a.reads, Writes: a.writes, Values: values, Classification: class})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Offset < result[j].Offset })
+	return result
+}

--- a/internal/donor/mmio/compare_test.go
+++ b/internal/donor/mmio/compare_test.go
@@ -1,0 +1,56 @@
+package mmio
+
+import "testing"
+
+func TestCompareTracesClassifiesAndSortsRegisters(t *testing.T) {
+	traces := []*TraceResult{
+		{Records: []AccessRecord{
+			{Offset: 0x20, Type: AccessRead, Value: 1},
+			{Offset: 0x10, Type: AccessRead, Value: 0xdeadbeef},
+			{Offset: 0x30, Type: AccessWrite, Value: 7},
+			{Offset: 0x30, Type: AccessRead, Value: 7},
+			{Offset: 0x40, Type: AccessWrite, Value: 1},
+		}},
+		{Records: []AccessRecord{
+			{Offset: 0x20, Type: AccessRead, Value: 2},
+			{Offset: 0x10, Type: AccessRead, Value: 0xdeadbeef},
+			{Offset: 0x30, Type: AccessWrite, Value: 9},
+			{Offset: 0x30, Type: AccessRead, Value: 9},
+			{Offset: 0x40, Type: AccessWrite, Value: 1},
+		}},
+	}
+
+	got := CompareTraces(traces)
+	if len(got) != 4 {
+		t.Fatalf("CompareTraces() returned %d registers, want 4", len(got))
+	}
+	wantOffsets := []uint32{0x10, 0x20, 0x30, 0x40}
+	wantClasses := []RegisterClass{RegisterStable, RegisterChanging, RegisterReadAfterWrite, RegisterInitializationWrite}
+	for i := range got {
+		if got[i].Offset != wantOffsets[i] || got[i].Classification != wantClasses[i] {
+			t.Errorf("result[%d] = {offset: 0x%x, class: %q}, want {offset: 0x%x, class: %q}", i, got[i].Offset, got[i].Classification, wantOffsets[i], wantClasses[i])
+		}
+	}
+	if len(got[1].Values) != 2 || got[1].Values[0] != 1 || got[1].Values[1] != 2 {
+		t.Fatalf("changing values = %v, want [1 2]", got[1].Values)
+	}
+}
+
+func TestCompareTracesIgnoresNilTraces(t *testing.T) {
+	if got := CompareTraces([]*TraceResult{nil}); len(got) != 0 {
+		t.Fatalf("CompareTraces(nil) = %v, want empty", got)
+	}
+}
+
+func TestCompareTracesRequiresWriteBeforeReadForReadAfterWrite(t *testing.T) {
+	trace := &TraceResult{Records: []AccessRecord{
+		{Offset: 0x10, Type: AccessRead, Value: 1},
+		{Offset: 0x10, Type: AccessWrite, Value: 1},
+	}}
+
+	got := CompareTraces([]*TraceResult{trace})
+
+	if len(got) != 1 || got[0].Classification != RegisterStable {
+		t.Fatalf("classification = %v, want %q", got, RegisterStable)
+	}
+}

--- a/internal/donor/mmio/import.go
+++ b/internal/donor/mmio/import.go
@@ -60,7 +60,7 @@ func parseTextTraceLine(line string, barBase uint64) (AccessRecord, bool) {
 		return AccessRecord{}, false
 	}
 
-	var rec AccessRecord
+	rec := AccessRecord{CPU: -1}
 	switch fields[0] {
 	case "R":
 		rec.Type = AccessRead
@@ -68,6 +68,17 @@ func parseTextTraceLine(line string, barBase uint64) (AccessRecord, bool) {
 		rec.Type = AccessWrite
 	default:
 		return AccessRecord{}, false
+	}
+	width, err := strconv.ParseUint(fields[1], 10, 8)
+	if err != nil || (width != 1 && width != 2 && width != 4) {
+		return AccessRecord{}, false
+	}
+	rec.Width = uint8(width)
+	if !strings.HasPrefix(fields[3], "0x") {
+		cpu, cpuErr := strconv.Atoi(fields[3])
+		if cpuErr == nil {
+			rec.CPU = cpu
+		}
 	}
 
 	addrField, valueField, ok := traceAddressValueFields(fields)
@@ -85,12 +96,24 @@ func parseTextTraceLine(line string, barBase uint64) (AccessRecord, bool) {
 	}
 
 	rec.Offset = traceOffset(addr, barBase)
+	rec.ByteEnable = accessByteEnable(rec.Offset, rec.Width)
 	rec.Value = value
 	if ts, err := strconv.ParseFloat(fields[2], 64); err == nil {
 		rec.Timestamp = time.Duration(ts * float64(time.Second))
 	}
 
 	return rec, true
+}
+
+func accessByteEnable(offset uint32, width uint8) uint8 {
+	switch width {
+	case 1:
+		return 1 << (offset & 3)
+	case 2:
+		return 3 << (offset & 2)
+	default:
+		return 0xF
+	}
 }
 
 func traceAddressValueFields(fields []string) (string, string, bool) {

--- a/internal/donor/mmio/import_test.go
+++ b/internal/donor/mmio/import_test.go
@@ -74,3 +74,14 @@ func TestParseTextTrace_DurationUsesLastTimestamp(t *testing.T) {
 		t.Fatalf("duration = %s, want 250ms", trace.Duration)
 	}
 }
+
+func TestParseTextTracePreservesWidthByteEnableAndCPU(t *testing.T) {
+	trace, err := ParseTextTrace(strings.NewReader("W 1 1.000 2 0x1003 0xaa 0x0 0\n"), TextTraceOptions{BARBase: 0x1000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := trace.Records[0]
+	if record.Width != 1 || record.ByteEnable != 0x8 || record.CPU != 2 {
+		t.Fatalf("record metadata = %+v, want width=1 byte_enable=8 cpu=2", record)
+	}
+}

--- a/internal/donor/mmio/tracer.go
+++ b/internal/donor/mmio/tracer.go
@@ -25,10 +25,13 @@ func (a AccessType) String() string {
 
 // AccessRecord is one captured BAR read or write.
 type AccessRecord struct {
-	Offset    uint32        // byte offset within the BAR
-	Type      AccessType    // read or write
-	Value     uint32        // value read or written
-	Timestamp time.Duration // time since trace started
+	Offset     uint32        `json:"offset"`      // byte offset within the BAR
+	Width      uint8         `json:"width"`       // access width in bytes
+	ByteEnable uint8         `json:"byte_enable"` // DWORD byte-enable mask
+	CPU        int           `json:"cpu"`         // tracing CPU, -1 when unavailable
+	Type       AccessType    `json:"type"`        // read or write
+	Value      uint32        `json:"value"`       // value read or written
+	Timestamp  time.Duration `json:"timestamp"`   // time since trace started
 }
 
 // TraceResult is everything captured during one tracing session.

--- a/internal/donor/session/analyze.go
+++ b/internal/donor/session/analyze.go
@@ -1,0 +1,349 @@
+package session
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+// Confidence identifies how broadly an inferred behavior was observed.
+type Confidence string
+
+const (
+	ConfidenceInferred Confidence = "inferred"
+	ConfidenceObserved Confidence = "observed"
+)
+
+// WriteEffect describes an observed relationship between a write and later read.
+type WriteEffect string
+
+const (
+	WriteEffectUnknown      WriteEffect = "unknown"
+	WriteEffectDirectLatch  WriteEffect = "direct latch"
+	WriteEffectSelfClearing WriteEffect = "self-clearing"
+)
+
+// CaptureData is the normalized input for initialization analysis.
+type CaptureData struct {
+	Manifest     *Manifest
+	Trace        *mmio.TraceResult
+	ConfigBefore *pci.ConfigSpace
+	ConfigAfter  *pci.ConfigSpace
+}
+
+// Phase is a time-bounded group of initialization accesses.
+type Phase struct {
+	Session int           `json:"session"`
+	Index   int           `json:"index"`
+	Start   time.Duration `json:"start"`
+	End     time.Duration `json:"end"`
+	Kind    string        `json:"kind"`
+	Records int           `json:"records"`
+}
+
+// RegisterEvidence summarizes observations for one BAR offset.
+type RegisterEvidence struct {
+	Offset         uint32      `json:"offset"`
+	Widths         []int       `json:"widths"`
+	Reads          int         `json:"reads"`
+	Writes         int         `json:"writes"`
+	Values         []uint32    `json:"values"`
+	Classification string      `json:"classification"`
+	Confidence     Confidence  `json:"confidence"`
+	FirstPhase     int         `json:"first_phase"`
+	Polling        bool        `json:"polling"`
+	WriteEffect    WriteEffect `json:"write_effect"`
+}
+
+// Dependency is an observed write followed by polling of another register.
+type Dependency struct {
+	WriteOffset uint32 `json:"write_offset"`
+	ReadOffset  uint32 `json:"read_offset"`
+	Occurrences int    `json:"occurrences"`
+}
+
+// ConfigChange is one changed configuration-space DWORD.
+type ConfigChange struct {
+	Offset uint32 `json:"offset"`
+	Before uint32 `json:"before"`
+	After  uint32 `json:"after"`
+	Mask   uint32 `json:"mask"`
+}
+
+// MACCandidate is a cautiously inferred Ethernet MAC location.
+type MACCandidate struct {
+	Address    string     `json:"address"`
+	Source     string     `json:"source"`
+	Confidence Confidence `json:"confidence"`
+}
+
+// Analysis is the deterministic result of comparing initialization sessions.
+type Analysis struct {
+	SessionCount  int                `json:"session_count"`
+	Phases        []Phase            `json:"phases"`
+	Registers     []RegisterEvidence `json:"registers"`
+	Dependencies  []Dependency       `json:"dependencies,omitempty"`
+	ConfigChanges []ConfigChange     `json:"config_changes,omitempty"`
+	MACCandidates []MACCandidate     `json:"mac_candidates,omitempty"`
+}
+
+type registerAggregate struct {
+	widths      map[uint8]struct{}
+	values      map[uint32]struct{}
+	sessions    map[int]struct{}
+	reads       int
+	writes      int
+	firstPhase  int
+	polling     bool
+	writeEffect WriteEffect
+}
+
+// AnalyzeInitialization derives evidence from repeated capture sessions.
+func AnalyzeInitialization(captures []CaptureData) Analysis {
+	analysis := Analysis{SessionCount: len(captures)}
+	registers := make(map[uint32]*registerAggregate)
+	dependencies := make(map[[2]uint32]int)
+	changes := make(map[string]ConfigChange)
+	for sessionIndex, capture := range captures {
+		if capture.Trace == nil {
+			continue
+		}
+		phases, phaseByRecord := segmentPhases(sessionIndex, capture.Trace.Records)
+		analysis.Phases = append(analysis.Phases, phases...)
+		collectRegisterEvidence(registers, sessionIndex, capture.Trace.Records, phaseByRecord)
+		collectDependencies(dependencies, capture.Trace.Records)
+		collectConfigChanges(changes, capture.ConfigBefore, capture.ConfigAfter)
+	}
+	analysis.Registers = finishRegisterEvidence(registers)
+	analysis.Dependencies = finishDependencies(dependencies)
+	analysis.ConfigChanges = finishConfigChanges(changes)
+	analysis.MACCandidates = inferMACCandidates(captures, analysis.Registers)
+	return analysis
+}
+
+func segmentPhases(session int, records []mmio.AccessRecord) ([]Phase, []int) {
+	if len(records) == 0 {
+		return nil, nil
+	}
+	phaseByRecord := make([]int, len(records))
+	start := 0
+	var phases []Phase
+	for i := 1; i <= len(records); i++ {
+		boundary := i == len(records) || records[i].Timestamp-records[i-1].Timestamp > time.Millisecond
+		if !boundary {
+			continue
+		}
+		index := len(phases)
+		for j := start; j < i; j++ {
+			phaseByRecord[j] = index
+		}
+		kind := "initialization"
+		if records[start].Type == mmio.AccessWrite && hasRepeatedRead(records[start:i]) {
+			kind = "command-poll"
+		}
+		phases = append(phases, Phase{Session: session, Index: index, Start: records[start].Timestamp, End: records[i-1].Timestamp, Kind: kind, Records: i - start})
+		start = i
+	}
+	return phases, phaseByRecord
+}
+
+func collectRegisterEvidence(out map[uint32]*registerAggregate, session int, records []mmio.AccessRecord, phaseByRecord []int) {
+	for i, record := range records {
+		a := out[record.Offset]
+		if a == nil {
+			a = &registerAggregate{widths: make(map[uint8]struct{}), values: make(map[uint32]struct{}), sessions: make(map[int]struct{}), firstPhase: phaseByRecord[i], writeEffect: WriteEffectUnknown}
+			out[record.Offset] = a
+		}
+		a.widths[record.Width] = struct{}{}
+		a.values[record.Value] = struct{}{}
+		a.sessions[session] = struct{}{}
+		if record.Type == mmio.AccessWrite {
+			a.writes++
+			for _, later := range records[i+1:] {
+				if later.Offset != record.Offset || later.Type != mmio.AccessRead {
+					continue
+				}
+				if later.Value == 0 && record.Value != 0 {
+					a.writeEffect = WriteEffectSelfClearing
+				} else if later.Value == record.Value && a.writeEffect == WriteEffectUnknown {
+					a.writeEffect = WriteEffectDirectLatch
+				}
+				break
+			}
+		} else {
+			a.reads++
+		}
+	}
+	for offset, a := range out {
+		if repeatedReadCount(records, offset) >= 3 {
+			a.polling = true
+		}
+	}
+}
+
+func collectDependencies(out map[[2]uint32]int, records []mmio.AccessRecord) {
+	for i, record := range records {
+		if record.Type != mmio.AccessWrite {
+			continue
+		}
+		limit := i + 17
+		if limit > len(records) {
+			limit = len(records)
+		}
+		counts := make(map[uint32]int)
+		for _, later := range records[i+1 : limit] {
+			if later.Type == mmio.AccessRead && later.Offset != record.Offset {
+				counts[later.Offset]++
+			}
+		}
+		for offset, count := range counts {
+			if count >= 3 {
+				out[[2]uint32{record.Offset, offset}]++
+			}
+		}
+	}
+}
+
+func collectConfigChanges(out map[string]ConfigChange, before, after *pci.ConfigSpace) {
+	if before == nil || after == nil {
+		return
+	}
+	limit := before.Size
+	if after.Size < limit {
+		limit = after.Size
+	}
+	for offset := 0; offset+4 <= limit; offset += 4 {
+		oldValue, newValue := before.ReadU32(offset), after.ReadU32(offset)
+		if oldValue != newValue {
+			change := ConfigChange{Offset: uint32(offset), Before: oldValue, After: newValue, Mask: oldValue ^ newValue}
+			out[fmt.Sprintf("%x:%x:%x", offset, oldValue, newValue)] = change
+		}
+	}
+}
+
+func finishRegisterEvidence(input map[uint32]*registerAggregate) []RegisterEvidence {
+	result := make([]RegisterEvidence, 0, len(input))
+	for offset, a := range input {
+		widths := sortedUint8Keys(a.widths)
+		values := sortedUint32Keys(a.values)
+		classification := "stable"
+		switch {
+		case a.polling:
+			classification = "polling"
+		case a.reads == 0:
+			classification = "write-only"
+		case a.writes > 0:
+			classification = "read-write"
+		case len(values) > 1:
+			classification = "changing"
+		}
+		confidence := ConfidenceInferred
+		if len(a.sessions) >= 2 {
+			confidence = ConfidenceObserved
+		}
+		result = append(result, RegisterEvidence{Offset: offset, Widths: widths, Reads: a.reads, Writes: a.writes, Values: values, Classification: classification, Confidence: confidence, FirstPhase: a.firstPhase, Polling: a.polling, WriteEffect: a.writeEffect})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Offset < result[j].Offset })
+	return result
+}
+
+func finishDependencies(input map[[2]uint32]int) []Dependency {
+	result := make([]Dependency, 0, len(input))
+	for key, count := range input {
+		result = append(result, Dependency{WriteOffset: key[0], ReadOffset: key[1], Occurrences: count})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].WriteOffset == result[j].WriteOffset {
+			return result[i].ReadOffset < result[j].ReadOffset
+		}
+		return result[i].WriteOffset < result[j].WriteOffset
+	})
+	return result
+}
+
+func finishConfigChanges(input map[string]ConfigChange) []ConfigChange {
+	result := make([]ConfigChange, 0, len(input))
+	for _, change := range input {
+		result = append(result, change)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Offset != result[j].Offset {
+			return result[i].Offset < result[j].Offset
+		}
+		if result[i].Before != result[j].Before {
+			return result[i].Before < result[j].Before
+		}
+		return result[i].After < result[j].After
+	})
+	return result
+}
+
+func inferMACCandidates(captures []CaptureData, registers []RegisterEvidence) []MACCandidate {
+	if len(captures) == 0 || captures[0].Manifest == nil || captures[0].Manifest.Device.ClassCode>>16 != 0x02 {
+		return nil
+	}
+	var low, high *RegisterEvidence
+	for i := range registers {
+		if registers[i].Offset == 0 && len(registers[i].Values) == 1 {
+			low = &registers[i]
+		}
+		if registers[i].Offset == 4 && len(registers[i].Values) == 1 {
+			high = &registers[i]
+		}
+	}
+	if low == nil || high == nil {
+		return nil
+	}
+	lo, hi := low.Values[0], high.Values[0]
+	if lo == 0 || lo == 0xffffffff || hi&0xffff == 0 || hi&0xffff == 0xffff {
+		return nil
+	}
+	address := fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", byte(lo), byte(lo>>8), byte(lo>>16), byte(lo>>24), byte(hi), byte(hi>>8))
+	return []MACCandidate{{Address: address, Source: "BAR offsets 0x0/0x4", Confidence: ConfidenceInferred}}
+}
+
+func hasRepeatedRead(records []mmio.AccessRecord) bool {
+	counts := make(map[uint32]int)
+	for _, record := range records {
+		if record.Type == mmio.AccessRead {
+			counts[record.Offset]++
+		}
+	}
+	for _, count := range counts {
+		if count >= 3 {
+			return true
+		}
+	}
+	return false
+}
+
+func repeatedReadCount(records []mmio.AccessRecord, offset uint32) int {
+	count := 0
+	for _, record := range records {
+		if record.Type == mmio.AccessRead && record.Offset == offset {
+			count++
+		}
+	}
+	return count
+}
+
+func sortedUint8Keys(input map[uint8]struct{}) []int {
+	result := make([]int, 0, len(input))
+	for value := range input {
+		result = append(result, int(value))
+	}
+	sort.Ints(result)
+	return result
+}
+
+func sortedUint32Keys(input map[uint32]struct{}) []uint32 {
+	result := make([]uint32, 0, len(input))
+	for value := range input {
+		result = append(result, value)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
+	return result
+}

--- a/internal/donor/session/analyze_test.go
+++ b/internal/donor/session/analyze_test.go
@@ -1,0 +1,75 @@
+package session
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func TestAnalyzeInitializationBuildsEvidencePhasesAndDependencies(t *testing.T) {
+	captures := []CaptureData{
+		analysisFixture(4),
+		analysisFixture(6),
+	}
+
+	analysis := AnalyzeInitialization(captures)
+	if analysis.SessionCount != 2 || len(analysis.Phases) < 2 {
+		t.Fatalf("analysis summary = %+v", analysis)
+	}
+	reset := findRegister(t, analysis.Registers, 0x37)
+	if reset.WriteEffect != WriteEffectSelfClearing || reset.Confidence != ConfidenceObserved {
+		t.Fatalf("reset evidence = %+v", reset)
+	}
+	status := findRegister(t, analysis.Registers, 0x3e)
+	if !status.Polling || status.Reads != 8 {
+		t.Fatalf("status evidence = %+v", status)
+	}
+	if len(analysis.Dependencies) == 0 || analysis.Dependencies[0].WriteOffset != 0x37 || analysis.Dependencies[0].ReadOffset != 0x3e {
+		t.Fatalf("dependencies = %+v", analysis.Dependencies)
+	}
+	if len(analysis.ConfigChanges) != 1 || analysis.ConfigChanges[0].Offset != 4 {
+		t.Fatalf("config changes = %+v", analysis.ConfigChanges)
+	}
+}
+
+func analysisFixture(terminal uint32) CaptureData {
+	before := pci.NewConfigSpace()
+	after := pci.NewConfigSpace()
+	after.WriteU32(4, 7)
+	trace := &mmio.TraceResult{Records: []mmio.AccessRecord{
+		{Offset: 0x37, Width: 1, ByteEnable: 8, Type: mmio.AccessWrite, Value: 0x10, Timestamp: 0},
+		{Offset: 0x3e, Width: 2, ByteEnable: 0xc, Type: mmio.AccessRead, Value: 1, Timestamp: 10 * time.Microsecond},
+		{Offset: 0x3e, Width: 2, ByteEnable: 0xc, Type: mmio.AccessRead, Value: 1, Timestamp: 20 * time.Microsecond},
+		{Offset: 0x3e, Width: 2, ByteEnable: 0xc, Type: mmio.AccessRead, Value: 1, Timestamp: 30 * time.Microsecond},
+		{Offset: 0x3e, Width: 2, ByteEnable: 0xc, Type: mmio.AccessRead, Value: terminal, Timestamp: 40 * time.Microsecond},
+		{Offset: 0x37, Width: 1, ByteEnable: 8, Type: mmio.AccessRead, Value: 0, Timestamp: 50 * time.Microsecond},
+		{Offset: 0x40, Width: 4, ByteEnable: 0xf, Type: mmio.AccessWrite, Value: 1, Timestamp: 2 * time.Millisecond},
+	}}
+	return CaptureData{Manifest: &Manifest{Device: pci.PCIDevice{ClassCode: 0x020000}}, Trace: trace, ConfigBefore: before, ConfigAfter: after}
+}
+
+func findRegister(t *testing.T, registers []RegisterEvidence, offset uint32) RegisterEvidence {
+	t.Helper()
+	for _, register := range registers {
+		if register.Offset == offset {
+			return register
+		}
+	}
+	t.Fatalf("register 0x%x not found", offset)
+	return RegisterEvidence{}
+}
+
+func TestAnalysisJSONEncodesWidthsAsNumbers(t *testing.T) {
+	analysis := AnalyzeInitialization([]CaptureData{analysisFixture(4)})
+	data, err := json.Marshal(analysis)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) == "" || !strings.Contains(string(data), `"widths":[1]`) {
+		t.Fatalf("analysis JSON widths are not numeric: %s", data)
+	}
+}

--- a/internal/donor/session/capture.go
+++ b/internal/donor/session/capture.go
@@ -1,0 +1,116 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+// CaptureSource provides host data for one initialization session.
+type CaptureSource interface {
+	Device() (*pci.PCIDevice, error)
+	Config() (*pci.ConfigSpace, error)
+	BARs() ([]pci.BAR, error)
+	Resources() ([]byte, error)
+	Interrupts() ([]byte, error)
+	Trace() (*mmio.TraceResult, error)
+	Driver() string
+	Kernel() string
+}
+
+// Capture records before/after state and a trace in one checksummed session directory.
+func Capture(dir string, scenario Scenario, source CaptureSource) (*Manifest, error) {
+	if source == nil {
+		return nil, fmt.Errorf("capture source is nil")
+	}
+	started := time.Now().UTC()
+	device, err := source.Device()
+	if err != nil {
+		return nil, fmt.Errorf("read device: %w", err)
+	}
+	before, err := source.Config()
+	if err != nil {
+		return nil, fmt.Errorf("read config before trace: %w", err)
+	}
+	bars, err := source.BARs()
+	if err != nil {
+		return nil, fmt.Errorf("read BARs: %w", err)
+	}
+	resources, err := source.Resources()
+	if err != nil {
+		return nil, fmt.Errorf("read resources: %w", err)
+	}
+	interruptsBefore, err := source.Interrupts()
+	if err != nil {
+		return nil, fmt.Errorf("read interrupts before trace: %w", err)
+	}
+	trace, err := source.Trace()
+	if err != nil {
+		return nil, fmt.Errorf("capture trace: %w", err)
+	}
+	after, err := source.Config()
+	if err != nil {
+		return nil, fmt.Errorf("read config after trace: %w", err)
+	}
+	interruptsAfter, err := source.Interrupts()
+	if err != nil {
+		return nil, fmt.Errorf("read interrupts after trace: %w", err)
+	}
+	traceJSON, err := json.MarshalIndent(trace, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode trace: %w", err)
+	}
+	manifest := &Manifest{
+		Version: 1, Scenario: scenario, BDF: device.BDF.String(), Driver: source.Driver(), Kernel: source.Kernel(),
+		StartedAt: started, Duration: time.Since(started), Device: *device, BARs: bars,
+	}
+	files := map[string][]byte{
+		"config-before.bin":     append([]byte(nil), before.Data[:before.Size]...),
+		"config-after.bin":      append([]byte(nil), after.Data[:after.Size]...),
+		"resources.txt":         resources,
+		"interrupts-before.txt": interruptsBefore,
+		"interrupts-after.txt":  interruptsAfter,
+		"trace.json":            append(traceJSON, '\n'),
+	}
+	if err := Save(dir, manifest, files); err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+// LoadCapture verifies and loads one captured initialization session.
+func LoadCapture(dir string) (CaptureData, error) {
+	manifest, err := Load(dir)
+	if err != nil {
+		return CaptureData{}, err
+	}
+	if verifyErr := Verify(dir, manifest); verifyErr != nil {
+		return CaptureData{}, verifyErr
+	}
+	before, err := os.ReadFile(filepath.Join(dir, "config-before.bin"))
+	if err != nil {
+		return CaptureData{}, fmt.Errorf("read config before: %w", err)
+	}
+	after, err := os.ReadFile(filepath.Join(dir, "config-after.bin"))
+	if err != nil {
+		return CaptureData{}, fmt.Errorf("read config after: %w", err)
+	}
+	traceData, err := os.ReadFile(filepath.Join(dir, "trace.json"))
+	if err != nil {
+		return CaptureData{}, fmt.Errorf("read trace: %w", err)
+	}
+	var trace mmio.TraceResult
+	if err := json.Unmarshal(traceData, &trace); err != nil {
+		return CaptureData{}, fmt.Errorf("decode trace: %w", err)
+	}
+	return CaptureData{
+		Manifest: manifest, Trace: &trace,
+		ConfigBefore: pci.NewConfigSpaceFromBytes(before),
+		ConfigAfter:  pci.NewConfigSpaceFromBytes(after),
+	}, nil
+}

--- a/internal/donor/session/capture_test.go
+++ b/internal/donor/session/capture_test.go
@@ -1,0 +1,59 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/donor/mmio"
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+type fakeCaptureSource struct {
+	configReads int
+}
+
+func (f *fakeCaptureSource) Device() (*pci.PCIDevice, error) {
+	return &pci.PCIDevice{BDF: pci.BDF{Bus: 2}, VendorID: 0x10ec, DeviceID: 0x8168}, nil
+}
+func (f *fakeCaptureSource) Config() (*pci.ConfigSpace, error) {
+	f.configReads++
+	cs := pci.NewConfigSpace()
+	cs.WriteU32(4, uint32(f.configReads))
+	return cs, nil
+}
+func (f *fakeCaptureSource) BARs() ([]pci.BAR, error) {
+	return []pci.BAR{{Index: 0, Type: pci.BARTypeMem32, Size: 4096}}, nil
+}
+func (f *fakeCaptureSource) Resources() ([]byte, error)  { return []byte("resources\n"), nil }
+func (f *fakeCaptureSource) Interrupts() ([]byte, error) { return []byte("interrupts\n"), nil }
+func (f *fakeCaptureSource) Trace() (*mmio.TraceResult, error) {
+	return &mmio.TraceResult{BDF: "0000:02:00.0", Duration: time.Millisecond, Records: []mmio.AccessRecord{{Offset: 4, Width: 4, ByteEnable: 0xf, Type: mmio.AccessWrite, Value: 1}}}, nil
+}
+func (f *fakeCaptureSource) Driver() string { return "r8169" }
+func (f *fakeCaptureSource) Kernel() string { return "test-kernel" }
+
+func TestCaptureWritesBeforeAfterTraceAndMetadata(t *testing.T) {
+	dir := t.TempDir()
+	manifest, err := Capture(dir, ScenarioTrace, &fakeCaptureSource{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"config-before.bin", "config-after.bin", "resources.txt", "interrupts-before.txt", "interrupts-after.txt", "trace.json"} {
+		if _, ok := manifest.Artifacts[name]; !ok {
+			t.Errorf("missing artifact %q", name)
+		}
+	}
+	if manifest.Driver != "r8169" || manifest.Kernel != "test-kernel" || manifest.Device.VendorID != 0x10ec {
+		t.Fatalf("manifest metadata = %+v", manifest)
+	}
+	if verifyErr := Verify(dir, manifest); verifyErr != nil {
+		t.Fatal(verifyErr)
+	}
+	loaded, err := LoadCapture(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Trace == nil || len(loaded.Trace.Records) != 1 || loaded.ConfigBefore.ReadU32(4) != 1 || loaded.ConfigAfter.ReadU32(4) != 2 {
+		t.Fatalf("loaded capture = %+v", loaded)
+	}
+}

--- a/internal/donor/session/driver.go
+++ b/internal/donor/session/driver.go
@@ -1,0 +1,132 @@
+package session
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DriverController performs one bounded PCI driver unbind/bind cycle.
+type DriverController struct {
+	devicesPath string
+	routePath   string
+}
+
+// NewDriverController creates a controller with injectable Linux paths.
+func NewDriverController(devicesPath, routePath string) *DriverController {
+	return &DriverController{devicesPath: devicesPath, routePath: routePath}
+}
+
+// NewLinuxDriverController creates a controller for the running Linux host.
+func NewLinuxDriverController() *DriverController {
+	return NewDriverController("/sys/bus/pci/devices", "/proc/net/route")
+}
+
+// RunUnbindBind unbinds the device, runs capture, and always restores its driver.
+func (c *DriverController) RunUnbindBind(bdf string, force bool, capture func() error) error {
+	if capture == nil {
+		return fmt.Errorf("capture callback is nil")
+	}
+	return c.RunUnbindBindCapture(bdf, force, func(_ func() error) error {
+		return capture()
+	})
+}
+
+// RunUnbindBindCapture lets capture rebind the device while tracing remains active.
+func (c *DriverController) RunUnbindBindCapture(bdf string, force bool, capture func(bind func() error) error) (resultErr error) {
+	if capture == nil {
+		return fmt.Errorf("capture callback is nil")
+	}
+	if err := c.CheckSafe(bdf, force); err != nil {
+		return err
+	}
+
+	driverPath, err := filepath.EvalSymlinks(filepath.Join(c.devicesPath, bdf, "driver"))
+	if err != nil {
+		return fmt.Errorf("resolve driver for %s: %w", bdf, err)
+	}
+	if err := os.WriteFile(filepath.Join(driverPath, "unbind"), []byte(bdf), 0o200); err != nil {
+		return fmt.Errorf("unbind %s: %w", bdf, err)
+	}
+	bound := false
+	bind := func() error {
+		if bound {
+			return nil
+		}
+		if err := os.WriteFile(filepath.Join(driverPath, "bind"), []byte(bdf), 0o200); err != nil {
+			return fmt.Errorf("bind %s: %w", bdf, err)
+		}
+		bound = true
+		return nil
+	}
+	defer func() {
+		if err := bind(); err != nil {
+			if resultErr == nil {
+				resultErr = fmt.Errorf("restore driver for %s: %w", bdf, err)
+			} else {
+				resultErr = fmt.Errorf("capture failed: %w; restore driver for %s: %w", resultErr, bdf, err)
+			}
+		}
+	}()
+	return capture(bind)
+}
+
+// CheckSafe refuses disruptive operations on the active default-route NIC.
+func (c *DriverController) CheckSafe(bdf string, force bool) error {
+	if force {
+		return nil
+	}
+	active, err := c.isDefaultRouteDevice(bdf)
+	if err != nil {
+		return err
+	}
+	if active {
+		return fmt.Errorf("refusing to disrupt default-route interface at %s; use --force only from a recoverable local session", bdf)
+	}
+	return nil
+}
+
+// Interfaces returns network interfaces exposed by a PCI device.
+func (c *DriverController) Interfaces(bdf string) ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(c.devicesPath, bdf, "net"))
+	if err != nil {
+		return nil, fmt.Errorf("read network interfaces for %s: %w", bdf, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names, nil
+}
+
+func (c *DriverController) isDefaultRouteDevice(bdf string) (bool, error) {
+	entries, err := os.ReadDir(filepath.Join(c.devicesPath, bdf, "net"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read network interfaces for %s: %w", bdf, err)
+	}
+	interfaces := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		interfaces[entry.Name()] = true
+	}
+	file, err := os.Open(c.routePath)
+	if err != nil {
+		return false, fmt.Errorf("read routes: %w", err)
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 2 && fields[1] == "00000000" && interfaces[fields[0]] {
+			return true, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, fmt.Errorf("scan routes: %w", err)
+	}
+	return false, nil
+}

--- a/internal/donor/session/driver_test.go
+++ b/internal/donor/session/driver_test.go
@@ -1,0 +1,101 @@
+package session
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunUnbindBindRestoresDriverAfterCaptureError(t *testing.T) {
+	root := t.TempDir()
+	bdf := "0000:02:00.0"
+	driverDir := filepath.Join(root, "drivers", "r8169")
+	deviceDir := filepath.Join(root, "devices", bdf)
+	mustMkdir(t, driverDir)
+	mustMkdir(t, filepath.Join(deviceDir, "net", "eth0"))
+	mustWrite(t, filepath.Join(driverDir, "unbind"), nil)
+	mustWrite(t, filepath.Join(driverDir, "bind"), nil)
+	if err := os.Symlink(driverDir, filepath.Join(deviceDir, "driver")); err != nil {
+		t.Fatal(err)
+	}
+	route := filepath.Join(root, "route")
+	mustWrite(t, route, []byte("Iface\tDestination\tGateway\tFlags\neth1\t00000000\t00000000\t0003\n"))
+	controller := NewDriverController(filepath.Join(root, "devices"), route)
+
+	err := controller.RunUnbindBind(bdf, false, func() error { return errors.New("capture failed") })
+	if err == nil || !strings.Contains(err.Error(), "capture failed") {
+		t.Fatalf("RunUnbindBind() error = %v", err)
+	}
+	bound, err := os.ReadFile(filepath.Join(driverDir, "bind"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(bound) != bdf {
+		t.Fatalf("bind = %q, want %q", bound, bdf)
+	}
+}
+
+func TestRunUnbindBindRefusesDefaultRouteInterface(t *testing.T) {
+	root := t.TempDir()
+	bdf := "0000:02:00.0"
+	deviceDir := filepath.Join(root, "devices", bdf)
+	mustMkdir(t, filepath.Join(deviceDir, "net", "eth0"))
+	route := filepath.Join(root, "route")
+	mustWrite(t, route, []byte("Iface\tDestination\tGateway\tFlags\neth0\t00000000\t00000000\t0003\n"))
+	controller := NewDriverController(filepath.Join(root, "devices"), route)
+
+	err := controller.RunUnbindBind(bdf, false, func() error { return nil })
+	if err == nil || !strings.Contains(err.Error(), "default-route interface") {
+		t.Fatalf("RunUnbindBind() error = %v", err)
+	}
+}
+
+func TestRunUnbindBindCaptureCanRebindDuringCapture(t *testing.T) {
+	root := t.TempDir()
+	bdf := "0000:02:00.0"
+	driverDir := filepath.Join(root, "drivers", "r8169")
+	deviceDir := filepath.Join(root, "devices", bdf)
+	mustMkdir(t, driverDir)
+	mustMkdir(t, filepath.Join(deviceDir, "net"))
+	mustWrite(t, filepath.Join(driverDir, "unbind"), nil)
+	mustWrite(t, filepath.Join(driverDir, "bind"), nil)
+	if err := os.Symlink(driverDir, filepath.Join(deviceDir, "driver")); err != nil {
+		t.Fatal(err)
+	}
+	route := filepath.Join(root, "route")
+	mustWrite(t, route, []byte("Iface\tDestination\tGateway\tFlags\n"))
+	controller := NewDriverController(filepath.Join(root, "devices"), route)
+
+	err := controller.RunUnbindBindCapture(bdf, false, func(bind func() error) error {
+		if err := bind(); err != nil {
+			return err
+		}
+		bound, err := os.ReadFile(filepath.Join(driverDir, "bind"))
+		if err != nil {
+			return err
+		}
+		if string(bound) != bdf {
+			return errors.New("driver was not rebound during capture")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWrite(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/donor/session/manifest.go
+++ b/internal/donor/session/manifest.go
@@ -1,0 +1,108 @@
+// Package session stores reproducible donor initialization captures.
+package session
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+const manifestName = "capture.json"
+
+// Scenario names one bounded initialization capture workflow.
+type Scenario string
+
+const (
+	ScenarioTrace       Scenario = "trace"
+	ScenarioUnbindBind  Scenario = "unbind-bind"
+	ScenarioInterfaceUp Scenario = "interface-up"
+)
+
+// Artifact records the integrity and size of one capture file.
+type Artifact struct {
+	SHA256 string `json:"sha256"`
+	Size   int    `json:"size"`
+}
+
+// Manifest describes one initialization capture.
+type Manifest struct {
+	Version   int                 `json:"version"`
+	Scenario  Scenario            `json:"scenario"`
+	BDF       string              `json:"bdf"`
+	Driver    string              `json:"driver,omitempty"`
+	Kernel    string              `json:"kernel,omitempty"`
+	StartedAt time.Time           `json:"started_at"`
+	Duration  time.Duration       `json:"duration"`
+	Device    pci.PCIDevice       `json:"device"`
+	BARs      []pci.BAR           `json:"bars,omitempty"`
+	Artifacts map[string]Artifact `json:"artifacts"`
+}
+
+// Save writes capture artifacts and their manifest to dir.
+func Save(dir string, manifest *Manifest, files map[string][]byte) error {
+	if manifest == nil {
+		return fmt.Errorf("manifest is nil")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create session directory: %w", err)
+	}
+	manifest.Artifacts = make(map[string]Artifact, len(files))
+	for name, data := range files {
+		if name == "" || filepath.Base(name) != name || name == manifestName {
+			return fmt.Errorf("unsafe artifact name %q", name)
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o644); err != nil {
+			return fmt.Errorf("write artifact %q: %w", name, err)
+		}
+		sum := sha256.Sum256(data)
+		manifest.Artifacts[name] = Artifact{SHA256: hex.EncodeToString(sum[:]), Size: len(data)}
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode manifest: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, manifestName), append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write manifest: %w", err)
+	}
+	return nil
+}
+
+// Load reads a capture manifest from dir.
+func Load(dir string) (*Manifest, error) {
+	data, err := os.ReadFile(filepath.Join(dir, manifestName))
+	if err != nil {
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("decode manifest: %w", err)
+	}
+	return &manifest, nil
+}
+
+// Verify checks every capture artifact against its recorded checksum and size.
+func Verify(dir string, manifest *Manifest) error {
+	if manifest == nil {
+		return fmt.Errorf("manifest is nil")
+	}
+	for name, artifact := range manifest.Artifacts {
+		if name == "" || filepath.Base(name) != name || name == manifestName {
+			return fmt.Errorf("unsafe artifact name %q", name)
+		}
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return fmt.Errorf("read artifact %q: %w", name, err)
+		}
+		sum := sha256.Sum256(data)
+		if len(data) != artifact.Size || hex.EncodeToString(sum[:]) != artifact.SHA256 {
+			return fmt.Errorf("artifact %q failed integrity check", name)
+		}
+	}
+	return nil
+}

--- a/internal/donor/session/manifest_test.go
+++ b/internal/donor/session/manifest_test.go
@@ -1,0 +1,51 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveAndLoadManifestChecksumsArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	manifest := Manifest{Version: 1, Scenario: ScenarioTrace, BDF: "0000:02:00.0"}
+	files := map[string][]byte{"config-before.bin": {1, 2, 3}, "resources.txt": []byte("resource\n")}
+
+	if err := Save(dir, &manifest, files); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Artifacts) != 2 || loaded.Artifacts["config-before.bin"].SHA256 == "" {
+		t.Fatalf("artifacts = %+v", loaded.Artifacts)
+	}
+	if err := Verify(dir, loaded); err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config-before.bin"), []byte("changed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Verify(dir, loaded); err == nil {
+		t.Fatal("Verify() accepted changed artifact")
+	}
+}
+
+func TestSaveRejectsUnsafeArtifactName(t *testing.T) {
+	err := Save(t.TempDir(), &Manifest{Version: 1}, map[string][]byte{"../escape": {1}})
+	if err == nil {
+		t.Fatal("Save() accepted path traversal")
+	}
+}
+
+func TestVerifyRejectsUnsafeArtifactName(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "session")
+	mustMkdir(t, dir)
+	mustWrite(t, filepath.Join(root, "outside"), []byte("x"))
+	manifest := &Manifest{Artifacts: map[string]Artifact{"../outside": {SHA256: "2d711642b726b04401627ca9fbac32f5c8530fb1903cc4db02258717921a4881", Size: 1}}}
+	if err := Verify(dir, manifest); err == nil {
+		t.Fatal("Verify() accepted path traversal")
+	}
+}

--- a/internal/donor/validate.go
+++ b/internal/donor/validate.go
@@ -1,0 +1,40 @@
+package donor
+
+import "fmt"
+
+// ValidateDeviceLayout reports invalid BAR pairing and MSI-X table placement.
+func ValidateDeviceLayout(ctx *DeviceContext) []string {
+	if ctx == nil {
+		return []string{"device context is nil"}
+	}
+	var issues []string
+	barSizes := make(map[int]uint64, len(ctx.BARs))
+	for _, bar := range ctx.BARs {
+		barSizes[bar.Index] = bar.Size
+		if bar.Is64Bit && bar.Index == 5 {
+			issues = append(issues, "64-bit BAR5 has no upper BAR")
+		}
+	}
+	if ctx.MSIXData == nil || ctx.MSIXData.TableSize <= 0 {
+		return issues
+	}
+
+	msix := ctx.MSIXData
+	tableEnd := uint64(msix.TableOffset) + uint64(msix.TableSize)*16
+	issues = appendMSIXBoundsIssue(issues, "table", msix.TableBIR, tableEnd, barSizes)
+	pbaBytes := uint64((msix.TableSize+63)/64) * 8
+	pbaEnd := uint64(msix.PBAOffset) + pbaBytes
+	issues = appendMSIXBoundsIssue(issues, "PBA", msix.PBABIR, pbaEnd, barSizes)
+	return issues
+}
+
+func appendMSIXBoundsIssue(issues []string, kind string, barIndex int, end uint64, barSizes map[int]uint64) []string {
+	size, ok := barSizes[barIndex]
+	if !ok || size == 0 {
+		return append(issues, fmt.Sprintf("MSI-X %s references unavailable BAR%d", kind, barIndex))
+	}
+	if end > size {
+		return append(issues, fmt.Sprintf("MSI-X %s exceeds BAR%d: end 0x%x, size 0x%x", kind, barIndex, end, size))
+	}
+	return issues
+}

--- a/internal/donor/validate_test.go
+++ b/internal/donor/validate_test.go
@@ -1,0 +1,36 @@
+package donor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func TestValidateDeviceLayoutReportsBARAndMSIXBounds(t *testing.T) {
+	ctx := &DeviceContext{
+		BARs: []pci.BAR{
+			{Index: 0, Type: pci.BARTypeMem32, Size: 0x1000},
+			{Index: 5, Type: pci.BARTypeMem64, Size: 0x1000, Is64Bit: true},
+		},
+		MSIXData: &MSIXData{TableSize: 4, TableBIR: 0, TableOffset: 0xff0, PBABIR: 3, PBAOffset: 0},
+	}
+
+	issues := ValidateDeviceLayout(ctx)
+	joined := strings.Join(issues, "\n")
+	for _, want := range []string{"64-bit BAR5 has no upper BAR", "MSI-X table exceeds BAR0", "MSI-X PBA references unavailable BAR3"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("issues = %v, want %q", issues, want)
+		}
+	}
+}
+
+func TestValidateDeviceLayoutAcceptsValidMSIXPlacement(t *testing.T) {
+	ctx := &DeviceContext{
+		BARs:     []pci.BAR{{Index: 0, Type: pci.BARTypeMem64, Size: 0x2000, Is64Bit: true}},
+		MSIXData: &MSIXData{TableSize: 4, TableBIR: 0, TableOffset: 0x1000, PBABIR: 0, PBAOffset: 0x1100},
+	}
+	if issues := ValidateDeviceLayout(ctx); len(issues) != 0 {
+		t.Fatalf("ValidateDeviceLayout() = %v, want no issues", issues)
+	}
+}

--- a/internal/firmware/codegen/codegen.go
+++ b/internal/firmware/codegen/codegen.go
@@ -48,7 +48,7 @@ func GenerateConfigSpaceCOE(cs *pci.ConfigSpace) string {
 // GenerateWritemaskCOE outputs the writemask COE (1=writable, 0=read-only).
 // Shadow BRAM is the sole read source under cfgtlp_zero=0, so masks match BAR
 // sizes (sizing probes return size-encoded values); identity regs stay read-only.
-func GenerateWritemaskCOE(cs *pci.ConfigSpace) string {
+func GenerateWritemask(cs *pci.ConfigSpace) []uint32 {
 	masks := make([]uint32, shadowCfgSpaceWords)
 
 	// 0x40-0xFF capabilities: fully writable. Locking here would desync shadow BRAM from the IP core.
@@ -94,13 +94,18 @@ func GenerateWritemaskCOE(cs *pci.ConfigSpace) string {
 	masks[14] = 0x00000000 // 0x38: reserved
 	masks[15] = 0x000000FF // 0x3C: IntLine writable, IntPin/MinGnt/MaxLat RO
 
+	return masks
+}
+
+// GenerateWritemaskCOE outputs the writemask COE (1=writable, 0=read-only).
+func GenerateWritemaskCOE(cs *pci.ConfigSpace) string {
 	return formatCOE(
 		"; PCILeechGen - Configuration Space Write Mask (4KB shadow)\n"+
 			"; 1 = writable bit, 0 = read-only bit\n"+
 			"; BAR masks match scrubbed BAR sizes for correct BAR sizing\n"+
 			"; Identity registers (VID/DID, ClassCode, SubsysIDs) are read-only\n"+
 			";\n",
-		masks,
+		GenerateWritemask(cs),
 	)
 }
 

--- a/internal/pci/capability_validate.go
+++ b/internal/pci/capability_validate.go
@@ -1,0 +1,62 @@
+package pci
+
+import "fmt"
+
+// ValidateCapabilityChains reports malformed standard and extended capability links.
+func ValidateCapabilityChains(cs *ConfigSpace) []string {
+	if cs == nil {
+		return []string{"configuration space is nil"}
+	}
+
+	var issues []string
+	if cs.HasCapabilities() {
+		issues = append(issues, validateStandardCapabilityChain(cs)...)
+	}
+	if cs.Size >= ConfigSpaceSize {
+		issues = append(issues, validateExtendedCapabilityChain(cs)...)
+	}
+	return issues
+}
+
+func validateStandardCapabilityChain(cs *ConfigSpace) []string {
+	visited := make(map[int]bool)
+	ptr := int(cs.CapabilityPointer())
+	for ptr != 0 {
+		if ptr < 0x40 || ptr > 0xFC {
+			return []string{fmt.Sprintf("standard capability pointer 0x%03x outside 0x040-0x0fc", ptr)}
+		}
+		if ptr&3 != 0 {
+			return []string{fmt.Sprintf("standard capability pointer 0x%03x is not DWORD-aligned", ptr)}
+		}
+		if visited[ptr] {
+			return []string{fmt.Sprintf("standard capability loop at 0x%03x", ptr)}
+		}
+		visited[ptr] = true
+		ptr = int(cs.ReadU8(ptr + 1))
+	}
+	return nil
+}
+
+func validateExtendedCapabilityChain(cs *ConfigSpace) []string {
+	visited := make(map[int]bool)
+	ptr := 0x100
+	for ptr != 0 {
+		if ptr < 0x100 || ptr > 0xFFC {
+			return []string{fmt.Sprintf("extended capability pointer 0x%03x outside 0x100-0xffc", ptr)}
+		}
+		if ptr&3 != 0 {
+			return []string{fmt.Sprintf("extended capability pointer 0x%03x is not DWORD-aligned", ptr)}
+		}
+		if visited[ptr] {
+			return []string{fmt.Sprintf("extended capability loop at 0x%03x", ptr)}
+		}
+		visited[ptr] = true
+
+		header := cs.ReadU32(ptr)
+		if header == 0 || header == 0xFFFFFFFF {
+			return nil
+		}
+		ptr = int((header >> 20) & 0xFFF)
+	}
+	return nil
+}

--- a/internal/pci/capability_validate_test.go
+++ b/internal/pci/capability_validate_test.go
@@ -1,0 +1,67 @@
+package pci
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateCapabilityChainsAcceptsValidChains(t *testing.T) {
+	cs := NewConfigSpace()
+	cs.WriteU16(0x06, 0x0010)
+	cs.WriteU8(0x34, 0x40)
+	cs.WriteU8(0x40, CapIDPowerManagement)
+	cs.WriteU8(0x41, 0x50)
+	cs.WriteU8(0x50, CapIDPCIExpress)
+	cs.WriteU32(0x100, uint32(ExtCapIDAER)|(1<<16)|(0x140<<20))
+	cs.WriteU32(0x140, uint32(ExtCapIDDeviceSerialNumber)|(1<<16))
+
+	if issues := ValidateCapabilityChains(cs); len(issues) != 0 {
+		t.Fatalf("ValidateCapabilityChains() = %v, want no issues", issues)
+	}
+}
+
+func TestValidateCapabilityChainsReportsLoopsAndInvalidPointers(t *testing.T) {
+	tests := []struct {
+		name string
+		make func(*ConfigSpace)
+		want string
+	}{
+		{
+			name: "standard loop",
+			make: func(cs *ConfigSpace) {
+				cs.WriteU16(0x06, 0x0010)
+				cs.WriteU8(0x34, 0x40)
+				cs.WriteU8(0x40, CapIDPowerManagement)
+				cs.WriteU8(0x41, 0x40)
+			},
+			want: "standard capability loop at 0x040",
+		},
+		{
+			name: "standard pointer below capability area",
+			make: func(cs *ConfigSpace) {
+				cs.WriteU16(0x06, 0x0010)
+				cs.WriteU8(0x34, 0x20)
+			},
+			want: "standard capability pointer 0x020 outside 0x040-0x0fc",
+		},
+		{
+			name: "extended loop",
+			make: func(cs *ConfigSpace) {
+				cs.WriteU32(0x100, uint32(ExtCapIDAER)|(1<<16)|(0x140<<20))
+				cs.WriteU32(0x140, uint32(ExtCapIDDeviceSerialNumber)|(1<<16)|(0x100<<20))
+			},
+			want: "extended capability loop at 0x100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := NewConfigSpace()
+			tt.make(cs)
+			issues := ValidateCapabilityChains(cs)
+			if len(issues) != 1 || !strings.Contains(issues[0], tt.want) {
+				t.Fatalf("ValidateCapabilityChains() = %v, want %q", issues, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## summary
- report donor identity, capabilities, BAR layout, generated write masks, and validation issues
- reject malformed capability chains, invalid 64-bit BAR5 layouts, and out-of-bounds MSI-X placement
- capture checksummed initialization sessions with config, PCI resources, interrupt snapshots, and width-aware MMIO traces
- support guarded trace, driver unbind/bind, and interface down/up capture scenarios with restoration paths
- compare repeated sessions into phases, register evidence, polling loops, write effects, dependencies, config transitions, confidence, and MAC candidates

## affected modules
- `cmd/pcileechgen`
- `internal/donor/session`
- `internal/donor/mmio`
- `internal/pci`
- `internal/firmware/codegen`

## tests
- `go test ./...`
- `go test -race ./...`
- changed-package `golangci-lint` passes
- offline multi-session text and JSON smoke tests

`make check` still reports pre-existing lint findings in untouched `internal/firmware/scrub`, `internal/firmware/output`, and existing output tests; changed packages are clean.