### PR TITLE
feat: add family-aware Intel Ethernet DMA early access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,31 @@ check: vet lint test
 EARLYACCESS_NAME  ?= PCILeechGen-EarlyAccess
 EARLYACCESS_STAMP ?= $(shell date +%m%d%y)
 EARLYACCESS_ZIP   ?= $(EARLYACCESS_NAME)-$(EARLYACCESS_STAMP).zip
+EARLYACCESS_REQUIRED = \
+	Makefile go.mod cmd/pcileechgen/main.go \
+	internal/firmware/svgen/templates/ethernet_dma_engine.sv.tmpl \
+	internal/firmware/svgen/templates/bar_controller.sv.tmpl \
+	internal/firmware/svgen/templates/bar_impl_device.sv.tmpl \
+	internal/firmware/output/writer.go \
+	vfio-user/src/behavior_ethernet.c tests/cocotb/test_eth_init.py
 
 early-access:
+	@command -v zip >/dev/null 2>&1 || { echo "zip is required" >&2; exit 1; }
+	@command -v unzip >/dev/null 2>&1 || { echo "unzip is required" >&2; exit 1; }
 	@rm -f "$(EARLYACCESS_ZIP)"
 	@zip -r "$(EARLYACCESS_ZIP)" . \
 		-x '.git/*' 'analysis/*' 'bin/*' 'dist/*' 'pcileech_datastore/*' \
+		   'vfio-user/build' 'vfio-user/build/*' 'tests/cocotb/out*' 'tests/cocotb/out*/**' \
+		   'tests/cocotb/sim_build' 'tests/cocotb/sim_build/' 'tests/cocotb/sim_build/**' \
+		   '**/__pycache__' '**/__pycache__/' '**/__pycache__/**' \
+		   '*.pyc' '*.pyo' '*.dSYM' '*.dSYM/**' '*.o' '*.so' \
 		   '*.zip' '.DS_Store' '*/.DS_Store' '.idea/*' '.vscode/*' \
 		   'coverage.out' 'coverage.html' '*.swp' '*.swo' '*~' \
 		> /dev/null
+	@unzip -t "$(EARLYACCESS_ZIP)" >/dev/null
+	@for file in $(EARLYACCESS_REQUIRED); do \
+		unzip -Z1 "$(EARLYACCESS_ZIP)" | grep -Fxq "$$file" || { \
+			echo "early-access archive is missing $$file" >&2; exit 1; \
+		}; \
+	done
 	@echo "$(EARLYACCESS_ZIP)"

--- a/cmd/pcileechgen/build.go
+++ b/cmd/pcileechgen/build.go
@@ -15,18 +15,20 @@ import (
 
 // buildFlags groups all build command flags.
 type buildFlags struct {
-	bdf           string
-	board         string
-	vivadoPath    string
-	output        string
-	skipVivado    bool
-	jobs          int
-	timeout       int
-	libDir        string
-	fromJSON      string
-	stockBar      bool
-	behaviorRules string
-	force         bool
+	bdf               string
+	board             string
+	vivadoPath        string
+	output            string
+	skipVivado        bool
+	jobs              int
+	timeout           int
+	libDir            string
+	fromJSON          string
+	stockBar          bool
+	behaviorRules     string
+	force             bool
+	allowStateChanges bool
+	profileBARs       bool
 }
 
 var buildOpts buildFlags
@@ -102,6 +104,12 @@ func runBuild(cmd *cobra.Command, args []string) error {
 func loadDonorContext() (*donor.DeviceContext, error) {
 	var ctx *donor.DeviceContext
 	var err error
+	if buildOpts.fromJSON != "" && buildOpts.bdf != "" {
+		return nil, fmt.Errorf("--bdf and --from-json are mutually exclusive")
+	}
+	if buildOpts.profileBARs && !buildOpts.allowStateChanges {
+		return nil, fmt.Errorf("--profile-bars requires --allow-device-state-changes")
+	}
 	if buildOpts.fromJSON != "" {
 		slog.Info("loading device context", "file", buildOpts.fromJSON)
 		ctx, err = donor.LoadContext(buildOpts.fromJSON)
@@ -118,7 +126,16 @@ func loadDonorContext() (*donor.DeviceContext, error) {
 		}
 		slog.Info("target device", "bdf", bdf.String())
 		slog.Info("collecting donor device data")
-		collector := donor.NewCollector()
+		if buildOpts.allowStateChanges {
+			slog.Warn("live donor state changes enabled; collection may bind drivers, change power/command registers, or reset the device")
+		}
+		if buildOpts.profileBARs {
+			slog.Warn("destructive BAR profiling enabled; probe writes may trigger irreversible device side effects")
+		}
+		collector := donor.NewCollectorWithOptions(donor.CollectorOptions{
+			AllowStateChanges: buildOpts.allowStateChanges,
+			ProfileBARs:       buildOpts.profileBARs,
+		})
 		ctx, err = collector.Collect(bdf)
 		if err != nil {
 			return nil, fmt.Errorf("device data collection failed: %w", err)
@@ -173,6 +190,8 @@ func init() {
 	buildCmd.Flags().StringVar(&buildOpts.libDir, "lib-dir", "lib/pcileech-fpga", "path to pcileech-fpga library")
 	buildCmd.Flags().BoolVar(&buildOpts.stockBar, "stock-bar", false, "use stock bar controller (diagnostic: skip custom SV modules)")
 	buildCmd.Flags().BoolVar(&buildOpts.force, "force", false, "ignore donor BAR > board BRAM check")
+	buildCmd.Flags().BoolVar(&buildOpts.allowStateChanges, "allow-device-state-changes", false, "allow live collection to change power state, PCI command, driver binding, or reset the donor")
+	buildCmd.Flags().BoolVar(&buildOpts.profileBARs, "profile-bars", false, "destructively probe live BAR registers (requires --allow-device-state-changes)")
 
 	_ = buildCmd.MarkFlagRequired("board")
 

--- a/cmd/pcileechgen/build_rules_test.go
+++ b/cmd/pcileechgen/build_rules_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sercanarga/pcileechgen/internal/donor"
@@ -68,5 +69,23 @@ func TestLoadDonorContext_RejectsInvalidBehaviorRules(t *testing.T) {
 	buildOpts = buildFlags{fromJSON: contextPath, behaviorRules: rulesPath}
 	if _, err := loadDonorContext(); err == nil {
 		t.Fatal("expected unsupported rule schema version to be rejected")
+	}
+}
+
+func TestLoadDonorContextRejectsMutuallyExclusiveSources(t *testing.T) {
+	previous := buildOpts
+	t.Cleanup(func() { buildOpts = previous })
+	buildOpts = buildFlags{bdf: "0000:01:00.0", fromJSON: "context.json"}
+	if _, err := loadDonorContext(); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("loadDonorContext error = %v", err)
+	}
+}
+
+func TestLoadDonorContextRequiresConsentForBARProfiling(t *testing.T) {
+	previous := buildOpts
+	t.Cleanup(func() { buildOpts = previous })
+	buildOpts = buildFlags{bdf: "0000:01:00.0", profileBARs: true}
+	if _, err := loadDonorContext(); err == nil || !strings.Contains(err.Error(), "requires --allow-device-state-changes") {
+		t.Fatalf("loadDonorContext error = %v", err)
 	}
 }

--- a/internal/donor/collector.go
+++ b/internal/donor/collector.go
@@ -23,23 +23,40 @@ const (
 
 // Collector gathers donor PCI data from sysfs.
 type Collector struct {
-	sysfs *SysfsReader
+	sysfs   *SysfsReader
+	options CollectorOptions
+}
+
+// CollectorOptions controls operations that can alter a live donor. Both
+// options default to false so ordinary collection remains read-only.
+type CollectorOptions struct {
+	AllowStateChanges bool
+	ProfileBARs       bool
 }
 
 func NewCollector() *Collector {
+	return NewCollectorWithOptions(CollectorOptions{})
+}
+
+func NewCollectorWithOptions(options CollectorOptions) *Collector {
 	return &Collector{
-		sysfs: NewSysfsReader(),
+		sysfs:   NewSysfsReader(),
+		options: options,
 	}
 }
 
 // NewCollectorWithSysfs lets tests inject a fake sysfs reader.
 func NewCollectorWithSysfs(sr *SysfsReader) *Collector {
 	return &Collector{
-		sysfs: sr,
+		sysfs:   sr,
+		options: CollectorOptions{},
 	}
 }
 
 func (c *Collector) Collect(bdf pci.BDF) (*DeviceContext, error) {
+	if c.options.ProfileBARs && !c.options.AllowStateChanges {
+		return nil, fmt.Errorf("BAR profiling requires explicit permission for device state changes")
+	}
 	ctx := &DeviceContext{
 		CollectedAt: time.Now(),
 		ToolVersion: version.Version,
@@ -68,10 +85,15 @@ func (c *Collector) Collect(bdf pci.BDF) (*DeviceContext, error) {
 
 	// One shared native-driver visit for the whole Collect() (see runNativeVisit):
 	// the BAR fallback and the NVMe identity capture reuse a single rebind cycle.
-	visit := &nativeVisitCache{bdf: bdf, bars: bars, nvme: isNVMeClass(ctx.Device.ClassCode)}
+	var visit *nativeVisitCache
+	if c.options.AllowStateChanges {
+		visit = &nativeVisitCache{bdf: bdf, bars: bars, nvme: isNVMeClass(ctx.Device.ClassCode)}
+	}
 
 	ctx.BARContents = c.collectBARMemory(bdf, bars, visit)
-	ctx.BARProfiles = c.collectBARProfiles(bdf, bars, ctx.BARContents)
+	if c.options.ProfileBARs {
+		ctx.BARProfiles = c.collectBARProfiles(bdf, bars, ctx.BARContents)
+	}
 	ctx.Capabilities = pci.ParseCapabilities(cs)
 	ctx.ExtCapabilities = pci.ParseExtCapabilities(cs)
 	ctx.MSIXData = c.collectMSIXData(cs, ctx.BARContents)
@@ -453,6 +475,9 @@ func (c *Collector) collectNVMeIdentity(bdf pci.BDF, classCode uint32, vc *nativ
 func (c *Collector) collectConfigSpace(bdf pci.BDF) (*pci.ConfigSpace, error) {
 	cs, err := c.sysfs.ReadConfigSpace(bdf)
 	if err != nil {
+		if !c.options.AllowStateChanges {
+			return nil, fmt.Errorf("config space read failed for %s: %w (VFIO binding requires --allow-device-state-changes)", bdf, err)
+		}
 		slog.Info("sysfs config read failed, trying VFIO", "error", err)
 		if bindErr := vfio.BindToVFIO(bdf.String()); bindErr != nil {
 			return nil, fmt.Errorf("config space read failed for %s (sysfs: %w, VFIO: %w)", bdf, err, bindErr)
@@ -473,19 +498,20 @@ func (c *Collector) collectBARMemory(bdf pci.BDF, bars []pci.BAR, vc *nativeVisi
 
 	contents := make(map[int][]byte)
 
-	// wake device from D3 if needed, otherwise BAR reads return 0xFF
-	if err := vfio.WakeToD0(bdf.String()); err != nil {
-		slog.Warn("could not wake device to D0", "bdf", bdf, "error", err)
+	if c.options.AllowStateChanges {
+		// PMCSR writes are intentionally opt-in; ordinary collection is read-only.
+		if err := vfio.WakeToD0(bdf.String()); err != nil {
+			slog.Warn("could not wake device to D0", "bdf", bdf, "error", err)
+		}
 	}
 
-	// try reading without touching config space first.
-	// works on most devices since BIOS/previous driver left memory space on.
+	// Always try a read-only BAR snapshot first.
 	c.readBARs(bdf, eligible, contents)
-	if !memBARsAllFF(contents, bars) {
+	if !memBARsAllFF(contents, bars) || !c.options.AllowStateChanges {
 		return contents
 	}
 
-	// didn't work, try enabling memory space (vfio-pci clears it on bind).
+	// Explicit consent allows recovery operations that modify donor state.
 	if vfio.IsBoundToVFIO(bdf.String()) {
 		if err := vfio.EnableMemorySpace(bdf.String()); err != nil {
 			slog.Warn("could not enable PCI memory space",
@@ -501,9 +527,8 @@ func (c *Collector) collectBARMemory(bdf pci.BDF, bars []pci.BAR, vc *nativeVisi
 		}
 	}
 
-	// last resort: let the native driver init the device (single shared visit).
-	// avoid VFIO sessions here, session close can trigger FLR.
-	if vfio.IsBoundToVFIO(bdf.String()) {
+	// Last resort after explicit consent: let the native driver initialize it.
+	if vc != nil && vfio.IsBoundToVFIO(bdf.String()) {
 		slog.Info("all memory BAR contents are 0xFF, attempting native driver visit")
 		res, vErr := c.runNativeVisit(vc)
 		if vErr != nil {

--- a/internal/donor/collector_test.go
+++ b/internal/donor/collector_test.go
@@ -7,6 +7,21 @@ import (
 	"github.com/sercanarga/pcileechgen/internal/pci"
 )
 
+func TestCollectorDefaultsToReadOnly(t *testing.T) {
+	collector := NewCollector()
+	if collector.options.AllowStateChanges || collector.options.ProfileBARs {
+		t.Fatalf("unsafe collector defaults: %+v", collector.options)
+	}
+}
+
+func TestCollectorBARProfilingRequiresStateChangeConsent(t *testing.T) {
+	collector := NewCollectorWithOptions(CollectorOptions{ProfileBARs: true})
+	_, err := collector.Collect(pci.BDF{})
+	if err == nil || !strings.Contains(err.Error(), "requires explicit permission") {
+		t.Fatalf("Collect error = %v, want explicit consent error", err)
+	}
+}
+
 func TestIsAllFF(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/donor/context.go
+++ b/internal/donor/context.go
@@ -2,9 +2,11 @@
 package donor
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"time"
@@ -12,6 +14,8 @@ import (
 	"github.com/sercanarga/pcileechgen/internal/donor/behavior"
 	"github.com/sercanarga/pcileechgen/internal/pci"
 )
+
+const maxContextFileSize = 32 << 20
 
 // MSIXData holds donor MSI-X table content.
 type MSIXData struct {
@@ -116,8 +120,19 @@ func (dc *DeviceContext) ToJSON() ([]byte, error) {
 // UnmarshalJSON implements json.Unmarshaler for DeviceContext.
 func (dc *DeviceContext) UnmarshalJSON(data []byte) error {
 	var j deviceContextJSON
-	if err := json.Unmarshal(data, &j); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&j); err != nil {
 		return fmt.Errorf("failed to parse device context JSON: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("failed to parse device context JSON: trailing data")
+	}
+	if j.ConfigSpaceSize != pci.ConfigSpaceLegacySize && j.ConfigSpaceSize != pci.ConfigSpaceSize {
+		return fmt.Errorf("config_space_size must be %d or %d, got %d", pci.ConfigSpaceLegacySize, pci.ConfigSpaceSize, j.ConfigSpaceSize)
+	}
+	if len(j.ConfigSpaceHex) != j.ConfigSpaceSize/4 {
+		return fmt.Errorf("config_space_hex has %d words, want %d", len(j.ConfigSpaceHex), j.ConfigSpaceSize/4)
 	}
 
 	dc.CollectedAt = j.CollectedAt
@@ -131,16 +146,36 @@ func (dc *DeviceContext) UnmarshalJSON(data []byte) error {
 	dc.NVMeIdentity = j.NVMeIdentity
 	dc.BehaviorRules = j.BehaviorRules
 
+	if len(dc.BARs) > 6 {
+		return fmt.Errorf("bars contains %d entries, maximum is 6", len(dc.BARs))
+	}
+	declaredBARs := make(map[int]pci.BAR, len(dc.BARs))
+	for _, bar := range dc.BARs {
+		if bar.Index < 0 || bar.Index > 5 {
+			return fmt.Errorf("BAR index %d is outside 0..5", bar.Index)
+		}
+		if _, duplicate := declaredBARs[bar.Index]; duplicate {
+			return fmt.Errorf("duplicate BAR index %d", bar.Index)
+		}
+		if !bar.IsDisabled() && (bar.Size == 0 || (bar.Size&(bar.Size-1)) != 0) {
+			return fmt.Errorf("BAR%d size %#x is not a nonzero power of two", bar.Index, bar.Size)
+		}
+		declaredBARs[bar.Index] = bar
+	}
+
 	// Reconstruct config space from hex words
 	if len(j.ConfigSpaceHex) > 0 {
 		dc.ConfigSpace = pci.NewConfigSpace()
 		dc.ConfigSpace.Size = j.ConfigSpaceSize
 		for i, hexWord := range j.ConfigSpaceHex {
-			var word uint32
-			if _, err := fmt.Sscanf(hexWord, "%x", &word); err != nil {
+			if len(hexWord) != 8 {
+				return fmt.Errorf("invalid config space hex word %d (%q): want exactly 8 hexadecimal digits", i, hexWord)
+			}
+			parsed, err := strconv.ParseUint(hexWord, 16, 32)
+			if err != nil {
 				return fmt.Errorf("invalid config space hex word %d (%q): %w", i, hexWord, err)
 			}
-			dc.ConfigSpace.WriteU32(i*4, word)
+			dc.ConfigSpace.WriteU32(i*4, uint32(parsed))
 		}
 	}
 
@@ -149,12 +184,19 @@ func (dc *DeviceContext) UnmarshalJSON(data []byte) error {
 		dc.BARContents = make(map[int][]byte)
 		for idxStr, b64 := range j.BARContents {
 			idx, err := strconv.Atoi(idxStr)
-			if err != nil {
-				return fmt.Errorf("invalid BAR index %q: %w", idxStr, err)
+			if err != nil || idx < 0 || idx > 5 {
+				return fmt.Errorf("invalid BAR index %q", idxStr)
+			}
+			bar, declared := declaredBARs[idx]
+			if !declared || bar.IsDisabled() || bar.IsIO() {
+				return fmt.Errorf("BAR%d content references an undeclared or non-memory BAR", idx)
 			}
 			barData, err := base64.StdEncoding.DecodeString(b64)
 			if err != nil {
 				return fmt.Errorf("failed to decode BAR%d content: %w", idx, err)
+			}
+			if len(barData) > maxBARReadSize || uint64(len(barData)) > bar.Size {
+				return fmt.Errorf("BAR%d content size %d exceeds capture/aperture limit", idx, len(barData))
 			}
 			dc.BARContents[idx] = barData
 		}
@@ -165,10 +207,62 @@ func (dc *DeviceContext) UnmarshalJSON(data []byte) error {
 		dc.BARProfiles = make(map[int]*BARProfile)
 		for idxStr, profile := range j.BARProfiles {
 			idx, err := strconv.Atoi(idxStr)
-			if err != nil {
-				return fmt.Errorf("invalid BAR profile index %q: %w", idxStr, err)
+			if err != nil || idx < 0 || idx > 5 {
+				return fmt.Errorf("invalid BAR profile index %q", idxStr)
+			}
+			bar, declared := declaredBARs[idx]
+			if !declared || bar.IsDisabled() || bar.IsIO() || profile == nil {
+				return fmt.Errorf("BAR%d profile references an undeclared or non-memory BAR", idx)
+			}
+			if profile.BarIndex != idx || profile.Size < 0 || profile.Size > maxBARReadSize || uint64(profile.Size) > bar.Size {
+				return fmt.Errorf("BAR%d profile has invalid index or size", idx)
+			}
+			seenOffsets := make(map[uint32]struct{}, len(profile.Probes))
+			for _, probe := range profile.Probes {
+				if probe.Offset%4 != 0 || uint64(probe.Offset)+4 > uint64(profile.Size) {
+					return fmt.Errorf("BAR%d profile probe offset %#x is out of range or unaligned", idx, probe.Offset)
+				}
+				if _, duplicate := seenOffsets[probe.Offset]; duplicate {
+					return fmt.Errorf("BAR%d profile contains duplicate probe offset %#x", idx, probe.Offset)
+				}
+				if probe.W1CMask&^probe.RWMask != 0 {
+					return fmt.Errorf("BAR%d profile W1C mask is not a subset of RW mask at %#x", idx, probe.Offset)
+				}
+				seenOffsets[probe.Offset] = struct{}{}
 			}
 			dc.BARProfiles[idx] = profile
+		}
+	}
+
+	if dc.NVMeIdentity != nil {
+		for name, raw := range map[string][]byte{
+			"controller": dc.NVMeIdentity.RawControllerIdent,
+			"namespace":  dc.NVMeIdentity.RawNamespaceIdent,
+		} {
+			if len(raw) != 0 && len(raw) != 4096 {
+				return fmt.Errorf("raw NVMe %s identify data must be exactly 4096 bytes", name)
+			}
+		}
+	}
+	if dc.MSIXData != nil {
+		m := dc.MSIXData
+		if m.TableSize < 1 || m.TableSize > 2048 || len(m.Entries) > m.TableSize {
+			return fmt.Errorf("invalid MSI-X table size or entry count")
+		}
+		for name, bir := range map[string]int{"table": m.TableBIR, "PBA": m.PBABIR} {
+			bar, ok := declaredBARs[bir]
+			if !ok || bar.IsDisabled() || bar.IsIO() {
+				return fmt.Errorf("MSI-X %s references invalid BAR%d", name, bir)
+			}
+		}
+		if m.TableOffset%8 != 0 || m.PBAOffset%8 != 0 {
+			return fmt.Errorf("MSI-X table and PBA offsets must be 8-byte aligned")
+		}
+		tableBytes := uint64(m.TableSize) * 16
+		pbaBytes := uint64((m.TableSize+63)/64) * 8
+		if uint64(m.TableOffset)+tableBytes > declaredBARs[m.TableBIR].Size ||
+			uint64(m.PBAOffset)+pbaBytes > declaredBARs[m.PBABIR].Size {
+			return fmt.Errorf("MSI-X table or PBA exceeds its BAR aperture")
 		}
 	}
 
@@ -177,6 +271,9 @@ func (dc *DeviceContext) UnmarshalJSON(data []byte) error {
 
 // FromJSON deserializes a DeviceContext from JSON.
 func FromJSON(data []byte) (*DeviceContext, error) {
+	if len(data) > maxContextFileSize {
+		return nil, fmt.Errorf("device context exceeds %d-byte limit", maxContextFileSize)
+	}
 	dc := &DeviceContext{}
 	if err := json.Unmarshal(data, dc); err != nil {
 		return nil, err
@@ -185,6 +282,10 @@ func FromJSON(data []byte) (*DeviceContext, error) {
 	if dc.ConfigSpace == nil {
 		return nil, fmt.Errorf("config_space_hex not found in JSON, file may be from an unsupported tool")
 	}
+
+	// Capability caches are derived data; never trust serialized copies.
+	dc.Capabilities = pci.ParseCapabilities(dc.ConfigSpace)
+	dc.ExtCapabilities = pci.ParseExtCapabilities(dc.ConfigSpace)
 
 	if dc.BehaviorRules != nil {
 		if err := behavior.Validate(dc.BehaviorRules); err != nil {
@@ -206,9 +307,17 @@ func SaveContext(ctx *DeviceContext, path string) error {
 
 // LoadContext restores a DeviceContext from a JSON file.
 func LoadContext(path string) (*DeviceContext, error) {
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read device context file: %w", err)
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, maxContextFileSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read device context file: %w", err)
+	}
+	if len(data) > maxContextFileSize {
+		return nil, fmt.Errorf("device context exceeds %d-byte limit", maxContextFileSize)
 	}
 	return FromJSON(data)
 }

--- a/internal/donor/context_validation_test.go
+++ b/internal/donor/context_validation_test.go
@@ -1,0 +1,82 @@
+package donor
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/sercanarga/pcileechgen/internal/pci"
+)
+
+func validContextJSON(t *testing.T) []byte {
+	t.Helper()
+	data, err := (&DeviceContext{ConfigSpace: pci.NewConfigSpace()}).ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func TestFromJSONRejectsUnknownFields(t *testing.T) {
+	data := bytes.TrimSuffix(validContextJSON(t), []byte("}"))
+	data = append(data, []byte(`,"unknown_field":true}`)...)
+	if _, err := FromJSON(data); err == nil {
+		t.Fatal("unknown field was accepted")
+	}
+}
+
+func TestFromJSONRejectsInvalidConfigSize(t *testing.T) {
+	cs := pci.NewConfigSpace()
+	cs.Size = 64
+	data, err := (&DeviceContext{ConfigSpace: cs}).ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := FromJSON(data); err == nil {
+		t.Fatal("invalid config-space size was accepted")
+	}
+}
+
+func TestFromJSONRejectsDuplicateBARs(t *testing.T) {
+	ctx := &DeviceContext{
+		ConfigSpace: pci.NewConfigSpace(),
+		BARs: []pci.BAR{
+			{Index: 0, Type: pci.BARTypeMem32, Size: 4096},
+			{Index: 0, Type: pci.BARTypeMem32, Size: 4096},
+		},
+	}
+	data, err := ctx.ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := FromJSON(data); err == nil {
+		t.Fatal("duplicate BAR index was accepted")
+	}
+}
+
+func TestFromJSONRejectsInvalidRawNVMeIdentityLength(t *testing.T) {
+	ctx := &DeviceContext{
+		ConfigSpace:  pci.NewConfigSpace(),
+		NVMeIdentity: &NVMeIdentity{RawControllerIdent: []byte{1}},
+	}
+	data, err := ctx.ToJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := FromJSON(data); err == nil {
+		t.Fatal("invalid raw Identify length was accepted")
+	}
+}
+
+func FuzzFromJSONContext(f *testing.F) {
+	seed, err := (&DeviceContext{ConfigSpace: pci.NewConfigSpace()}).ToJSON()
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(seed)
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 1<<20 {
+			t.Skip()
+		}
+		_, _ = FromJSON(data)
+	})
+}

--- a/internal/donor/context_w1c_test.go
+++ b/internal/donor/context_w1c_test.go
@@ -12,6 +12,7 @@ func TestDeviceContext_W1CMaskRoundTrip(t *testing.T) {
 	ctx := &DeviceContext{
 		CollectedAt: time.Now(),
 		ConfigSpace: pci.NewConfigSpace(),
+		BARs:        []pci.BAR{{Index: 0, Type: pci.BARTypeMem32, Size: 4096}},
 		BARProfiles: map[int]*BARProfile{
 			0: {BarIndex: 0, Size: 4096, Probes: []BARProbeResult{
 				{Offset: 0x10, Original: 0x000000FF, RWMask: 0x000000FF, W1CMask: 0x00000010, MaybeRW1C: true},

--- a/internal/donor/nvme_identity_test.go
+++ b/internal/donor/nvme_identity_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestDeviceContext_NVMeIdentity_RoundTrip(t *testing.T) {
 	cs := pci.NewConfigSpace()
-	cs.Size = 64
+	cs.Size = pci.ConfigSpaceLegacySize
 	cs.WriteU32(0, 0x12345678)
 
 	ctx := &DeviceContext{
@@ -45,7 +45,7 @@ func TestDeviceContext_NVMeIdentity_RoundTrip(t *testing.T) {
 
 func TestDeviceContext_NVMeIdentity_NilOmitted(t *testing.T) {
 	cs := pci.NewConfigSpace()
-	cs.Size = 64
+	cs.Size = pci.ConfigSpaceLegacySize
 	cs.WriteU32(0, 0x12345678)
 
 	ctx := &DeviceContext{ConfigSpace: cs}

--- a/internal/firmware/barmodel/ethernet_dma_model_test.go
+++ b/internal/firmware/barmodel/ethernet_dma_model_test.go
@@ -1,0 +1,21 @@
+package barmodel
+
+import "testing"
+
+func TestIntelE1000BARModelHasDescriptorDMARegisters(t *testing.T) {
+	model := BuildIntelE1000BARModel(nil)
+	want := []uint32{0x14, 0x20, 0xC0, 0xC8, 0xD0, 0xD8, 0x2800, 0x2804, 0x2808,
+		0x2810, 0x2818, 0x3800, 0x3804, 0x3808, 0x3810, 0x3818}
+	for _, offset := range want {
+		found := false
+		for _, reg := range model.Registers {
+			if reg.Offset == offset {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Ethernet BAR missing register 0x%X", offset)
+		}
+	}
+}

--- a/internal/firmware/barmodel/model.go
+++ b/internal/firmware/barmodel/model.go
@@ -522,6 +522,60 @@ func buildEthernetBARModel(barData []byte) *BARModel {
 	}
 }
 
+// BuildIntelE1000BARModel returns the tested Intel I219-LM/e1000e register
+// subset used by the descriptor DMA engine. It is intentionally separate from
+// the class-wide Realtek model: PCI class 0x020000 alone does not identify a
+// compatible descriptor or register layout.
+func BuildIntelE1000BARModel(barData []byte) *BARModel {
+	regs := []BARRegister{
+		{Offset: 0x0000, Width: 4, Name: "CTRL", RWMask: 0xFFFFFFFF},
+		{Offset: 0x0008, Width: 4, Name: "STATUS", Reset: 0x80080783},
+		{Offset: 0x0014, Width: 4, Name: "EERD", RWMask: 0x00000001, IsFSMDriven: true},
+		{Offset: 0x0020, Width: 4, Name: "MDIC", Reset: 0x08000000, RWMask: 0xFFFFFFFF, IsFSMDriven: true},
+		{Offset: 0x00C0, Width: 4, Name: "ICR", IsFSMDriven: true},
+		{Offset: 0x00C8, Width: 4, Name: "ICS", RWMask: 0xFFFFFFFF, IsFSMDriven: true},
+		{Offset: 0x00D0, Width: 4, Name: "IMS", RWMask: 0xFFFFFFFF, IsFSMDriven: true},
+		{Offset: 0x00D8, Width: 4, Name: "IMC", RWMask: 0xFFFFFFFF, IsFSMDriven: true},
+		{Offset: 0x0100, Width: 4, Name: "RCTL", RWMask: 0xFFFFFFFF},
+		{Offset: 0x0400, Width: 4, Name: "TCTL", RWMask: 0xFFFFFFFF},
+		{Offset: 0x2800, Width: 4, Name: "RDBAL", RWMask: 0xFFFFFF80},
+		{Offset: 0x2804, Width: 4, Name: "RDBAH", RWMask: 0xFFFFFFFF},
+		{Offset: 0x2808, Width: 4, Name: "RDLEN", RWMask: 0x000FFF80},
+		{Offset: 0x2810, Width: 4, Name: "RDH", IsFSMDriven: true},
+		{Offset: 0x2818, Width: 4, Name: "RDT", RWMask: 0x0000FFFF},
+		{Offset: 0x3800, Width: 4, Name: "TDBAL", RWMask: 0xFFFFFF80},
+		{Offset: 0x3804, Width: 4, Name: "TDBAH", RWMask: 0xFFFFFFFF},
+		{Offset: 0x3808, Width: 4, Name: "TDLEN", RWMask: 0x000FFF80},
+		{Offset: 0x3810, Width: 4, Name: "TDH", IsFSMDriven: true},
+		{Offset: 0x3818, Width: 4, Name: "TDT", RWMask: 0x0000FFFF},
+		{Offset: 0x5400, Width: 4, Name: "RAL0", Reset: 0x49435002, RWMask: 0xFFFFFFFF},
+		{Offset: 0x5404, Width: 4, Name: "RAH0", Reset: 0x8000454C, RWMask: 0x8000FFFF},
+	}
+
+	populateResetValues(regs, barData)
+	for i := range regs {
+		switch regs[i].Offset {
+		case 0x0008:
+			if regs[i].Reset == 0 {
+				regs[i].Reset = 0x80080783
+			}
+		case 0x0020:
+			if regs[i].Reset == 0 {
+				regs[i].Reset = 0x08000000
+			}
+		case 0x5400:
+			if regs[i].Reset == 0 {
+				regs[i].Reset = 0x49435002
+			}
+		case 0x5404:
+			if regs[i].Reset == 0 {
+				regs[i].Reset = 0x8000454C
+			}
+		}
+	}
+	return &BARModel{Size: len(barData), Registers: regs}
+}
+
 // HD Audio BAR0. Sub-word regs packed into DWORDs for SV template.
 // buildAudioBARModel builds the HD Audio BAR0 register map.
 // When donor BAR data is all 0xFF (no codec connected), spec defaults are used.

--- a/internal/firmware/devclass/emulation.go
+++ b/internal/firmware/devclass/emulation.go
@@ -1,0 +1,132 @@
+package devclass
+
+// EmulationLevel describes the deepest device-facing behavior implemented for a
+// donor family. Levels are ordered from identity-only fallback to host-memory
+// DMA and interrupt behavior.
+type EmulationLevel string
+
+const (
+	EmulationIdentity  EmulationLevel = "identity"
+	EmulationRegisters EmulationLevel = "registers"
+	EmulationBehavior  EmulationLevel = "behavior"
+	EmulationDMA       EmulationLevel = "dma"
+)
+
+// EmulationSupport is the machine-readable support contract for one donor.
+// Validated means that the stated level has executable regression coverage; it
+// does not imply that every command or proprietary firmware path is emulated.
+type EmulationSupport struct {
+	Family      string         `json:"family"`
+	Level       EmulationLevel `json:"level"`
+	Validated   bool           `json:"validated"`
+	Limitations []string       `json:"limitations,omitempty"`
+}
+
+// Complete reports whether the device has validated DMA-level behavior without
+// a known functional limitation. Most real hardware families intentionally do
+// not meet this bar yet; callers must not infer completeness from PCI class.
+func (s EmulationSupport) Complete() bool {
+	return s.Level == EmulationDMA && s.Validated && len(s.Limitations) == 0
+}
+
+// AssessEmulation identifies the implemented family and current support level.
+// Device-family dispatch is deliberately vendor/device aware where register or
+// descriptor formats differ within one PCI class.
+func AssessEmulation(classCode uint32, vendorID, deviceID uint16, hasMSIX bool) EmulationSupport {
+	baseClass := byte(classCode >> 16)
+	subClass := byte(classCode >> 8)
+	progIF := byte(classCode)
+
+	switch {
+	case baseClass == 0x01 && subClass == 0x08 && progIF == 0x02:
+		return EmulationSupport{
+			Family:    "nvme",
+			Level:     EmulationDMA,
+			Validated: true,
+			Limitations: []string{
+				"admin and bounded BRAM-backed I/O paths only; arbitrary vendor commands are not emulated",
+			},
+		}
+	case baseClass == 0x02 && subClass == 0x00 && vendorID == 0x8086 && deviceID == 0x15B7:
+		if hasMSIX {
+			return EmulationSupport{
+				Family:      "intel-e1000e-i219",
+				Level:       EmulationRegisters,
+				Validated:   false,
+				Limitations: []string{"descriptor DMA is disabled because the Ethernet MSI-X delivery path is not implemented"},
+			}
+		}
+		return EmulationSupport{
+			Family:    "intel-e1000e-i219",
+			Level:     EmulationDMA,
+			Validated: true,
+			Limitations: []string{
+				"single legacy descriptor queue, MSI-only interrupts, and 2048-byte receive buffers",
+			},
+		}
+	case baseClass == 0x02 && subClass == 0x00 && vendorID == 0x10EC && deviceID == 0x8125:
+		return EmulationSupport{
+			Family:      "realtek-rtl8125",
+			Level:       EmulationRegisters,
+			Validated:   true,
+			Limitations: []string{"link/register startup only; Realtek descriptor DMA and firmware paths are not emulated"},
+		}
+	case baseClass == 0x02 && subClass == 0x00:
+		return EmulationSupport{
+			Family:      "ethernet-generic",
+			Level:       EmulationIdentity,
+			Validated:   false,
+			Limitations: []string{"unknown Ethernet register and descriptor family; donor-backed static fallback only"},
+		}
+	case baseClass == 0x0C && subClass == 0x03 && progIF == 0x30:
+		return EmulationSupport{
+			Family:      "xhci-generic",
+			Level:       EmulationRegisters,
+			Validated:   false,
+			Limitations: []string{"command ring, transfer rings, event ring DMA, slots, endpoints, and interrupts are not emulated"},
+		}
+	case baseClass == 0x04 && subClass == 0x03:
+		return EmulationSupport{
+			Family:    "hda-generic",
+			Level:     EmulationDMA,
+			Validated: true,
+			Limitations: []string{
+				"basic codec verbs and RIRB DMA only; stream DMA and vendor codec extensions are not emulated",
+			},
+		}
+	case baseClass == 0x01 && subClass == 0x06:
+		return EmulationSupport{
+			Family:      "ahci-generic",
+			Level:       EmulationRegisters,
+			Validated:   false,
+			Limitations: []string{"command-list/FIS DMA and ATA command execution are not emulated"},
+		}
+	case baseClass == 0x02 && subClass == 0x80:
+		family := "wifi-generic"
+		if vendorID == 0x14C3 {
+			family = "wifi-mediatek"
+		}
+		return EmulationSupport{
+			Family:      family,
+			Level:       EmulationRegisters,
+			Validated:   false,
+			Limitations: []string{"firmware upload, mailbox, DMA queues, radio, and interrupt behavior are not emulated"},
+		}
+	case baseClass == 0x03:
+		return EmulationSupport{
+			Family:      "gpu-generic",
+			Level:       EmulationRegisters,
+			Validated:   false,
+			Limitations: []string{"VBIOS, engines, memory controller, display, command processors, and interrupts are not emulated"},
+		}
+	case baseClass == 0x0C && subClass == 0x80:
+		return EmulationSupport{
+			Family:      "thunderbolt-nhi",
+			Level:       EmulationRegisters,
+			Validated:   false,
+			Limitations: []string{"NHI rings, mailboxes, topology discovery, DMA, and interrupts are not emulated"},
+		}
+	default:
+		return EmulationSupport{Family: "generic", Level: EmulationIdentity, Validated: true}
+	}
+}

--- a/internal/firmware/devclass/emulation_test.go
+++ b/internal/firmware/devclass/emulation_test.go
@@ -1,0 +1,59 @@
+package devclass
+
+import "testing"
+
+func TestAssessEmulationByFamily(t *testing.T) {
+	tests := []struct {
+		name      string
+		classCode uint32
+		vendorID  uint16
+		deviceID  uint16
+		hasMSIX   bool
+		family    string
+		level     EmulationLevel
+		validated bool
+	}{
+		{"nvme", 0x010802, 0x144D, 0xA808, true, "nvme", EmulationDMA, true},
+		{"intel-i219-msi", 0x020000, 0x8086, 0x15B7, false, "intel-e1000e-i219", EmulationDMA, true},
+		{"intel-i219-msix-fallback", 0x020000, 0x8086, 0x15B7, true, "intel-e1000e-i219", EmulationRegisters, false},
+		{"realtek-rtl8125", 0x020000, 0x10EC, 0x8125, false, "realtek-rtl8125", EmulationRegisters, true},
+		{"unknown-ethernet", 0x020000, 0x14E4, 0x16B1, false, "ethernet-generic", EmulationIdentity, false},
+		{"xhci", 0x0C0330, 0x8086, 0xA36D, true, "xhci-generic", EmulationRegisters, false},
+		{"hda", 0x040300, 0x8086, 0xA348, false, "hda-generic", EmulationDMA, true},
+		{"sata-ahci", 0x010601, 0x8086, 0xA352, true, "ahci-generic", EmulationRegisters, false},
+		{"wifi", 0x028000, 0x14C3, 0x7922, true, "wifi-mediatek", EmulationRegisters, false},
+		{"gpu", 0x030000, 0x10DE, 0x2684, true, "gpu-generic", EmulationRegisters, false},
+		{"thunderbolt", 0x0C8000, 0x8086, 0x15EF, true, "thunderbolt-nhi", EmulationRegisters, false},
+		{"unknown", 0xFF0000, 0x1234, 0x5678, false, "generic", EmulationIdentity, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			support := AssessEmulation(tt.classCode, tt.vendorID, tt.deviceID, tt.hasMSIX)
+			if support.Family != tt.family {
+				t.Fatalf("Family = %q, want %q", support.Family, tt.family)
+			}
+			if support.Level != tt.level {
+				t.Fatalf("Level = %q, want %q", support.Level, tt.level)
+			}
+			if support.Validated != tt.validated {
+				t.Fatalf("Validated = %v, want %v", support.Validated, tt.validated)
+			}
+			if support.Level != EmulationDMA && len(support.Limitations) == 0 && support.Family != "generic" {
+				t.Fatal("partial family must report at least one limitation")
+			}
+		})
+	}
+}
+
+func TestEmulationSupportCompleteOnlyWithoutLimitations(t *testing.T) {
+	if (EmulationSupport{Level: EmulationDMA, Validated: true}).Complete() != true {
+		t.Fatal("validated DMA support without limitations should be complete")
+	}
+	if (EmulationSupport{Level: EmulationDMA, Validated: true, Limitations: []string{"missing I/O queues"}}).Complete() {
+		t.Fatal("support with limitations must not be complete")
+	}
+	if (EmulationSupport{Level: EmulationRegisters, Validated: true}).Complete() {
+		t.Fatal("register-only support must not be complete")
+	}
+}

--- a/internal/firmware/devclass/profile_test.go
+++ b/internal/firmware/devclass/profile_test.go
@@ -128,10 +128,10 @@ func TestProfileForClass_Generic(t *testing.T) {
 	}
 }
 
-func TestProfileForClass_ProgIFAgnostic(t *testing.T) {
+func TestProfileForClass_RejectsWrongProgrammingInterface(t *testing.T) {
 	p := ProfileForClass(0x010801)
-	if p == nil {
-		t.Fatal("NVMe Fabrics should still match NVMe profile")
+	if p == nil || p.ClassName != "Generic" {
+		t.Fatalf("non-NVMe programming interface must use Generic profile: %+v", p)
 	}
 }
 

--- a/internal/firmware/devclass/strategy.go
+++ b/internal/firmware/devclass/strategy.go
@@ -54,11 +54,12 @@ func StrategyForClass(classCode uint32) DeviceStrategy {
 func StrategyForClassAndVendor(classCode uint32, vendorID uint16) DeviceStrategy {
 	baseClass := (classCode >> 16) & 0xFF
 	subClass := (classCode >> 8) & 0xFF
+	progIF := classCode & 0xFF
 
 	switch {
-	case baseClass == 0x01 && subClass == 0x08:
+	case baseClass == 0x01 && subClass == 0x08 && progIF == 0x02:
 		return &nvmeStrategy{baseStrategy{"NVMe", ClassNVMe, nvmeProfile}}
-	case baseClass == 0x0C && subClass == 0x03:
+	case baseClass == 0x0C && subClass == 0x03 && progIF == 0x30:
 		return &xhciStrategy{baseStrategy{"xHCI", ClassXHCI, xhciProfile}}
 	case baseClass == 0x02 && subClass == 0x00:
 		return &ethernetStrategy{baseStrategy{"Ethernet", ClassEthernet, ethernetProfile}}

--- a/internal/firmware/devclass/strategy_test.go
+++ b/internal/firmware/devclass/strategy_test.go
@@ -2,6 +2,7 @@ package devclass
 
 import (
 	"encoding/binary"
+	"fmt"
 	"testing"
 )
 
@@ -31,6 +32,16 @@ func TestStrategyForClass_xHCI(t *testing.T) {
 	}
 	if s.DeviceClass() != ClassXHCI {
 		t.Errorf("expected %s, got %s", ClassXHCI, s.DeviceClass())
+	}
+}
+
+func TestStrategyForClass_RejectsIncompatibleProgrammingInterfaces(t *testing.T) {
+	for _, classCode := range []uint32{0x010801, 0x0C0300, 0x0C0310, 0x0C0320} {
+		t.Run(fmt.Sprintf("%06x", classCode), func(t *testing.T) {
+			if got := StrategyForClass(classCode).DeviceClass(); got != ClassGeneric {
+				t.Fatalf("class %#06x selected %q, want generic", classCode, got)
+			}
+		})
 	}
 }
 

--- a/internal/firmware/output/device_model_test.go
+++ b/internal/firmware/output/device_model_test.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,6 +12,7 @@ import (
 	"github.com/sercanarga/pcileechgen/internal/board"
 	"github.com/sercanarga/pcileechgen/internal/donor"
 	"github.com/sercanarga/pcileechgen/internal/firmware"
+	"github.com/sercanarga/pcileechgen/internal/firmware/devclass"
 	"github.com/sercanarga/pcileechgen/internal/firmware/devicemodel"
 	"github.com/sercanarga/pcileechgen/internal/firmware/nvme"
 	"github.com/sercanarga/pcileechgen/internal/firmware/svgen"
@@ -148,6 +150,7 @@ endmodule`,
 	for _, name := range []string{
 		"device_context.json",
 		"device_model.json",
+		"emulation_report.json",
 		"pcileech_cfgspace.coe",
 		"vivado_generate_project.tcl",
 		"build_manifest.json",
@@ -155,6 +158,17 @@ endmodule`,
 		if _, werr := os.Stat(filepath.Join(outDir, name)); werr != nil {
 			t.Errorf("WriteAll did not produce %s: %v", name, werr)
 		}
+	}
+	reportData, err := os.ReadFile(filepath.Join(outDir, "emulation_report.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report emulationReport
+	if err := json.Unmarshal(reportData, &report); err != nil {
+		t.Fatalf("WriteAll emulation report is invalid: %v", err)
+	}
+	if !report.StockBAR || report.Support.Level != devclass.EmulationIdentity {
+		t.Fatalf("stock BAR report overstates support: %+v", report)
 	}
 	data, err := os.ReadFile(filepath.Join(outDir, "device_model.json"))
 	if err != nil {

--- a/internal/firmware/output/validator.go
+++ b/internal/firmware/output/validator.go
@@ -1,9 +1,11 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/sercanarga/pcileechgen/internal/firmware"
@@ -68,9 +70,56 @@ func ValidateOutputDir(dir string) *ValidationResult {
 				continue
 			}
 		}
+		if name == "emulation_report.json" {
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				result.fail(fmt.Sprintf("%s: unreadable: %v", name, readErr))
+				continue
+			}
+			if parseErr := validateEmulationReport(data); parseErr != nil {
+				result.fail(fmt.Sprintf("%s: invalid: %v", name, parseErr))
+				continue
+			}
+		}
 		result.pass(fmt.Sprintf("%s: OK (%d bytes)", name, info.Size()))
 	}
 	return result
+}
+
+func validateEmulationReport(data []byte) error {
+	var report emulationReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return fmt.Errorf("parse JSON: %w", err)
+	}
+	if report.SchemaVersion != 1 {
+		return fmt.Errorf("unsupported schema_version %d", report.SchemaVersion)
+	}
+	for name, value := range map[string]string{
+		"vendor_id": report.VendorID,
+		"device_id": report.DeviceID,
+	} {
+		if len(value) != 4 {
+			return fmt.Errorf("%s must contain exactly four hexadecimal digits", name)
+		}
+		if _, err := strconv.ParseUint(value, 16, 16); err != nil {
+			return fmt.Errorf("%s is not hexadecimal: %w", name, err)
+		}
+	}
+	if len(report.ClassCode) != 6 {
+		return fmt.Errorf("class_code must contain exactly six hexadecimal digits")
+	}
+	if _, err := strconv.ParseUint(report.ClassCode, 16, 24); err != nil {
+		return fmt.Errorf("class_code is not hexadecimal: %w", err)
+	}
+	if report.Support.Family == "" {
+		return fmt.Errorf("support.family is required")
+	}
+	switch report.Support.Level {
+	case "identity", "registers", "behavior", "dma":
+	default:
+		return fmt.Errorf("unsupported support.level %q", report.Support.Level)
+	}
+	return nil
 }
 
 // ValidateSVIDs checks that vendor/device IDs appear in generated SV.
@@ -135,6 +184,8 @@ func outputFileRequired(dir string, name string) bool {
 		return generatedLocalparamPresent(dir, "MSIX_NUM_VECTORS")
 	case "pcileech_nvme_admin_responder.sv", "pcileech_nvme_dma_bridge.sv":
 		return generatedFeatureEnabled(dir, "HAS_NVME_RESP")
+	case "pcileech_ethernet_dma_bridge.sv", "pcileech_ethernet_dma_engine.sv":
+		return generatedFeatureEnabled(dir, "HAS_ETHERNET_DMA")
 	default:
 		return true
 	}

--- a/internal/firmware/output/validator_optional_test.go
+++ b/internal/firmware/output/validator_optional_test.go
@@ -75,6 +75,9 @@ func writeOutputFixture(t *testing.T, tmpDir string, skip map[string]bool, devic
 		if name == "device_model.json" {
 			content = validOutputDeviceModelJSON(t)
 		}
+		if name == "emulation_report.json" {
+			content = []byte(`{"schema_version":1,"vendor_id":"1234","device_id":"5678","class_code":"ff0000","support":{"family":"generic","level":"identity","validated":true}}`)
+		}
 		if err := os.WriteFile(filepath.Join(tmpDir, name), content, 0644); err != nil {
 			t.Fatalf("WriteFile(%s): %v", name, err)
 		}

--- a/internal/firmware/output/validator_test.go
+++ b/internal/firmware/output/validator_test.go
@@ -117,6 +117,9 @@ func TestValidateOutputDir_WithFiles(t *testing.T) {
 			if name == "device_model.json" {
 				content = validOutputDeviceModelJSON(t)
 			}
+			if name == "emulation_report.json" {
+				content = []byte(`{"schema_version":1,"vendor_id":"1234","device_id":"5678","class_code":"ff0000","stock_bar":false,"support":{"family":"generic","level":"identity","validated":true}}`)
+			}
 			if err := os.WriteFile(filepath.Join(tmpDir, name), content, 0644); err != nil {
 				t.Fatal(err)
 			}
@@ -126,6 +129,23 @@ func TestValidateOutputDir_WithFiles(t *testing.T) {
 	result := ValidateOutputDir(tmpDir)
 	if result.HasFailures() {
 		t.Errorf("All files present, but got failures: %v", result.Failed)
+	}
+}
+
+func TestValidateEmulationReport(t *testing.T) {
+	valid := []byte(`{"schema_version":1,"vendor_id":"8086","device_id":"15b7","class_code":"020000","support":{"family":"intel-e1000e-i219","level":"dma","validated":true}}`)
+	if err := validateEmulationReport(valid); err != nil {
+		t.Fatalf("valid report rejected: %v", err)
+	}
+	for _, invalid := range [][]byte{
+		[]byte(`not-json`),
+		[]byte(`{"schema_version":0,"support":{"family":"generic","level":"identity"}}`),
+		[]byte(`{"schema_version":1,"vendor_id":"xyz","device_id":"5678","class_code":"ff0000","support":{"family":"generic","level":"identity"}}`),
+		[]byte(`{"schema_version":1,"vendor_id":"1234","device_id":"5678","class_code":"ff0000","support":{"family":"generic","level":"unknown"}}`),
+	} {
+		if err := validateEmulationReport(invalid); err == nil {
+			t.Fatalf("invalid report accepted: %s", invalid)
+		}
 	}
 }
 

--- a/internal/firmware/output/writer.go
+++ b/internal/firmware/output/writer.go
@@ -3,6 +3,7 @@ package output
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -87,6 +88,9 @@ func (ow *OutputWriter) WriteAll(ctx *donor.DeviceContext, b *board.Board) error
 	if err := ow.writeDeviceModel(ctx, scrubbedCS, svCfg); err != nil {
 		return err
 	}
+	if err := ow.writeEmulationReport(ctx, ids, svCfg); err != nil {
+		return err
+	}
 
 	if err := ow.writeConfigSpaceArtifacts(ctx, scrubbedCS, b); err != nil {
 		return err
@@ -133,6 +137,54 @@ func (ow *OutputWriter) writeDeviceContext(ctx *donor.DeviceContext) error {
 	}
 	if err := ow.writeFile("device_context.json", string(data)); err != nil {
 		return fmt.Errorf("failed to write device context: %w", err)
+	}
+	return nil
+}
+
+type emulationReport struct {
+	SchemaVersion int                       `json:"schema_version"`
+	VendorID      string                    `json:"vendor_id"`
+	DeviceID      string                    `json:"device_id"`
+	ClassCode     string                    `json:"class_code"`
+	StockBAR      bool                      `json:"stock_bar"`
+	Support       devclass.EmulationSupport `json:"support"`
+}
+
+func (ow *OutputWriter) writeEmulationReport(ctx *donor.DeviceContext, ids firmware.DeviceIDs, cfg *svgen.SVGeneratorConfig) error {
+	hasMSIX := ctx.MSIXData != nil && ctx.MSIXData.TableSize > 0
+	support := devclass.AssessEmulation(ctx.Device.ClassCode, ids.VendorID, ids.DeviceID, hasMSIX)
+
+	if ow.StockBar && support.Level != devclass.EmulationIdentity {
+		support.Level = devclass.EmulationIdentity
+		support.Validated = true
+		support.Limitations = append([]string{"stock-bar mode disables generated register, behavior, and DMA emulation"}, support.Limitations...)
+	}
+	if support.Family == "intel-e1000e-i219" && cfg != nil && !cfg.EthernetDMA && support.Level == devclass.EmulationDMA {
+		support.Level = devclass.EmulationRegisters
+		support.Validated = false
+		support.Limitations = append([]string{"descriptor DMA was disabled by generated-build compatibility checks"}, support.Limitations...)
+	}
+
+	report := emulationReport{
+		SchemaVersion: 1,
+		VendorID:      fmt.Sprintf("%04x", ids.VendorID),
+		DeviceID:      fmt.Sprintf("%04x", ids.DeviceID),
+		ClassCode:     fmt.Sprintf("%06x", ctx.Device.ClassCode),
+		StockBAR:      ow.StockBar,
+		Support:       support,
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal emulation report: %w", err)
+	}
+	data = append(data, '\n')
+	if err := ow.writeFile("emulation_report.json", string(data)); err != nil {
+		return fmt.Errorf("failed to write emulation report: %w", err)
+	}
+	if support.Complete() {
+		slog.Info("emulation support assessed", "family", support.Family, "level", support.Level, "validated", support.Validated)
+	} else {
+		slog.Warn("partial donor emulation", "family", support.Family, "level", support.Level, "validated", support.Validated, "limitations", support.Limitations)
 	}
 	return nil
 }
@@ -452,6 +504,7 @@ func ListOutputFiles() []string {
 	return []string{
 		"device_context.json",
 		"device_model.json",
+		"emulation_report.json",
 		"pcileech_cfgspace.coe",
 		"pcileech_cfgspace_writemask.coe",
 		"pcileech_bar_zero4k.coe",
@@ -472,6 +525,8 @@ func ListOutputFiles() []string {
 		"pcileech_msix_table.sv",
 		"pcileech_nvme_admin_responder.sv",
 		"pcileech_nvme_dma_bridge.sv",
+		"pcileech_ethernet_dma_bridge.sv",
+		"pcileech_ethernet_dma_engine.sv",
 		"pcileech_bram_disk.sv",
 		"tlp_latency_emulator.sv",
 		"device_config.sv",
@@ -596,11 +651,40 @@ func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.
 			preferredBIR = profile.PreferredBAR
 		}
 	}
+	support := devclass.AssessEmulation(
+		ctx.Device.ClassCode,
+		ids.VendorID,
+		ids.DeviceID,
+		ctx.MSIXData != nil && ctx.MSIXData.TableSize > 0,
+	)
+	intelE1000Family := support.Family == "intel-e1000e-i219"
+	intelE1000DMA := intelE1000Family && support.Level == devclass.EmulationDMA
+	if intelE1000Family {
+		preferredBIR = 0
+	}
 
 	models, err := barmodel.BuildBARModels(ctx.BARs, ctx.BARContents, ctx.BARProfiles,
 		ctx.Device.ClassCode, preferredBIR)
 	if err != nil {
 		return nil, fmt.Errorf("invalid donor BAR topology: %w", err)
+	}
+	if intelE1000Family {
+		for index, model := range models {
+			if model == nil || model.BIR != 0 {
+				continue
+			}
+			replacement := barmodel.BuildIntelE1000BARModel(ctx.BARContents[0])
+			replacement.BIR = model.BIR
+			replacement.Size = model.Size
+			replacement.Aperture = model.Aperture
+			replacement.Type = model.Type
+			replacement.Prefetchable = model.Prefetchable
+			replacement.Is64Bit = model.Is64Bit
+			replacement.UpperBIR = model.UpperBIR
+			replacement.ClassSpecific = true
+			models[index] = replacement
+			break
+		}
 	}
 	primary := barmodel.ModelForBIR(models, preferredBIR)
 	if primary == nil && len(models) > 0 {
@@ -678,6 +762,7 @@ func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.
 		BuildEntropy:                entropy,
 		PRNGSeeds:                   svgen.BuildPRNGSeeds(ids.VendorID, ids.DeviceID, entropy),
 		DeviceClass:                 devClass,
+		EthernetDMA:                 intelE1000DMA && primary != nil && primary.BIR == 0 && primary.Size >= 0x5408,
 		Bar0Size:                    bar0Size,
 		ReadCompletionBoundaryBytes: 64,
 		MaxPayloadBytes:             128,
@@ -795,6 +880,11 @@ func (ow *OutputWriter) buildSVConfig(ctx *donor.DeviceContext, scrubbedCS *pci.
 	if msiInfo := extractMSIInfo(scrubbedCS); msiInfo != nil {
 		cfg.MSIConfig = msiInfo
 	}
+	// Ethernet DMA currently uses the legacy MSI request path. Keep it disabled
+	// for MSI-X donors until Ethernet vector delivery and PBA handling are wired.
+	if cfg.MSIXConfig != nil {
+		cfg.EthernetDMA = false
+	}
 
 	bram := b.BRAMSizeOrDefault()
 	// Validate *donor demand* (may exceed) against board BRAM; error unless --force.
@@ -897,6 +987,24 @@ func (ow *OutputWriter) writeConditionalArtifacts(cfg *svgen.SVGeneratorConfig, 
 		}
 	}
 
+	if cfg.EthernetDMA && cfg.BARModel != nil {
+		engineSV, err := svgen.GenerateEthernetDMAEngineSV(cfg)
+		if err != nil {
+			return fmt.Errorf("generating pcileech_ethernet_dma_engine.sv: %w", err)
+		}
+		if writeErr := ow.writeFile("pcileech_ethernet_dma_engine.sv", engineSV); writeErr != nil {
+			return writeErr
+		}
+
+		bridgeSV, err := svgen.GenerateEthernetDMABridgeSV(cfg)
+		if err != nil {
+			return fmt.Errorf("generating pcileech_ethernet_dma_bridge.sv: %w", err)
+		}
+		if writeErr := ow.writeFile("pcileech_ethernet_dma_bridge.sv", bridgeSV); writeErr != nil {
+			return writeErr
+		}
+	}
+
 	return nil
 }
 
@@ -915,6 +1023,12 @@ func (ow *OutputWriter) logSVSummary(cfg *svgen.SVGeneratorConfig) {
 		features = append(features, "HD Audio FSM", "RIRB DMA Bridge")
 		if cfg.MSIConfig != nil {
 			features = append(features, "MSI Interrupt Gen")
+		}
+	case devclass.ClassEthernet:
+		if cfg.EthernetDMA {
+			features = append(features, "Intel e1000e descriptor DMA", "Ethernet packet engine")
+		} else {
+			features = append(features, "static Ethernet BAR model")
 		}
 	}
 	if cfg.MSIXConfig != nil {

--- a/internal/firmware/svgen/ethernet_dma_test.go
+++ b/internal/firmware/svgen/ethernet_dma_test.go
@@ -1,0 +1,62 @@
+package svgen
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateEthernetDMAEngineSV(t *testing.T) {
+	sv, err := GenerateEthernetDMAEngineSV(&SVGeneratorConfig{})
+	if err != nil {
+		t.Fatalf("GenerateEthernetDMAEngineSV: %v", err)
+	}
+	for _, want := range []string{
+		"module pcileech_ethernet_dma_engine",
+		"rdt_write",
+		"dma_rd_req",
+		"dma_wr_valid",
+		"32'h0000003C",
+		"32'h00000003",
+		"icmp_word",
+		"packet_profile",
+	} {
+		if !strings.Contains(sv, want) {
+			t.Errorf("Ethernet DMA engine missing %q", want)
+		}
+	}
+}
+
+func TestGenerateEthernetDMAEngineSVVerilatorLint(t *testing.T) {
+	if _, err := exec.LookPath("verilator"); err != nil {
+		t.Skip("verilator unavailable")
+	}
+	sv, err := GenerateEthernetDMAEngineSV(&SVGeneratorConfig{})
+	if err != nil {
+		t.Fatalf("GenerateEthernetDMAEngineSV: %v", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ethernet_dma_engine.sv")
+	if err := os.WriteFile(path, []byte(sv), 0o600); err != nil {
+		t.Fatalf("write generated SV: %v", err)
+	}
+	cmd := exec.Command("verilator", "--lint-only", "--language", "1800-2012", path)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("verilator lint: %v\n%s", err, output)
+	}
+}
+
+func TestGenerateEthernetDMABridgeSVUsesEthernetModuleName(t *testing.T) {
+	sv, err := GenerateEthernetDMABridgeSV(&SVGeneratorConfig{})
+	if err != nil {
+		t.Fatalf("GenerateEthernetDMABridgeSV: %v", err)
+	}
+	if !strings.Contains(sv, "module pcileech_ethernet_dma_bridge") {
+		t.Fatal("Ethernet bridge module name missing")
+	}
+	if strings.Contains(sv, "module pcileech_nvme_dma_bridge") {
+		t.Fatal("Ethernet bridge retained NVMe module declaration")
+	}
+}

--- a/internal/firmware/svgen/generator.go
+++ b/internal/firmware/svgen/generator.go
@@ -4,6 +4,7 @@ package svgen
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/template"
 
 	"github.com/sercanarga/pcileechgen/internal/board"
@@ -39,6 +40,7 @@ type SVGeneratorConfig struct {
 	BuildEntropy                uint32             // seed for PRNG uniqueness per build
 	PRNGSeeds                   [4]uint32          // computed PRNG seeds for latency emulator
 	DeviceClass                 string             // "nvme", "xhci", "audio", "ethernet", or ""
+	EthernetDMA                 bool               // tested Intel I219-LM/e1000e BAR0 descriptor engine
 	MSIXConfig                  *MSIXConfig        // MSI-X table replication (nil = no MSI-X table)
 	MSIConfig                   *MSIConfig         // MSI capability info (nil = no MSI cap or disabled)
 	NVMeIdentify                *nvme.IdentifyData // NVMe Identify Controller/Namespace data (nil = no responder)
@@ -314,6 +316,22 @@ func GenerateNVMeResponderSV(cfg *SVGeneratorConfig) (string, error) {
 // GenerateNVMeDMABridgeSV renders the NVMe DMA TLP bridge module.
 func GenerateNVMeDMABridgeSV(cfg *SVGeneratorConfig) (string, error) {
 	return renderTemplate("nvme_dma_bridge", cfg)
+}
+
+// GenerateEthernetDMABridgeSV reuses the verified PCIe MRd/MWr transport with
+// Ethernet-specific module naming. The request/response contract is shared by
+// the Ethernet descriptor engine and the NVMe responder.
+func GenerateEthernetDMABridgeSV(cfg *SVGeneratorConfig) (string, error) {
+	sv, err := renderTemplate("nvme_dma_bridge", cfg)
+	if err != nil {
+		return "", err
+	}
+	return strings.ReplaceAll(sv, "pcileech_nvme_dma_bridge", "pcileech_ethernet_dma_bridge"), nil
+}
+
+// GenerateEthernetDMAEngineSV renders the descriptor-side Ethernet engine.
+func GenerateEthernetDMAEngineSV(cfg *SVGeneratorConfig) (string, error) {
+	return renderTemplate("ethernet_dma_engine", cfg)
 }
 
 // GenerateNVMeBRAMDiskSV renders the disk cache. Uses [[ ]] delimiters because

--- a/internal/firmware/svgen/svgen_test.go
+++ b/internal/firmware/svgen/svgen_test.go
@@ -209,13 +209,16 @@ func audioConfig() *SVGeneratorConfig {
 }
 
 func ethernetConfig() *SVGeneratorConfig {
+	model := barmodel.BuildIntelE1000BARModel(make([]byte, 0x20000))
+	model.BIR = 0
+	model.ClassSpecific = true
 	return &SVGeneratorConfig{
 		DeviceIDs: firmware.DeviceIDs{
-			VendorID:       0x10EC,
-			DeviceID:       0x8125,
-			SubsysVendorID: 0x10EC,
-			SubsysDeviceID: 0x8125,
-			RevisionID:     0x04,
+			VendorID:       0x8086,
+			DeviceID:       0x15B7,
+			SubsysVendorID: 0x8086,
+			SubsysDeviceID: 0x0000,
+			RevisionID:     0x31,
 			ClassCode:      0x020000,
 			HasPCIeCap:     true,
 			LinkSpeed:      3,
@@ -223,15 +226,11 @@ func ethernetConfig() *SVGeneratorConfig {
 		},
 		ClassCode:    0x020000,
 		DeviceClass:  "ethernet",
+		EthernetDMA:  true,
 		BuildEntropy: 0xFEEDFACE,
-		PRNGSeeds:    BuildPRNGSeeds(0x10EC, 0x8125, 0xFEEDFACE),
-		BARModel: &barmodel.BARModel{
-			Size: 4096,
-			Registers: []barmodel.BARRegister{
-				{Offset: 0x00, Width: 4, Name: "MAC0_3", RWMask: 0xFFFFFFFF, Reset: 0xBEADDE02},
-				{Offset: 0x6C, Width: 4, Name: "PHYSTATUS", RWMask: 0x00000000, Reset: 0x00003010},
-			},
-		},
+		PRNGSeeds:    BuildPRNGSeeds(0x8086, 0x15B7, 0xFEEDFACE),
+		BARModel:     model,
+		BARModels:    []*barmodel.BARModel{model},
 	}
 }
 
@@ -276,6 +275,23 @@ func TestGenerateBarImplDeviceSV_Ethernet(t *testing.T) {
 	// Ethernet should NOT have NVMe FSM
 	if strings.Contains(result, "cc_en_prev") {
 		t.Error("Ethernet should NOT contain NVMe FSM")
+	}
+}
+
+func TestGenerateBarControllerSV_EthernetDMA(t *testing.T) {
+	result, err := GenerateBarControllerSV(ethernetConfig())
+	if err != nil {
+		t.Fatalf("Ethernet bar_controller generation failed: %v", err)
+	}
+	for _, want := range []string{
+		"pcileech_ethernet_dma_engine",
+		"pcileech_ethernet_dma_bridge",
+		"i_fifo_ethernet_dma",
+		"eth_rdt_write",
+	} {
+		if !strings.Contains(result, want) {
+			t.Errorf("Ethernet bar_controller missing %q", want)
+		}
 	}
 }
 

--- a/internal/firmware/svgen/templates/bar_controller.sv.tmpl
+++ b/internal/firmware/svgen/templates/bar_controller.sv.tmpl
@@ -391,6 +391,75 @@ module pcileech_tlps128_bar_controller(
     assign in_is_wr_ready = wrengine_ready;
 {{ end }}
 
+{{ if .EthernetDMA }}
+    pcileech_ethernet_dma_engine i_ethernet_dma_engine(
+        .rst            ( device_reset                  ),
+        .clk            ( clk                           ),
+        .dma_enabled    ( dma_enabled                   ),
+        .rdbal          ( eth_rdbal                     ),
+        .rdlen          ( eth_rdlen                     ),
+        .rdh            ( eth_rdh                       ),
+        .rdt            ( eth_rdt                       ),
+        .rdt_value      ( eth_rdt_value                 ),
+        .rdt_write      ( eth_rdt_write                 ),
+        .tdbal          ( eth_tdbal                     ),
+        .tdlen          ( eth_tdlen                     ),
+        .tdh            ( eth_tdh                       ),
+        .tdt            ( eth_tdt                       ),
+        .tdt_value      ( eth_tdt_value                 ),
+        .tdt_write      ( eth_tdt_write                 ),
+        .rdh_valid      ( eth_rdh_valid                 ),
+        .rdh_value      ( eth_rdh_value                 ),
+        .tdh_valid      ( eth_tdh_valid                 ),
+        .tdh_value      ( eth_tdh_value                 ),
+        .icr_cause      ( eth_icr_cause                 ),
+        .dma_rd_req     ( eth_dma_rd_req                ),
+        .dma_rd_addr    ( eth_dma_rd_addr               ),
+        .dma_rd_len     ( eth_dma_rd_len                ),
+        .dma_rd_valid   ( eth_dma_rd_valid              ),
+        .dma_rd_data    ( eth_dma_rd_data               ),
+        .dma_rd_done    ( eth_dma_rd_done               ),
+        .dma_rd_error   ( eth_dma_rd_error              ),
+        .dma_wr_req     ( eth_dma_wr_req                ),
+        .dma_wr_addr    ( eth_dma_wr_addr               ),
+        .dma_wr_data    ( eth_dma_wr_data               ),
+        .dma_wr_be      ( eth_dma_wr_be                 ),
+        .dma_wr_valid   ( eth_dma_wr_valid              ),
+        .dma_wr_done    ( eth_dma_wr_done               )
+    );
+
+    pcileech_ethernet_dma_bridge i_ethernet_dma_bridge(
+        .rst            ( device_reset                  ),
+        .clk            ( clk                           ),
+        .dma_enabled    ( dma_enabled                   ),
+        .pcie_id        ( pcie_id                       ),
+        .dma_wr_req     ( eth_dma_wr_req                ),
+        .dma_wr_addr    ( eth_dma_wr_addr               ),
+        .dma_wr_data    ( eth_dma_wr_data               ),
+        .dma_wr_be      ( eth_dma_wr_be                 ),
+        .dma_wr_valid   ( eth_dma_wr_valid              ),
+        .dma_wr_done    ( eth_dma_wr_done               ),
+        .dma_rd_req     ( eth_dma_rd_req                ),
+        .dma_rd_addr    ( eth_dma_rd_addr               ),
+        .dma_rd_len     ( eth_dma_rd_len                ),
+        .dma_rd_valid   ( eth_dma_rd_valid              ),
+        .dma_rd_data    ( eth_dma_rd_data               ),
+        .dma_rd_done    ( eth_dma_rd_done               ),
+        .dma_rd_error   ( eth_dma_rd_error              ),
+        .tlp_tx_tdata   ( eth_tlp_tx_tdata              ),
+        .tlp_tx_tkeepdw ( eth_tlp_tx_tkeepdw            ),
+        .tlp_tx_tvalid  ( eth_tlp_tx_tvalid             ),
+        .tlp_tx_tlast   ( eth_tlp_tx_tlast              ),
+        .tlp_tx_tuser   ( eth_tlp_tx_tuser              ),
+        .tlp_tx_tready  ( eth_tlp_tx_tready             ),
+        .tlp_rx_tdata   ( tlps_in.tdata                 ),
+        .tlp_rx_tkeepdw ( tlps_in.tkeepdw               ),
+        .tlp_rx_tvalid  ( tlps_in.tvalid                ),
+        .tlp_rx_tuser   ( tlps_in.tuser                 ),
+        .dbg_status     (                               )
+    );
+{{ end }}
+
 {{ if .LatencyConfig }}
     // BAR0 raw response wires (before latency emulation)
     wire [87:0] bar0_raw_ctx;
@@ -557,6 +626,40 @@ module pcileech_tlps128_bar_controller(
     assign nvme_msix_vector_masked = 1'b1;
 {{ end }}{{ end }}
 
+{{ if .EthernetDMA }}
+    wire [63:0] eth_rdbal;
+    wire [31:0] eth_rdlen, eth_rdh, eth_rdt;
+    wire [63:0] eth_tdbal;
+    wire [31:0] eth_tdlen, eth_tdh, eth_tdt;
+    wire        eth_rdt_write, eth_tdt_write;
+    wire [31:0] eth_rdt_value, eth_tdt_value;
+    wire        eth_rdh_valid;
+    wire [31:0] eth_rdh_value;
+    wire        eth_tdh_valid;
+    wire [31:0] eth_tdh_value;
+    wire [31:0] eth_icr_cause;
+    wire        eth_irq_event;
+    wire        eth_dma_rd_req;
+    wire [63:0] eth_dma_rd_addr;
+    wire [9:0]  eth_dma_rd_len;
+    wire        eth_dma_rd_valid;
+    wire [31:0] eth_dma_rd_data;
+    wire        eth_dma_rd_done;
+    wire        eth_dma_rd_error;
+    wire        eth_dma_wr_req;
+    wire [63:0] eth_dma_wr_addr;
+    wire [31:0] eth_dma_wr_data;
+    wire [3:0]  eth_dma_wr_be;
+    wire        eth_dma_wr_valid;
+    wire        eth_dma_wr_done;
+    wire [127:0] eth_tlp_tx_tdata;
+    wire [3:0]   eth_tlp_tx_tkeepdw;
+    wire         eth_tlp_tx_tvalid;
+    wire         eth_tlp_tx_tlast;
+    wire [8:0]   eth_tlp_tx_tuser;
+    wire         eth_tlp_tx_tready;
+{{ end }}
+
 
 {{ range .BARSlots }}
     assign bar_rsp_ctx[{{ .BIR }}]   = bar_base_ctx[{{ .BIR }}];
@@ -647,6 +750,26 @@ module pcileech_tlps128_bar_controller(
         .msi_trigger     ( hda_msi_trigger               ),
         .rirbintsts      ( hda_rirbintsts                ),
         .crst_falling    ( hda_crst_falling              )
+{{ end }}
+{{ if .EthernetDMA }}        ,
+        .eth_rdbal       ( eth_rdbal                    ),
+        .eth_rdlen       ( eth_rdlen                    ),
+        .eth_rdh         ( eth_rdh                      ),
+        .eth_rdt         ( eth_rdt                      ),
+        .eth_tdbal       ( eth_tdbal                    ),
+        .eth_tdlen       ( eth_tdlen                    ),
+        .eth_tdh         ( eth_tdh                      ),
+        .eth_tdt         ( eth_tdt                      ),
+        .eth_rdt_write   ( eth_rdt_write                ),
+        .eth_rdt_value   ( eth_rdt_value                ),
+        .eth_tdt_write   ( eth_tdt_write                ),
+        .eth_tdt_value   ( eth_tdt_value                ),
+        .eth_rdh_valid   ( eth_rdh_valid                ),
+        .eth_rdh_value   ( eth_rdh_value                ),
+        .eth_tdh_valid   ( eth_tdh_valid                ),
+        .eth_tdh_value   ( eth_tdh_value                ),
+        .eth_icr_cause   ( eth_icr_cause                ),
+        .eth_irq_event   ( eth_irq_event                )
 {{ end }}
     );
 {{ end }}
@@ -908,6 +1031,7 @@ module pcileech_tlps128_bar_controller(
     wire        nvme_dma_rd_valid;
     wire [31:0] nvme_dma_rd_data;
     wire        nvme_dma_rd_done;
+    wire        nvme_dma_rd_error;
     wire        nvme_dma_wr_req;
     wire [63:0] nvme_dma_wr_addr;
     wire [31:0] nvme_dma_wr_data;
@@ -1088,6 +1212,7 @@ module pcileech_tlps128_bar_controller(
         .dma_rd_valid       ( nvme_dma_rd_valid             ),
         .dma_rd_data        ( nvme_dma_rd_data              ),
         .dma_rd_done        ( nvme_dma_rd_done              ),
+        .dma_rd_error       ( nvme_dma_rd_error             ),
         .tlp_tx_tdata       ( nvme_tlp_tx_tdata             ),
         .tlp_tx_tkeepdw     ( nvme_tlp_tx_tkeepdw           ),
         .tlp_tx_tvalid      ( nvme_tlp_tx_tvalid            ),
@@ -1122,11 +1247,13 @@ module pcileech_tlps128_bar_controller(
 
     wire nvme_dma_fifo_wr_en = nvme_tlp_tx_tvalid && !nvme_dma_fifo_full;
     wire nvme_dma_pkt_inc    = nvme_dma_fifo_wr_en && nvme_tlp_tx_tlast;
-    wire nvme_dma_pkt_dec    = nvme_dma_fifo_tvalid && nvme_dma_fifo_tlast;
+    wire nvme_dma_fifo_rd_en = tlps_dma_out.tready && nvme_dma_fifo_tvalid &&
+                               (nvme_dma_pkt_count != 11'd0);
+    wire nvme_dma_pkt_dec    = nvme_dma_fifo_rd_en && nvme_dma_fifo_tlast;
     wire [10:0] nvme_dma_pkt_count_next = nvme_dma_pkt_count +
                                           {10'h000, nvme_dma_pkt_inc} -
                                           {10'h000, nvme_dma_pkt_dec};
-    wire nvme_dma_fifo_rd_en = tlps_dma_out.tready && (nvme_dma_pkt_count_next != 11'd0);
+
 
     assign nvme_tlp_tx_tready = !nvme_dma_fifo_full;
 
@@ -1151,10 +1278,11 @@ module pcileech_tlps128_bar_controller(
 
     assign tlps_dma_out.tdata    = nvme_dma_fifo_tdata;
     assign tlps_dma_out.tkeepdw  = nvme_dma_fifo_tkeepdw;
-    assign tlps_dma_out.tvalid   = dma_enabled && nvme_dma_fifo_tvalid;
+    assign tlps_dma_out.tvalid   = dma_enabled && nvme_dma_fifo_tvalid &&
+                                   (nvme_dma_pkt_count != 11'd0);
     assign tlps_dma_out.tlast    = nvme_dma_fifo_tlast;
     assign tlps_dma_out.tuser    = {7'h00, nvme_dma_fifo_tlast, nvme_dma_fifo_first};
-    assign tlps_dma_out.has_data = dma_enabled && (nvme_dma_pkt_count_next != 11'd0);
+    assign tlps_dma_out.has_data = dma_enabled && (nvme_dma_pkt_count != 11'd0);
 
     assign tlps_out.tdata    = tlps_cpl.tdata;
     assign tlps_out.tkeepdw  = tlps_cpl.tkeepdw;
@@ -1163,6 +1291,59 @@ module pcileech_tlps128_bar_controller(
     assign tlps_out.tuser    = tlps_cpl.tuser;
     assign tlps_out.has_data = tlps_cpl.has_data;
     assign tlps_cpl.tready   = tlps_out.tready;
+{{ end }}
+
+{{ if .EthernetDMA }}
+    wire         eth_dma_fifo_full;
+    wire         eth_dma_fifo_first;
+    wire         eth_dma_fifo_tlast;
+    wire [3:0]   eth_dma_fifo_tkeepdw;
+    wire [127:0] eth_dma_fifo_tdata;
+    wire         eth_dma_fifo_tvalid;
+    reg  [10:0]  eth_dma_pkt_count;
+    wire eth_dma_fifo_wr_en = eth_tlp_tx_tvalid && !eth_dma_fifo_full;
+    wire eth_dma_pkt_inc = eth_dma_fifo_wr_en && eth_tlp_tx_tlast;
+    wire eth_dma_fifo_rd_en = tlps_dma_out.tready && eth_dma_fifo_tvalid &&
+                              (eth_dma_pkt_count != 11'd0);
+    wire eth_dma_pkt_dec = eth_dma_fifo_rd_en && eth_dma_fifo_tlast;
+    wire [10:0] eth_dma_pkt_count_next = eth_dma_pkt_count +
+                                          {10'h000, eth_dma_pkt_inc} -
+                                          {10'h000, eth_dma_pkt_dec};
+
+    assign eth_tlp_tx_tready = !eth_dma_fifo_full;
+
+    fifo_134_134_clk1_bar_rdrsp i_fifo_ethernet_dma(
+        .srst       ( device_reset || !dma_enabled                         ),
+        .clk        ( clk                                                   ),
+        .din        ( { eth_tlp_tx_tuser[0], eth_tlp_tx_tlast,
+                        eth_tlp_tx_tkeepdw, eth_tlp_tx_tdata }               ),
+        .wr_en      ( eth_dma_fifo_wr_en                                   ),
+        .rd_en      ( eth_dma_fifo_rd_en                                   ),
+        .dout       ( { eth_dma_fifo_first, eth_dma_fifo_tlast,
+                        eth_dma_fifo_tkeepdw, eth_dma_fifo_tdata }           ),
+        .full       ( eth_dma_fifo_full                                    ),
+        .empty      (                                                       ),
+        .prog_empty (                                                       ),
+        .valid      ( eth_dma_fifo_tvalid                                  )
+    );
+
+    always @(posedge clk)
+        eth_dma_pkt_count <= (device_reset || !dma_enabled) ? 11'd0 : eth_dma_pkt_count_next;
+
+    assign tlps_dma_out.tdata    = eth_dma_fifo_tdata;
+    assign tlps_dma_out.tkeepdw  = eth_dma_fifo_tkeepdw;
+    assign tlps_dma_out.tvalid   = dma_enabled && eth_dma_fifo_tvalid &&
+                                   (eth_dma_pkt_count != 11'd0);
+    assign tlps_dma_out.tlast    = eth_dma_fifo_tlast;
+    assign tlps_dma_out.tuser    = {7'h00, eth_dma_fifo_tlast, eth_dma_fifo_first};
+    assign tlps_dma_out.has_data = dma_enabled && (eth_dma_pkt_count != 11'd0);
+    assign tlps_out.tdata    = tlps_cpl.tdata;
+    assign tlps_out.tkeepdw  = tlps_cpl.tkeepdw;
+    assign tlps_out.tvalid   = tlps_cpl.tvalid;
+    assign tlps_out.tlast    = tlps_cpl.tlast;
+    assign tlps_out.tuser    = tlps_cpl.tuser;
+    assign tlps_out.has_data = tlps_cpl.has_data;
+    assign tlps_cpl.tready  = tlps_out.tready;
 {{ end }}
 
 {{ if and (eq .DeviceClass "audio") .HasClassEndpoint }}{{ if not (and (eq .DeviceClass "nvme") .NVMeIdentify) }}
@@ -1206,7 +1387,7 @@ module pcileech_tlps128_bar_controller(
 {{ end }}{{
  end }}
 
-{{ if not (or (and (eq .DeviceClass "nvme") .NVMeIdentify) (and (eq .DeviceClass "audio") .HasClassEndpoint)) }}
+{{ if not (or (and (eq .DeviceClass "nvme") .NVMeIdentify) (and (eq .DeviceClass "audio") .HasClassEndpoint) (and (eq .DeviceClass "ethernet") .HasClassEndpoint)) }}
     assign tlps_out.tdata    = tlps_cpl.tdata;
     assign tlps_out.tkeepdw  = tlps_cpl.tkeepdw;
     assign tlps_out.tvalid   = tlps_cpl.tvalid;
@@ -1252,7 +1433,7 @@ module pcileech_tlps128_bar_controller(
     );
 {{ end }}{{ end }}{{ end }}
 
-    assign intr_req = 1'b0{{ if and (eq .DeviceClass "audio") .HasClassEndpoint }} | hda_intr_req{{ end }}{{ if and (eq .DeviceClass "nvme") .NVMeIdentify (not .MSIXConfig) }} | nvme_intr_req{{ end }};
+    assign intr_req = 1'b0{{ if and (eq .DeviceClass "audio") .HasClassEndpoint }} | hda_intr_req{{ end }}{{ if and (eq .DeviceClass "nvme") .NVMeIdentify (not .MSIXConfig) }} | nvme_intr_req{{ end }}{{ if .EthernetDMA }} | eth_irq_event{{ end }};
 
 endmodule
 `default_nettype wire

--- a/internal/firmware/svgen/templates/bar_impl_device.sv.tmpl
+++ b/internal/firmware/svgen/templates/bar_impl_device.sv.tmpl
@@ -50,6 +50,25 @@ module {{ .BARImplementationModuleName }} #(
     output wire [31:0]  nvme_acq_lo,
     output wire [31:0]  nvme_acq_hi,
     output wire [31:0]  nvme_csts
+{{ end }}{{ if .EthernetDMA }}    ,
+    output wire [63:0]  eth_rdbal,
+    output wire [31:0]  eth_rdlen,
+    output wire [31:0]  eth_rdh,
+    output wire [31:0]  eth_rdt,
+    output wire [63:0]  eth_tdbal,
+    output wire [31:0]  eth_tdlen,
+    output wire [31:0]  eth_tdh,
+    output wire [31:0]  eth_tdt,
+    output wire         eth_rdt_write,
+    output wire [31:0]  eth_rdt_value,
+    output wire         eth_tdt_write,
+    output wire [31:0]  eth_tdt_value,
+    input  wire         eth_rdh_valid,
+    input  wire [31:0]  eth_rdh_value,
+    input  wire         eth_tdh_valid,
+    input  wire [31:0]  eth_tdh_value,
+    input  wire [31:0]  eth_icr_cause,
+    output wire         eth_irq_event
 {{ end }});
 
     wire wr_in_range = (wr_addr < BAR_SIZE);
@@ -60,6 +79,96 @@ module {{ .BARImplementationModuleName }} #(
     // registers
 {{ range .BARModel.Registers }}
     reg [{{ sub (mul .Width 8) 1 }}:0] reg_0x{{ hex08 .Offset }};  // {{ .Name }}
+{{ end }}
+
+{{ if .EthernetDMA }}
+    reg eth_rdt_write_r;
+    reg [31:0] eth_rdt_value_r;
+    reg eth_tdt_write_r;
+    reg [31:0] eth_tdt_value_r;
+
+    assign eth_rdbal = {reg_0x00002804, reg_0x00002800};
+    assign eth_rdlen = reg_0x00002808;
+    assign eth_rdh = reg_0x00002810;
+    assign eth_rdt = reg_0x00002818;
+    assign eth_tdbal = {reg_0x00003804, reg_0x00003800};
+    assign eth_tdlen = reg_0x00003808;
+    assign eth_tdh = reg_0x00003810;
+    assign eth_tdt = reg_0x00003818;
+    assign eth_rdt_write = eth_rdt_write_r;
+    assign eth_rdt_value = eth_rdt_value_r;
+    assign eth_tdt_write = eth_tdt_write_r;
+    assign eth_tdt_value = eth_tdt_value_r;
+
+    wire [31:0] eth_wr_be_mask = {
+        {8{wr_be[3]}}, {8{wr_be[2]}}, {8{wr_be[1]}}, {8{wr_be[0]}}
+    };
+    reg eth_irq_event_r;
+    assign eth_irq_event = eth_irq_event_r;
+
+    always @(posedge clk) begin
+        if (rst) begin
+            eth_rdt_write_r <= 1'b0;
+            eth_rdt_value_r <= 32'h0;
+            eth_tdt_write_r <= 1'b0;
+            eth_tdt_value_r <= 32'h0;
+            eth_irq_event_r <= 1'b0;
+            reg_0x000000C0 <= 32'h0;
+            reg_0x000000C8 <= 32'h0;
+            reg_0x000000D0 <= 32'h0;
+            reg_0x000000D8 <= 32'h0;
+            reg_0x00002810 <= 32'h0;
+            reg_0x00003810 <= 32'h0;
+            reg_0x00000014 <= 32'h0;
+            reg_0x00000020 <= 32'h08000000;
+        end else begin
+            eth_rdt_write_r <= 1'b0;
+            eth_tdt_write_r <= 1'b0;
+            eth_irq_event_r <= 1'b0;
+            reg_0x000000C8 <= 32'h0;
+            reg_0x000000D8 <= 32'h0;
+            if (wr_valid && ((wr_offset & 32'hFFFFFFFC) == 32'h00002818)) begin
+                eth_rdt_write_r <= 1'b1;
+                eth_rdt_value_r <= wr_data & 32'h0000FFFF;
+            end
+            if (wr_valid && ((wr_offset & 32'hFFFFFFFC) == 32'h00003818)) begin
+                eth_tdt_write_r <= 1'b1;
+                eth_tdt_value_r <= wr_data & 32'h0000FFFF;
+            end
+            if (wr_valid && ((wr_offset & 32'hFFFFFFFC) == 32'h00000014))
+                reg_0x00000014 <= (wr_data & 32'h1) | 32'h00000020 | 32'h11000000;
+            if (wr_valid && ((wr_offset & 32'hFFFFFFFC) == 32'h00000020)) begin
+                case (wr_data[20:16])
+                    5'd0: reg_0x00000020 <= (wr_data & 32'h03FF0000) | 32'h00001140 | 32'h10000000;
+                    5'd1: reg_0x00000020 <= (wr_data & 32'h03FF0000) | 32'h0000796D | 32'h10000000;
+                    default: reg_0x00000020 <= (wr_data & 32'h03FF0000) | 32'h10000000;
+                endcase
+            end
+            if (wr_valid && ((wr_offset & 32'hFFFFFFFC) == 32'h000000C8)) begin
+                reg_0x000000C0 <= reg_0x000000C0 | (wr_data & eth_wr_be_mask);
+                if (|(wr_data & eth_wr_be_mask & reg_0x000000D0))
+                    eth_irq_event_r <= 1'b1;
+            end
+            if (wr_valid && ((wr_offset & 32'hFFFFFFFC) == 32'h000000D0)) begin
+                reg_0x000000D0 <= reg_0x000000D0 | (wr_data & eth_wr_be_mask);
+                if (|(reg_0x000000C0 & wr_data & eth_wr_be_mask))
+                    eth_irq_event_r <= 1'b1;
+            end
+            if (wr_valid && ((wr_offset & 32'hFFFFFFFC) == 32'h000000D8))
+                reg_0x000000D0 <= reg_0x000000D0 & ~(wr_data & eth_wr_be_mask);
+            if (rd_req_valid && ((rd_req_offset & 32'hFFFFFFFC) == 32'h000000C0))
+                reg_0x000000C0 <= 32'h0;
+            if (eth_rdh_valid)
+                reg_0x00002810 <= eth_rdh_value;
+            if (eth_tdh_valid)
+                reg_0x00003810 <= eth_tdh_value;
+            if (eth_icr_cause != 32'h0) begin
+                reg_0x000000C0 <= reg_0x000000C0 | eth_icr_cause;
+                if (|(eth_icr_cause & reg_0x000000D0))
+                    eth_irq_event_r <= 1'b1;
+            end
+        end
+    end
 {{ end }}
 {{ if .CompiledBehavior }}
     reg [{{ sub .CompiledBehavior.StateBits 1 }}:0] behavior_state;
@@ -973,7 +1082,7 @@ module {{ .BARImplementationModuleName }} #(
     assign crst_falling = !reg_0x00000008[0] && crst_prev;  // CRST falling edge
 
 {{ end }}
-{{ if eq .DeviceClass "ethernet" }}
+{{ if and (eq .DeviceClass "ethernet") (not .EthernetDMA) }}
     // PHYAR/ERIAR done-flag auto-clear for r8169 driver.
     // Driver sets bit 31 and polls until it drops.
     // These registers are IsFSMDriven — sole driver is this always block.

--- a/internal/firmware/svgen/templates/device_config.sv.tmpl
+++ b/internal/firmware/svgen/templates/device_config.sv.tmpl
@@ -22,6 +22,7 @@
 {{ if eq .DeviceClass "nvme" }}//   - NVMe CC->CSTS state machine (dynamic handshake)
 {{ end }}{{ if eq .DeviceClass "xhci" }}//   - xHCI USBCMD/USBSTS state machine
 {{ end }}{{ if eq .DeviceClass "audio" }}//   - HD Audio GCTL.CRST handshake
+{{ end }}{{ if .EthernetDMA }}//   - Intel e1000e descriptor DMA and packet loopback
 {{ end }}{{ if .HasMSIX }}//   - MSI-X interrupt controller
 {{ end }}{{ if .LatencyConfig }}//   - TLP latency emulation (min={{ .LatencyConfig.MinCycles }}, max={{ .LatencyConfig.MaxCycles }}, avg={{ .LatencyConfig.AvgCycles }})
 {{ end }}
@@ -68,6 +69,7 @@ package device_config;
     // Feature flags
     localparam HAS_NVME_FSM     = {{ if eq .DeviceClass "nvme" }}1{{ else }}0{{ end }};
     localparam HAS_NVME_RESP    = {{ if and (eq .DeviceClass "nvme") .NVMeIdentify }}1{{ else }}0{{ end }};
+    localparam HAS_ETHERNET_DMA = {{ if .EthernetDMA }}1{{ else }}0{{ end }};
     localparam HAS_XHCI_FSM     = {{ if eq .DeviceClass "xhci" }}1{{ else }}0{{ end }};
     localparam HAS_AUDIO_FSM    = {{ if eq .DeviceClass "audio" }}1{{ else }}0{{ end }};
     localparam HAS_MSIX_INT     = {{ if .HasMSIX }}1{{ else }}0{{ end }};

--- a/internal/firmware/svgen/templates/ethernet_dma_engine.sv.tmpl
+++ b/internal/firmware/svgen/templates/ethernet_dma_engine.sv.tmpl
@@ -1,0 +1,424 @@
+// Ethernet descriptor DMA engine for generated firmware.
+// It consumes RX descriptors made available by RDT and writes a deterministic
+// 60-byte ARP request into host memory before completing the descriptor.
+`timescale 1ns / 1ps
+
+module pcileech_ethernet_dma_engine(
+    input  wire        rst,
+    input  wire        clk,
+    input  wire        dma_enabled,
+    input  wire [63:0] rdbal,
+    input  wire [31:0] rdlen,
+    input  wire [31:0] rdh,
+    input  wire [31:0] rdt,
+    input  wire [31:0] rdt_value,
+    input  wire        rdt_write,
+    input  wire [63:0] tdbal,
+    input  wire [31:0] tdlen,
+    input  wire [31:0] tdh,
+    input  wire [31:0] tdt,
+    input  wire [31:0] tdt_value,
+    input  wire        tdt_write,
+
+    output reg         rdh_valid,
+    output reg [31:0]  rdh_value,
+    output reg         tdh_valid,
+    output reg [31:0]  tdh_value,
+    output reg [31:0]  icr_cause,
+    output reg         dma_rd_req,
+    output reg [63:0]  dma_rd_addr,
+    output reg [9:0]   dma_rd_len,
+    input  wire        dma_rd_valid,
+    input  wire [31:0] dma_rd_data,
+    input  wire        dma_rd_done,
+    input  wire        dma_rd_error,
+    output reg         dma_wr_req,
+    output reg [63:0]  dma_wr_addr,
+    output reg [31:0]  dma_wr_data,
+    output reg [3:0]   dma_wr_be,
+    output reg         dma_wr_valid,
+    input  wire        dma_wr_done
+);
+    localparam [3:0] S_IDLE      = 4'd0;
+    localparam [3:0] S_DESC_LO   = 4'd1;
+    localparam [3:0] S_DESC_HI   = 4'd2;
+    localparam [3:0] S_PACKET    = 4'd3;
+    localparam [3:0] S_DESC_LEN  = 4'd4;
+    localparam [3:0] S_DESC_STAT = 4'd5;
+    localparam [3:0] S_TX_DESC_LO = 4'd6;
+    localparam [3:0] S_TX_DESC_HI = 4'd7;
+    localparam [3:0] S_TX_DESC_LEN = 4'd8;
+    localparam [3:0] S_TX_RX_LO = 4'd9;
+    localparam [3:0] S_TX_RX_HI = 4'd10;
+    localparam [3:0] S_TX_PAYLOAD_RD = 4'd11;
+    localparam [3:0] S_TX_PAYLOAD_WR = 4'd12;
+    localparam [3:0] S_TX_RX_LEN = 4'd13;
+    localparam [3:0] S_TX_RX_STAT = 4'd14;
+    localparam [3:0] S_TX_TX_STAT = 4'd15;
+
+    reg [3:0]  state;
+    reg [63:0] rx_desc_addr;
+    reg [63:0] rx_buffer_addr;
+    reg [11:0] packet_word;
+    reg [11:0] packet_words;
+    reg [15:0] packet_length;
+    reg [63:0] tx_desc_addr;
+    reg [63:0] tx_buffer_addr;
+    reg [63:0] tx_rx_desc_addr;
+    reg        packet_profile;
+    reg        fake_pending;
+    reg [7:0]  fake_countdown;
+    reg        dma_error_blocked;
+
+    wire [31:0] ring_entries = rdlen >> 4;
+    wire [31:0] rx_tail = rdt_write ? rdt_value : rdt;
+    wire ring_valid = (rdlen >= 32'd128) && (rdlen[6:0] == 7'd0) &&
+                      (rdbal[6:0] == 7'd0) &&
+                      (rdh < ring_entries) && (rx_tail < ring_entries);
+    wire rx_available = ring_valid && (rx_tail != rdh) && !dma_error_blocked;
+    wire [31:0] tx_ring_entries = tdlen >> 4;
+    wire [31:0] tx_tail = tdt_write ? tdt_value : tdt;
+    wire tx_ring_valid = (tdlen >= 32'd128) && (tdlen[6:0] == 7'd0) &&
+                         (tdbal[6:0] == 7'd0) &&
+                         (tdh < tx_ring_entries) && (tx_tail < tx_ring_entries);
+    wire tx_available = tx_ring_valid && (tx_tail != tdh) && rx_available;
+    wire dma_read_ok = dma_rd_done && dma_rd_valid && !dma_rd_error;
+    wire dma_read_failed = dma_rd_done && (dma_rd_error || !dma_rd_valid);
+
+    function [31:0] arp_word;
+        input [4:0] index;
+        begin
+            case (index)
+                5'd0:  arp_word = 32'hFFFFFFFF;
+                5'd1:  arp_word = 32'h5002FFFF;
+                5'd2:  arp_word = 32'h454C4943;
+                5'd3:  arp_word = 32'h01000608;
+                5'd4:  arp_word = 32'h04060008;
+                5'd5:  arp_word = 32'h50020100;
+                5'd6:  arp_word = 32'h454C4943;
+                5'd7:  arp_word = 32'h00000000;
+                5'd8:  arp_word = 32'h00000000;
+                5'd9:  arp_word = 32'h00C00000;
+                5'd10: arp_word = 32'h00000102;
+                5'd11: arp_word = 32'h00000000;
+                5'd12: arp_word = 32'h00000000;
+                5'd13: arp_word = 32'h00000000;
+                5'd14: arp_word = 32'h00000000;
+                default: arp_word = 32'h00000000;
+            endcase
+        end
+    endfunction
+
+    function [31:0] icmp_word;
+        input [4:0] index;
+        begin
+            case (index)
+                5'd0:  icmp_word = 32'h49435002;
+                5'd1:  icmp_word = 32'h5002464C;
+                5'd2:  icmp_word = 32'h454C4943;
+                5'd3:  icmp_word = 32'h00450008;
+                5'd4:  icmp_word = 32'h34122000;
+                5'd5:  icmp_word = 32'h01400000;
+                5'd6:  icmp_word = 32'h00C0A5E4;
+                5'd7:  icmp_word = 32'h00C00202;
+                5'd8:  icmp_word = 32'h00080102;
+                5'd9:  icmp_word = 32'h0100735B;
+                5'd10: icmp_word = 32'h43500100;
+                5'd11: icmp_word = 32'h0000474C;
+                default: icmp_word = 32'h00000000;
+            endcase
+        end
+    endfunction
+
+    function [31:0] fake_word;
+        input        profile;
+        input [4:0]  index;
+        begin
+            fake_word = profile ? icmp_word(index) : arp_word(index);
+        end
+    endfunction
+
+    function [3:0] payload_last_be;
+        input [1:0] remainder;
+        begin
+            case (remainder)
+                2'd1: payload_last_be = 4'b0001;
+                2'd2: payload_last_be = 4'b0011;
+                2'd3: payload_last_be = 4'b0111;
+                default: payload_last_be = 4'b1111;
+            endcase
+        end
+    endfunction
+
+    always @(posedge clk) begin
+        if (rst) begin
+            state          <= S_IDLE;
+            rx_desc_addr   <= 64'h0;
+            rx_buffer_addr <= 64'h0;
+            packet_word    <= 12'd0;
+            packet_words   <= 12'd0;
+            packet_length  <= 16'd0;
+            tx_desc_addr   <= 64'h0;
+            tx_buffer_addr <= 64'h0;
+            tx_rx_desc_addr <= 64'h0;
+            packet_profile <= 1'b0;
+            fake_pending   <= 1'b0;
+            fake_countdown <= 8'd0;
+            dma_error_blocked <= 1'b0;
+            rdh_valid      <= 1'b0;
+            rdh_value      <= 32'h0;
+            tdh_valid      <= 1'b0;
+            tdh_value      <= 32'h0;
+            icr_cause      <= 32'h0;
+
+            dma_rd_req    <= 1'b0;
+            dma_rd_addr   <= 64'h0;
+            dma_rd_len    <= 10'd0;
+            dma_wr_req    <= 1'b0;
+            dma_wr_addr   <= 64'h0;
+            dma_wr_data   <= 32'h0;
+            dma_wr_be     <= 4'hF;
+            dma_wr_valid  <= 1'b0;
+        end else begin
+            rdh_valid     <= 1'b0;
+            tdh_valid     <= 1'b0;
+            icr_cause     <= 32'h0;
+
+            dma_rd_req   <= 1'b0;
+            dma_wr_req   <= 1'b0;
+            dma_wr_valid <= 1'b0;
+
+            if (!dma_enabled) begin
+                state          <= S_IDLE;
+                fake_pending   <= 1'b0;
+                fake_countdown <= 8'd0;
+                dma_error_blocked <= 1'b0;
+            end else begin
+                if (rdt_write) begin
+                    fake_pending   <= 1'b1;
+                    fake_countdown <= 8'd32;
+                    dma_error_blocked <= 1'b0;
+                end else if (fake_pending && (fake_countdown != 8'd0)) begin
+                    fake_countdown <= fake_countdown - 1'b1;
+                end
+                if (tdt_write)
+                    dma_error_blocked <= 1'b0;
+                if (dma_read_failed) begin
+                    state <= S_IDLE;
+                    dma_error_blocked <= 1'b1;
+                end
+                case (state)
+                    S_IDLE: begin
+                        if (tx_available) begin
+                            tx_desc_addr <= tdbal + ({32'h0, tdh} << 4);
+                            dma_rd_addr  <= tdbal + ({32'h0, tdh} << 4);
+                            dma_rd_len   <= 10'd1;
+                            dma_rd_req   <= 1'b1;
+                            state        <= S_TX_DESC_LO;
+                        end else if (fake_pending && (fake_countdown == 8'd0) && rx_available) begin
+                            fake_pending <= 1'b0;
+                            rx_desc_addr <= rdbal + ({32'h0, rdh} << 4);
+                            dma_rd_addr  <= rdbal + ({32'h0, rdh} << 4);
+                            dma_rd_len   <= 10'd1;
+                            dma_rd_req   <= 1'b1;
+                            state        <= S_DESC_LO;
+                        end
+                    end
+                    S_DESC_LO: begin
+                        if (dma_rd_valid)
+                            rx_buffer_addr[31:0] <= dma_rd_data;
+                        if (dma_read_ok) begin
+                            dma_rd_addr <= rx_desc_addr + 64'd4;
+                            dma_rd_req  <= 1'b1;
+                            state       <= S_DESC_HI;
+                        end
+                    end
+                    S_DESC_HI: begin
+                        if (dma_rd_valid)
+                            rx_buffer_addr[63:32] <= dma_rd_data;
+                        if (dma_read_ok) begin
+                            if ({dma_rd_data, rx_buffer_addr[31:0]} == 64'd0) begin
+                                state <= S_IDLE;
+                            end else begin
+                                packet_word  <= 12'd0;
+                                dma_wr_addr  <= {dma_rd_data, rx_buffer_addr[31:0]};
+                                dma_wr_data  <= fake_word(packet_profile, 5'd0);
+                                dma_wr_be    <= 4'hF;
+                                dma_wr_req   <= 1'b1;
+                                dma_wr_valid <= 1'b1;
+                                state        <= S_PACKET;
+                            end
+                        end
+                    end
+                    S_PACKET: begin
+                        if (dma_wr_done) begin
+                            if (packet_word == 12'd14) begin
+                                dma_wr_addr  <= rx_desc_addr + 64'd8;
+                                dma_wr_data  <= 32'h0000003C;
+                                dma_wr_be    <= 4'b0011;
+                                dma_wr_req   <= 1'b1;
+                                dma_wr_valid <= 1'b1;
+                                state        <= S_DESC_LEN;
+                            end else begin
+                                packet_word  <= packet_word + 1'b1;
+                                dma_wr_addr  <= rx_buffer_addr + (({52'd0, packet_word} + 64'd1) << 2);
+                                dma_wr_data  <= fake_word(packet_profile, packet_word[4:0] + 5'd1);
+                                dma_wr_req   <= 1'b1;
+                                dma_wr_valid <= 1'b1;
+                            end
+                        end
+                    end
+                    S_DESC_LEN: begin
+                        if (dma_wr_done) begin
+                            dma_wr_addr  <= rx_desc_addr + 64'd12;
+                            dma_wr_data  <= 32'h00000003;
+                            dma_wr_be    <= 4'b0001;
+                            dma_wr_req   <= 1'b1;
+                            dma_wr_valid <= 1'b1;
+                            state        <= S_DESC_STAT;
+                        end
+                    end
+                    S_DESC_STAT: begin
+                        if (dma_wr_done) begin
+                            if (rdh + 1'b1 >= ring_entries)
+                                rdh_value <= 32'd0;
+                            else
+                                rdh_value <= rdh + 1'b1;
+                            rdh_valid <= 1'b1;
+                            icr_cause <= 32'h00000080;
+
+                            packet_profile <= ~packet_profile;
+                            state     <= S_IDLE;
+                        end
+                    end
+                    S_TX_DESC_LO: begin
+                        if (dma_rd_valid)
+                            tx_buffer_addr[31:0] <= dma_rd_data;
+                        if (dma_read_ok) begin
+                            dma_rd_addr <= tx_desc_addr + 64'd4;
+                            dma_rd_req  <= 1'b1;
+                            state       <= S_TX_DESC_HI;
+                        end
+                    end
+                    S_TX_DESC_HI: begin
+                        if (dma_rd_valid)
+                            tx_buffer_addr[63:32] <= dma_rd_data;
+                        if (dma_read_ok) begin
+                            dma_rd_addr <= tx_desc_addr + 64'd8;
+                            dma_rd_req  <= 1'b1;
+                            state       <= S_TX_DESC_LEN;
+                        end
+                    end
+                    S_TX_DESC_LEN: begin
+                        if (dma_rd_valid)
+                            packet_length <= dma_rd_data[15:0];
+                        if (dma_read_ok) begin
+                            if ((dma_rd_data[15:0] == 16'd0) ||
+                                (dma_rd_data[15:0] > 16'd2048) ||
+                                (tx_buffer_addr == 64'd0)) begin
+                                state <= S_IDLE;
+                            end else begin
+                                packet_length   <= dma_rd_data[15:0];
+                                packet_words    <= {1'b0, dma_rd_data[12:2]} +
+                                                   {11'b0, |dma_rd_data[1:0]};
+                                packet_word     <= 12'd0;
+                                tx_rx_desc_addr <= rdbal + ({32'h0, rdh} << 4);
+                                dma_rd_addr     <= rdbal + ({32'h0, rdh} << 4);
+                                dma_rd_req      <= 1'b1;
+                                state            <= S_TX_RX_LO;
+                            end
+                        end
+                    end
+                    S_TX_RX_LO: begin
+                        if (dma_rd_valid)
+                            rx_buffer_addr[31:0] <= dma_rd_data;
+                        if (dma_read_ok) begin
+                            dma_rd_addr <= tx_rx_desc_addr + 64'd4;
+                            dma_rd_req  <= 1'b1;
+                            state       <= S_TX_RX_HI;
+                        end
+                    end
+                    S_TX_RX_HI: begin
+                        if (dma_rd_valid)
+                            rx_buffer_addr[63:32] <= dma_rd_data;
+                        if (dma_read_ok) begin
+                            if ({dma_rd_data, rx_buffer_addr[31:0]} == 64'd0) begin
+                                state <= S_IDLE;
+                            end else begin
+                                dma_rd_addr <= tx_buffer_addr;
+                                dma_rd_req  <= 1'b1;
+                                state       <= S_TX_PAYLOAD_RD;
+                            end
+                        end
+                    end
+                    S_TX_PAYLOAD_RD: begin
+                        if (dma_read_ok) begin
+                            dma_wr_addr  <= rx_buffer_addr + ({52'd0, packet_word} << 2);
+                            dma_wr_data  <= dma_rd_data;
+                            dma_wr_be    <= (packet_word + 1'b1 >= packet_words)
+                                            ? payload_last_be(packet_length[1:0]) : 4'hF;
+                            dma_wr_req   <= 1'b1;
+                            dma_wr_valid <= 1'b1;
+                            state        <= S_TX_PAYLOAD_WR;
+                        end
+                    end
+                    S_TX_PAYLOAD_WR: begin
+                        if (dma_wr_done) begin
+                            if (packet_word + 1'b1 >= packet_words) begin
+                                dma_wr_addr  <= tx_rx_desc_addr + 64'd8;
+                                dma_wr_data  <= {16'h0, packet_length};
+                                dma_wr_be    <= 4'b0011;
+                                dma_wr_req   <= 1'b1;
+                                dma_wr_valid <= 1'b1;
+                                state        <= S_TX_RX_LEN;
+                            end else begin
+                                packet_word <= packet_word + 1'b1;
+                                dma_rd_addr <= tx_buffer_addr + (({52'd0, packet_word} + 64'd1) << 2);
+                                dma_rd_req  <= 1'b1;
+                                state       <= S_TX_PAYLOAD_RD;
+                            end
+                        end
+                    end
+                    S_TX_RX_LEN: begin
+                        if (dma_wr_done) begin
+                            dma_wr_addr  <= tx_rx_desc_addr + 64'd12;
+                            dma_wr_data  <= 32'h00000003;
+                            dma_wr_be    <= 4'b0001;
+                            dma_wr_req   <= 1'b1;
+                            dma_wr_valid <= 1'b1;
+                            state        <= S_TX_RX_STAT;
+                        end
+                    end
+                    S_TX_RX_STAT: begin
+                        if (dma_wr_done) begin
+                            dma_wr_addr  <= tx_desc_addr + 64'd12;
+                            dma_wr_data  <= 32'h00000001;
+                            dma_wr_be    <= 4'b0001;
+                            dma_wr_req   <= 1'b1;
+                            dma_wr_valid <= 1'b1;
+                            state        <= S_TX_TX_STAT;
+                        end
+                    end
+                    S_TX_TX_STAT: begin
+                        if (dma_wr_done) begin
+                            if (rdh + 1'b1 >= ring_entries)
+                                rdh_value <= 32'd0;
+                            else
+                                rdh_value <= rdh + 1'b1;
+                            if (tdh + 1'b1 >= tx_ring_entries)
+                                tdh_value <= 32'd0;
+                            else
+                                tdh_value <= tdh + 1'b1;
+                            rdh_valid <= 1'b1;
+                            tdh_valid <= 1'b1;
+                            icr_cause <= 32'h00000081;
+
+                            state     <= S_IDLE;
+                        end
+                    end
+                    default: state <= S_IDLE;
+                endcase
+            end
+        end
+    end
+endmodule

--- a/internal/firmware/svgen/templates/nvme_dma_bridge.sv.tmpl
+++ b/internal/firmware/svgen/templates/nvme_dma_bridge.sv.tmpl
@@ -28,8 +28,9 @@ module pcileech_nvme_dma_bridge(
     output reg          dma_rd_valid,
     output reg [31:0]   dma_rd_data,
     output reg          dma_rd_done,
+    output reg          dma_rd_error,
 
-    // outgoing TLP stream - muxed with BAR read completions
+    // outgoing TLP stream
     output reg [127:0]  tlp_tx_tdata,
     output reg [3:0]    tlp_tx_tkeepdw,
     output reg          tlp_tx_tvalid,
@@ -195,6 +196,7 @@ module pcileech_nvme_dma_bridge(
             dma_wr_done     <= 1'b0;
             dma_rd_valid    <= 1'b0;
             dma_rd_done     <= 1'b0;
+            dma_rd_error    <= 1'b0;
             dma_rd_data     <= 32'h0;
             tlp_tx_tdata    <= 128'h0;
             tlp_tx_tkeepdw  <= 4'h0;
@@ -219,6 +221,7 @@ module pcileech_nvme_dma_bridge(
             dma_wr_done  <= 1'b0;
             dma_rd_valid <= 1'b0;
             dma_rd_done  <= 1'b0;
+            dma_rd_error <= 1'b0;
             tag_alloc_valid <= 1'b0;
 
             if (!dma_enabled) begin
@@ -273,6 +276,7 @@ module pcileech_nvme_dma_bridge(
                         bstate <= B_RD_SEND;
                     end else if (dma_enabled && dma_rd_req) begin
                         dma_rd_done <= 1'b1;
+                        dma_rd_error <= 1'b1;
                     end
                 end
 
@@ -319,6 +323,7 @@ module pcileech_nvme_dma_bridge(
                         rd_payload <= 32'h0;
                         rd_remaining <= 10'h0;
                         dma_rd_done <= 1'b1;
+                        dma_rd_error <= 1'b1;
                         bstate <= B_IDLE;
                     end else if (tag_outcome_valid &&
                                  (tag_outcome_tag == rd_active_tag) &&
@@ -326,6 +331,7 @@ module pcileech_nvme_dma_bridge(
                         rd_payload <= 32'h0;
                         rd_remaining <= 10'h0;
                         dma_rd_done <= 1'b1;
+                        dma_rd_error <= 1'b1;
                         bstate <= B_IDLE;
                 end
                 end

--- a/internal/firmware/svgen/transaction_verilator_test.go
+++ b/internal/firmware/svgen/transaction_verilator_test.go
@@ -778,6 +778,7 @@ func extractHDLThroughAlways(t *testing.T, source, start, always string) string 
 
 func extractHDLBlock(t *testing.T, source, start, end string) string {
 	t.Helper()
+	source = strings.ReplaceAll(source, string([]byte{13, 10}), string([]byte{10}))
 	startIndex := strings.Index(source, start)
 	if startIndex < 0 {
 		t.Fatalf("start marker missing: %s", start)

--- a/scripts/hdl-lint.sh
+++ b/scripts/hdl-lint.sh
@@ -29,7 +29,7 @@ if [ "${#BOARDS[@]}" -eq 0 ]; then
 fi
 
 # whitelist of svgen output files (primitives like pcileech_fifo.sv are blackboxed)
-SVGEN_PATTERN='pcileech_lifecycle_service.sv|pcileech_dma_tag_service.sv|pcileech_interrupt_service.sv|pcileech_bar_impl_device.sv|pcileech_tlps128_bar_controller.sv|pcileech_tlp_normalizer.sv|pcileech_tlp_ur_completer.sv|pcileech_bar_rsp_arbiter.sv|pcileech_tlps128_bar_rdengine.sv|pcileech_tlps128_bar_wrengine.sv|pcileech_bar_impl_none.sv|pcileech_bar_impl_zerowrite4k.sv|pcileech_bar_impl_msi.sv|tlp_latency_emulator.sv|device_config.sv|pcileech_msix_table.sv|pcileech_nvme_admin_responder.sv|pcileech_nvme_dma_bridge.sv|pcileech_bram_disk.sv|pcileech_hda_rirb_dma.sv|pcileech_hda_msi.sv'
+SVGEN_PATTERN='pcileech_lifecycle_service.sv|pcileech_dma_tag_service.sv|pcileech_interrupt_service.sv|pcileech_bar_impl_device.sv|pcileech_tlps128_bar_controller.sv|pcileech_tlp_normalizer.sv|pcileech_tlp_ur_completer.sv|pcileech_bar_rsp_arbiter.sv|pcileech_tlps128_bar_rdengine.sv|pcileech_tlps128_bar_wrengine.sv|pcileech_bar_impl_none.sv|pcileech_bar_impl_zerowrite4k.sv|pcileech_bar_impl_msi.sv|tlp_latency_emulator.sv|device_config.sv|pcileech_msix_table.sv|pcileech_nvme_admin_responder.sv|pcileech_nvme_dma_bridge.sv|pcileech_ethernet_dma_engine.sv|pcileech_ethernet_dma_bridge.sv|pcileech_bram_disk.sv|pcileech_hda_rirb_dma.sv|pcileech_hda_msi.sv'
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT

--- a/tests/cocotb/test_eth_init.py
+++ b/tests/cocotb/test_eth_init.py
@@ -1,11 +1,39 @@
 import cocotb
+from cocotb.triggers import RisingEdge
 from test_helpers import reset, read_bar, write_bar
 
 CTRL = 0x0000
 STATUS = 0x0008
 RCTL = 0x0100
 TCTL = 0x0400
-RDBAL = 0x0200
+RDBAL = 0x2800
+RDBAL_DMA = RDBAL
+RDLEN_DMA = 0x2808
+RDH_DMA = 0x2810
+RDT_DMA = 0x2818
+TDBAL_DMA = 0x3800
+TDLEN_DMA = 0x3808
+TDH_DMA = 0x3810
+TDT_DMA = 0x3818
+IMS_DMA = 0x00D0
+ICR_DMA = 0x00C0
+ICS_DMA = 0x00C8
+IMC_DMA = 0x00D8
+
+
+async def host_poke(dut, word_index, value):
+    dut.host_poke_addr.value = word_index & 0xFFFF
+    dut.host_poke_data.value = value & 0xFFFFFFFF
+    dut.host_poke_valid.value = 1
+    await RisingEdge(dut.clk)
+    dut.host_poke_valid.value = 0
+
+
+async def host_peek(dut, word_index):
+    dut.host_peek_addr.value = word_index & 0xFFFF
+    await RisingEdge(dut.clk)
+    await RisingEdge(dut.clk)
+    return dut.host_peek_data.value.integer
 
 @cocotb.test()
 async def test_eth_ctrl_read(dut):
@@ -34,7 +62,21 @@ async def test_eth_descriptor_base_write(dut):
     await reset(dut)
     await write_bar(dut, RDBAL, 0xDEADBEEF)
     val = await read_bar(dut, RDBAL, tag=5)
-    assert val == 0xDEADBEEF, f"RDBAL readback: {val:#x}"
+    assert val == 0xDEADBE80, f"RDBAL alignment mask: {val:#x}"
+
+
+@cocotb.test()
+async def test_eth_interrupt_cause_and_mask_semantics(dut):
+    await reset(dut)
+    await write_bar(dut, IMS_DMA, 0x80)
+    await write_bar(dut, IMS_DMA, 0x01)
+    assert await read_bar(dut, IMS_DMA, tag=6) == 0x81
+    await write_bar(dut, IMC_DMA, 0x01)
+    assert await read_bar(dut, IMS_DMA, tag=7) == 0x80
+    await write_bar(dut, ICS_DMA, 0x80)
+    assert await read_bar(dut, ICR_DMA, tag=8) == 0x80
+    assert await read_bar(dut, ICR_DMA, tag=9) == 0
+
 
 @cocotb.test()
 async def test_eth_full_driver_init(dut):
@@ -45,3 +87,42 @@ async def test_eth_full_driver_init(dut):
     await write_bar(dut, TCTL, 0xFF)
     assert await read_bar(dut, RCTL, tag=12) == 0x3E
     assert await read_bar(dut, TCTL, tag=13) == 0xFF
+
+
+@cocotb.test()
+async def test_eth_dma_fake_rx_and_tx_loopback(dut):
+    await reset(dut)
+
+    # Intel rings have 128-byte minimum length (eight 16-byte descriptors).
+    await host_poke(dut, 0x1000 // 4, 0x00005000)
+    await host_poke(dut, 0x1000 // 4 + 4, 0x00005010)
+    await host_poke(dut, 0x2000 // 4, 0x00006000)
+    await host_poke(dut, 0x2000 // 4 + 2, 0x01000004)  # length=4, software-owned EOP
+    await host_poke(dut, 0x6000 // 4, 0x474E4950)  # "PING" in host byte order
+    await write_bar(dut, RDBAL_DMA, 0x1000)
+    await write_bar(dut, RDLEN_DMA, 128)
+    await write_bar(dut, TDBAL_DMA, 0x2000)
+    await write_bar(dut, TDLEN_DMA, 128)
+    await write_bar(dut, IMS_DMA, 1 << 7)
+
+    # RDT=1 causes firmware to DMA the synthetic ARP frame to RX buffer 0.
+    await write_bar(dut, RDT_DMA, 1)
+    for _ in range(2500):
+        await RisingEdge(dut.clk)
+    assert await host_peek(dut, 0x5000 // 4) == 0xFFFFFFFF
+    assert await host_peek(dut, 0x5000 // 4 + 3) == 0x01000608
+    assert await host_peek(dut, 0x1000 // 4 + 2) == 60
+    assert await host_peek(dut, 0x1000 // 4 + 3) == 3
+    assert await read_bar(dut, RDH_DMA, tag=20) == 1
+
+    # Make RX descriptor 1 available, then submit TX descriptor 0.
+    await write_bar(dut, RDT_DMA, 2)
+    await write_bar(dut, TDT_DMA, 1)
+    for _ in range(4000):
+        await RisingEdge(dut.clk)
+    assert await host_peek(dut, 0x5010 // 4) == 0x474E4950
+    assert await host_peek(dut, 0x1010 // 4 + 2) == 4
+    assert await host_peek(dut, 0x1010 // 4 + 3) == 3
+    assert await host_peek(dut, 0x2000 // 4 + 2) == 0x01000004
+    assert await host_peek(dut, 0x2000 // 4 + 3) == 1
+    assert await read_bar(dut, TDH_DMA, tag=21) == 1

--- a/tests/cocotb/test_helpers.py
+++ b/tests/cocotb/test_helpers.py
@@ -57,7 +57,7 @@ async def recv_all(dut, timeout=10000):
 
 
 async def reset(dut):
-    cocotb.start_soon(Clock(dut.clk, 10, unit="ns").start())
+    cocotb.start_soon(Clock(dut.clk, 10, units="ns").start())
     dut.rst.value = 1
     dut.tlps_in_tvalid.value = 0
     await Timer(200, "ns")

--- a/tests/cocotb/test_pcie_host.py
+++ b/tests/cocotb/test_pcie_host.py
@@ -77,7 +77,7 @@ async def recv_dma_all(dut, timeout=10000):
     return beats
 
 async def reset(dut):
-    cocotb.start_soon(Clock(dut.clk, 10, unit="ns").start())
+    cocotb.start_soon(Clock(dut.clk, 10, units="ns").start())
     dut.rst.value = 1
     dut.tlps_in_tvalid.value = 0
     dut.loopback_en.value = 1

--- a/tests/cocotb/test_pio.py
+++ b/tests/cocotb/test_pio.py
@@ -59,7 +59,7 @@ async def recv_all(dut, timeout=10000):
 
 
 async def reset(dut):
-    cocotb.start_soon(Clock(dut.clk, 10, unit="ns").start())
+    cocotb.start_soon(Clock(dut.clk, 10, units="ns").start())
     dut.rst.value = 1
     dut.tlps_in_tvalid.value = 0
     await Timer(200, "ns")

--- a/vfio-user/src/behavior_ethernet.c
+++ b/vfio-user/src/behavior_ethernet.c
@@ -4,6 +4,26 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define ETH_DESC_DD 0x01u
+#define ETH_DESC_EOP 0x02u
+#define ETH_MAX_PACKET 2048u
+#define ETH_MIN_PACKET 60u
+#define ETH_ICR_TXDW 0x00000001u
+#define ETH_ICR_RXT0 0x00000080u
+#define ETH_REG_ICR 0x00c0u
+#define ETH_REG_ICS 0x00c8u
+#define ETH_REG_IMS 0x00d0u
+#define ETH_REG_IMC 0x00d8u
+#define ETH_REG_RDBAL 0x2800u
+#define ETH_REG_RDBAH 0x2804u
+#define ETH_REG_RDLEN 0x2808u
+#define ETH_REG_RDH 0x2810u
+#define ETH_REG_RDT 0x2818u
+#define ETH_REG_TDBAL 0x3800u
+#define ETH_REG_TDBAH 0x3804u
+#define ETH_REG_TDLEN 0x3808u
+#define ETH_REG_TDH 0x3810u
+#define ETH_REG_TDT 0x3818u
 
 struct ethernet_state {
     struct device_behavior registers;
@@ -11,6 +31,7 @@ struct ethernet_state {
     uint32_t ctrl, status, eerd, mdic, icr, ims;
     uint64_t rdbal, tdbal;
     uint32_t rdlen, rdh, rdt, tdlen, tdh, tdt;
+    uint64_t rx_packets, tx_packets;
 };
 
 static uint32_t *reg32(struct ethernet_state *s, uint64_t off)
@@ -20,30 +41,235 @@ static uint32_t *reg32(struct ethernet_state *s, uint64_t off)
     case 0x0008: return &s->status;
     case 0x0014: return &s->eerd;
     case 0x0020: return &s->mdic;
-    case 0x00c0: return &s->icr;
-    case 0x00d0: return &s->ims;
-    case 0x0288: return &s->rdlen;
-    case 0x2810: return &s->rdh;
-    case 0x2818: return &s->rdt;
-    case 0x0388: return &s->tdlen;
-    case 0x3810: return &s->tdh;
-    case 0x3818: return &s->tdt;
+    case ETH_REG_ICR: return &s->icr;
+    case ETH_REG_IMS: return &s->ims;
+    case ETH_REG_RDLEN: return &s->rdlen;
+    case ETH_REG_RDH: return &s->rdh;
+    case ETH_REG_RDT: return &s->rdt;
+    case ETH_REG_TDLEN: return &s->tdlen;
+    case ETH_REG_TDH: return &s->tdh;
+    case ETH_REG_TDT: return &s->tdt;
     default: return NULL;
     }
 }
 
-static int ring_ready(const struct ethernet_state *state)
+static int ring_ready(uint64_t base, uint32_t length,
+                      uint32_t head, uint32_t tail)
 {
-    return state->rdlen >= 16 && state->tdlen >= 16 &&
-           (state->rdlen % 16) == 0 && (state->tdlen % 16) == 0 &&
-           state->tdh < state->tdlen / 16 && state->rdt < state->rdlen / 16;
+    uint32_t entries;
+
+    if (base == 0 || (base & 0x7fu) != 0 ||
+        length < 128 || (length & 0x7fu) != 0)
+        return 0;
+    entries = length / 16;
+    return head < entries && tail < entries;
+}
+
+static int rx_ring_ready(const struct ethernet_state *state)
+{
+    return ring_ready(state->rdbal, state->rdlen, state->rdh, state->rdt);
+}
+
+static int tx_ring_ready(const struct ethernet_state *state)
+{
+    return ring_ready(state->tdbal, state->tdlen, state->tdh, state->tdt);
 }
 
 static uint64_t reg64(struct ethernet_state *s, uint64_t off)
 {
-    if (off == 0x0280) return s->rdbal;
-    if (off == 0x0380) return s->tdbal;
+    if (off == ETH_REG_RDBAL || off == ETH_REG_RDBAH) return s->rdbal;
+    if (off == ETH_REG_TDBAL || off == ETH_REG_TDBAH) return s->tdbal;
     return 0;
+}
+
+static void ethernet_raise_irq(struct ethernet_state *state, uint32_t causes)
+{
+    state->icr |= causes;
+    if ((state->ims & causes) != 0 && state->host.irq != NULL)
+        state->host.irq(state->host.opaque, 0);
+}
+
+static int ethernet_complete_rx(struct ethernet_state *state, uint64_t desc,
+                                const uint8_t *payload, uint16_t length)
+{
+    uint8_t rx[8];
+    uint8_t status = ETH_DESC_DD | ETH_DESC_EOP;
+    uint64_t buffer;
+
+    if (state->host.dma_read(state->host.opaque, desc, rx, sizeof(rx)) < 0)
+        return -1;
+    memcpy(&buffer, rx, sizeof(buffer));
+    if (buffer == 0 || length == 0 || length > ETH_MAX_PACKET)
+        return -1;
+    if (state->host.dma_write(state->host.opaque, buffer, payload, length) < 0)
+        return -1;
+    if (state->host.dma_write(state->host.opaque, desc + 8, &length,
+                              sizeof(length)) < 0 ||
+        state->host.dma_write(state->host.opaque, desc + 12, &status,
+                              sizeof(status)) < 0)
+        return -1;
+    state->rx_packets++;
+    return 0;
+}
+
+static int ethernet_complete_tx(struct ethernet_state *state, uint64_t desc)
+{
+    uint8_t status = ETH_DESC_DD;
+
+    if (state->host.dma_write(state->host.opaque, desc + 12, &status,
+                              sizeof(status)) < 0)
+        return -1;
+    state->tx_packets++;
+    return 0;
+}
+
+static size_t ethernet_fake_arp(uint8_t *packet)
+{
+    static const uint8_t source[6] = {0x02, 0x50, 0x43, 0x49, 0x4c, 0x45};
+    static const uint8_t target_ip[4] = {192, 0, 2, 1};
+
+    memset(packet, 0, ETH_MIN_PACKET);
+    memset(packet, 0xff, 6);
+    memcpy(packet + 6, source, sizeof(source));
+    packet[12] = 0x08;
+    packet[13] = 0x06;
+    packet[14] = 0x00;
+    packet[15] = 0x01;
+    packet[16] = 0x08;
+    packet[17] = 0x00;
+    packet[18] = 0x06;
+    packet[19] = 0x04;
+    packet[20] = 0x00;
+    packet[21] = 0x01;
+    memcpy(packet + 22, source, sizeof(source));
+    memcpy(packet + 38, target_ip, sizeof(target_ip));
+    return ETH_MIN_PACKET;
+}
+
+static uint16_t ethernet_checksum(const uint8_t *data, size_t length)
+{
+    uint32_t sum = 0;
+
+    while (length > 1) {
+        sum += ((uint16_t)data[0] << 8) | data[1];
+        data += 2;
+        length -= 2;
+    }
+    if (length != 0)
+        sum += (uint16_t)data[0] << 8;
+    while ((sum >> 16) != 0)
+        sum = (sum & 0xffffu) + (sum >> 16);
+    return (uint16_t)~sum;
+}
+
+static void ethernet_put_be16(uint8_t *data, uint16_t value)
+{
+    data[0] = (uint8_t)(value >> 8);
+    data[1] = (uint8_t)value;
+}
+
+static size_t ethernet_fake_icmp(uint8_t *packet)
+{
+    static const uint8_t source[6] = {0x02, 0x50, 0x43, 0x49, 0x4c, 0x45};
+    static const uint8_t destination[6] = {0x02, 0x50, 0x43, 0x49, 0x4c, 0x46};
+    static const uint8_t payload[] = {'P', 'C', 'L', 'G'};
+    uint16_t checksum;
+
+    memset(packet, 0, ETH_MIN_PACKET);
+    memcpy(packet, destination, sizeof(destination));
+    memcpy(packet + 6, source, sizeof(source));
+    packet[12] = 0x08;
+    packet[13] = 0x00;
+    packet[14] = 0x45;
+    packet[16] = 0x00;
+    packet[17] = 0x20;
+    packet[18] = 0x12;
+    packet[19] = 0x34;
+    packet[20] = 0x00;
+    packet[21] = 0x00;
+    packet[22] = 64;
+    packet[23] = 1;
+    packet[26] = 192;
+    packet[27] = 0;
+    packet[28] = 2;
+    packet[29] = 2;
+    packet[30] = 192;
+    packet[31] = 0;
+    packet[32] = 2;
+    packet[33] = 1;
+    checksum = ethernet_checksum(packet + 14, 20);
+    ethernet_put_be16(packet + 24, checksum);
+    packet[34] = 8;
+    packet[35] = 0;
+    packet[36] = 0;
+    packet[37] = 0;
+    packet[38] = 0;
+    packet[39] = 1;
+    packet[40] = 0;
+    packet[41] = 1;
+    memcpy(packet + 42, payload, sizeof(payload));
+    checksum = ethernet_checksum(packet + 34, 12);
+    ethernet_put_be16(packet + 36, checksum);
+    return ETH_MIN_PACKET;
+}
+
+static int ethernet_inject_packet(struct ethernet_state *state)
+{
+    uint8_t packet[ETH_MIN_PACKET];
+    uint64_t desc = state->rdbal + (uint64_t)state->rdh * 16;
+
+    if ((state->rx_packets % 2) == 0) {
+        if (ethernet_fake_arp(packet) == 0)
+            return -1;
+    } else if (ethernet_fake_icmp(packet) == 0) {
+        return -1;
+    }
+    if (ethernet_complete_rx(state, desc, packet, sizeof(packet)) < 0)
+        return -1;
+    state->rdh = (state->rdh + 1) % (state->rdlen / 16);
+    ethernet_raise_irq(state, ETH_ICR_RXT0);
+    return 0;
+}
+
+
+static int ethernet_process_tx(struct ethernet_state *state)
+{
+    uint8_t tx[16];
+    uint64_t tx_desc;
+    uint64_t rx_desc;
+    uint64_t buffer;
+    uint16_t length;
+    uint8_t *payload;
+
+    if (state->host.dma_read == NULL || state->host.dma_write == NULL ||
+        !tx_ring_ready(state) || !rx_ring_ready(state) ||
+        state->tdh == state->tdt || state->rdh == state->rdt)
+        return 0;
+
+    tx_desc = state->tdbal + (uint64_t)state->tdh * 16;
+    rx_desc = state->rdbal + (uint64_t)state->rdh * 16;
+    if (state->host.dma_read(state->host.opaque, tx_desc, tx, sizeof(tx)) < 0)
+        return -1;
+    memcpy(&buffer, tx, sizeof(buffer));
+    memcpy(&length, tx + 8, sizeof(length));
+    if (buffer == 0 || length == 0 || length > ETH_MAX_PACKET)
+        return -1;
+
+    payload = malloc(length);
+    if (payload == NULL)
+        return -1;
+    if (state->host.dma_read(state->host.opaque, buffer, payload, length) < 0 ||
+        ethernet_complete_rx(state, rx_desc, payload, length) < 0 ||
+        ethernet_complete_tx(state, tx_desc) < 0) {
+        free(payload);
+        return -1;
+    }
+    free(payload);
+
+    state->tdh = (state->tdh + 1) % (state->tdlen / 16);
+    state->rdh = (state->rdh + 1) % (state->rdlen / 16);
+    ethernet_raise_irq(state, ETH_ICR_TXDW | ETH_ICR_RXT0);
+    return 1;
 }
 
 
@@ -63,6 +289,7 @@ static int ethernet_reset(void *opaque)
     state->icr = 0; state->ims = 0; state->rdbal = state->tdbal = 0;
     state->rdlen = state->rdh = state->rdt = 0;
     state->tdlen = state->tdh = state->tdt = 0;
+    state->rx_packets = state->tx_packets = 0;
     return rc;
 }
 
@@ -74,11 +301,25 @@ static ssize_t ethernet_read(void *opaque, unsigned bir, uint64_t offset,
     uint32_t *reg;
     if (state == NULL) return -EINVAL;
     if (data == NULL) return -EINVAL;
-    if (bir == 0 && length == 4 && (reg = reg32(state, offset)) != NULL) {
-        memcpy(data, reg, 4); return 4;
+    if (bir == 0 && length == 4 && offset == ETH_REG_ICR) {
+        uint32_t value = state->icr;
+        state->icr = 0;
+        memcpy(data, &value, sizeof(value));
+        return 4;
     }
-    if (bir == 0 && length == 4 && (offset == 0x0280 || offset == 0x0380)) {
-        uint32_t value = (uint32_t)reg64(state, offset); memcpy(data, &value, 4); return 4;
+    if (bir == 0 && length == 4 && (reg = reg32(state, offset)) != NULL) {
+        memcpy(data, reg, 4);
+        return 4;
+    }
+    if (bir == 0 && length == 4 &&
+        (offset == ETH_REG_RDBAL || offset == ETH_REG_RDBAH ||
+         offset == ETH_REG_TDBAL || offset == ETH_REG_TDBAH)) {
+        uint64_t value64 = reg64(state, offset);
+        uint32_t value = (offset == ETH_REG_RDBAH || offset == ETH_REG_TDBAH)
+                             ? (uint32_t)(value64 >> 32)
+                             : (uint32_t)value64;
+        memcpy(data, &value, sizeof(value));
+        return 4;
     }
     return state->registers.read(state->registers.state, bir, offset, data, length);
 }
@@ -89,12 +330,34 @@ static ssize_t ethernet_write(void *opaque, unsigned bir, uint64_t offset,
 {
     struct ethernet_state *state = opaque;
     uint32_t value;
+    uint32_t previous_rdt;
     if (state == NULL) return -EINVAL;
     if (data == NULL) return -EINVAL;
-    if (bir == 0 && length == 4 && (offset == 0x0280 || offset == 0x0380)) {
-        memcpy(&value, data, 4); if (offset == 0x0280) state->rdbal = value; else state->tdbal = value; return 4;
+    previous_rdt = state->rdt;
+    if (bir == 0 && length == 4 &&
+        (offset == ETH_REG_RDBAL || offset == ETH_REG_TDBAL)) {
+        uint64_t *base = offset == ETH_REG_RDBAL ? &state->rdbal : &state->tdbal;
+        memcpy(&value, data, sizeof(value));
+        *base = (*base & 0xffffffff00000000ULL) | (value & 0xffffff80u);
+        return 4;
     }
-    if (bir == 0 && length == 4 && (offset == 0x0284 || offset == 0x0384)) return 4;
+    if (bir == 0 && length == 4 &&
+        (offset == ETH_REG_RDBAH || offset == ETH_REG_TDBAH)) {
+        uint64_t *base = offset == ETH_REG_RDBAH ? &state->rdbal : &state->tdbal;
+        memcpy(&value, data, sizeof(value));
+        *base = (*base & 0xffffffffULL) | ((uint64_t)value << 32);
+        return 4;
+    }
+    if (bir == 0 && length == 4 && offset == ETH_REG_ICS) {
+        memcpy(&value, data, sizeof(value));
+        ethernet_raise_irq(state, value);
+        return 4;
+    }
+    if (bir == 0 && length == 4 && offset == ETH_REG_IMC) {
+        memcpy(&value, data, sizeof(value));
+        state->ims &= ~value;
+        return 4;
+    }
     if (bir == 0 && length == 4 && reg32(state, offset) != NULL) {
         memcpy(&value, data, 4);
         if (offset == 0x0014) { state->eerd = (value & 1) | (2u << 4) | (0x1100u << 16); return 4; }
@@ -104,49 +367,37 @@ static ssize_t ethernet_write(void *opaque, unsigned bir, uint64_t offset,
             state->mdic = (value & 0x03ff0000u) | phy_data | 0x10000000u;
             return 4;
         }
-        if (offset == 0x00c0) { state->icr &= ~value; return 4; }
-        if (offset == 0x00d0) { state->ims = value; return 4; }
+        if (offset == ETH_REG_ICR) return 4;
+        if (offset == ETH_REG_IMS) {
+            state->ims |= value;
+            if ((state->icr & value) != 0 && state->host.irq != NULL)
+                state->host.irq(state->host.opaque, 0);
+            return 4;
+        }
+        if (offset == ETH_REG_RDLEN || offset == ETH_REG_TDLEN)
+            value &= 0x000fff80u;
+        if (offset == ETH_REG_RDH || offset == ETH_REG_RDT ||
+            offset == ETH_REG_TDH || offset == ETH_REG_TDT)
+            value &= 0x0000ffffu;
         *reg32(state, offset) = value;
-        if (offset == 0x3818 && state->host.dma_read != NULL && state->host.dma_write != NULL &&
-            ring_ready(state)) {
-            uint8_t tx[16]; uint64_t desc = state->tdbal + (uint64_t)state->tdh * 16;
-            if (state->host.dma_read(state->host.opaque, desc, tx, sizeof(tx)) == 0) {
-                uint64_t buf; uint16_t len; memcpy(&buf, tx, 8); memcpy(&len, tx + 8, 2);
-                uint8_t rx[16]; uint64_t rx_desc = state->rdbal + (uint64_t)state->rdt * 16;
-                uint64_t rxbuf = 0;
-                if (state->host.dma_read(state->host.opaque, rx_desc, rx, sizeof(rx)) == 0) {
-                    memcpy(&rxbuf, rx, 8);
-                }
-                if (len > 0 && len <= 16384 && rxbuf != 0) {
-                    uint8_t *payload = malloc(len);
-                    if (payload != NULL && state->host.dma_read(state->host.opaque, buf, payload, len) == 0)
-                        state->host.dma_write(state->host.opaque, rxbuf, payload, len);
-                    free(payload);
-                }
-                if (state->host.dma_write(state->host.opaque, rx_desc, tx, sizeof(tx)) == 0) {
-                    state->rdt = (state->rdt + 1) % (state->rdlen / 16);
-                    state->icr |= 1u << 7;
-                    if (state->ims & (1u << 7) && state->host.irq) state->host.irq(state->host.opaque, 0);
-                }
-                (void)buf; (void)len;
+        if (state->host.dma_read != NULL && state->host.dma_write != NULL) {
+            uint32_t processed = 0;
+            uint32_t limit = tx_ring_ready(state) ? state->tdlen / 16 : 0;
+            int tx_result = 0;
+            if (offset == ETH_REG_TDT || offset == ETH_REG_RDT) {
+                while (processed < limit &&
+                       (tx_result = ethernet_process_tx(state)) > 0)
+                    processed++;
             }
+            if (offset == ETH_REG_RDT && value != previous_rdt &&
+                processed == 0 && tx_result == 0 &&
+                rx_ring_ready(state) && state->rdh != state->rdt)
+                (void)ethernet_inject_packet(state);
         }
         return 4;
     }
-    ssize_t result = state->registers.write(state->registers.state, bir, offset,
-                                            data, length);
-    uint32_t command;
-
-    if (result < 0 || bir != 0 || offset != 0x34 || length != 4) {
-        return result;
-    }
-    memcpy(&command, data, sizeof(command));
-    if ((command & 0x10000000u) == 0) {
-        return result;
-    }
-    command = 0x0c000000u;
-    return state->registers.write(state->registers.state, 0, 0x34,
-                                  &command, sizeof(command));
+    return state->registers.write(state->registers.state, bir, offset,
+                                  data, length);
 }
 
 
@@ -165,7 +416,8 @@ int behavior_ethernet_create(const struct device_model *model,
 {
     struct ethernet_state *state;
 
-    if (model == NULL || out == NULL || model->class_code != 0x020000) {
+    if (model == NULL || out == NULL || model->class_code != 0x020000 ||
+        model->vendor_id != 0x8086 || model->device_id != 0x15b7) {
         return -EINVAL;
     }
     state = calloc(1, sizeof(*state));

--- a/vfio-user/src/behavior_static.c
+++ b/vfio-user/src/behavior_static.c
@@ -187,7 +187,8 @@ int behavior_create(const struct device_model *model,
     if (model->class_code == 0x0c0330) {
         return behavior_xhci_create(model, out, err, err_len);
     }
-    if (model->class_code == 0x020000) {
+    if (model->class_code == 0x020000 &&
+        model->vendor_id == 0x8086 && model->device_id == 0x15b7) {
         return behavior_ethernet_create(model, out, err, err_len);
     }
     return behavior_static_create(model, out, err, err_len);

--- a/vfio-user/tests/fuzz_behavior.c
+++ b/vfio-user/tests/fuzz_behavior.c
@@ -82,10 +82,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         nvme->write(nvme->state, 0, 0x1000, &value, 4);
     } else {
         uint64_t ring = 0x3000;
-        ethernet->write(ethernet->state, 0, 0x280, &ring, 4);
-        ethernet->write(ethernet->state, 0, 0x380, &ring, 4);
-        ethernet->write(ethernet->state, 0, 0x288, &value, 4);
-        ethernet->write(ethernet->state, 0, 0x388, &value, 4);
+        ethernet->write(ethernet->state, 0, 0x2800, &ring, 4);
+        ethernet->write(ethernet->state, 0, 0x3800, &ring, 4);
+        ethernet->write(ethernet->state, 0, 0x2808, &value, 4);
+        ethernet->write(ethernet->state, 0, 0x3808, &value, 4);
         ethernet->write(ethernet->state, 0, 0x3818, &value, 4);
     }
 

--- a/vfio-user/tests/test_behavior_storage.c
+++ b/vfio-user/tests/test_behavior_storage.c
@@ -39,6 +39,20 @@ static int ethernet_irq(void *opaque, unsigned vector)
     return 0;
 }
 
+static uint16_t ethernet_test_checksum(const uint8_t *data, size_t length)
+{
+    uint32_t sum = 0;
+
+    while (length > 1) {
+        sum += ((uint16_t)data[0] << 8) | data[1];
+        data += 2;
+        length -= 2;
+    }
+    while ((sum >> 16) != 0)
+        sum = (sum & 0xffffu) + (sum >> 16);
+    return (uint16_t)sum;
+}
+
 
 static uint32_t read32(struct device_behavior *behavior, uint64_t offset)
 {
@@ -108,16 +122,21 @@ static void ethernet_link_status_and_reset(void **state)
     assert_int_equal(device_model_load("../tests/cocotb/out_ethernet", &model,
                                       err, sizeof(err)), 0);
     assert_int_equal(behavior_ethernet_create(model, &behavior, err, sizeof(err)), 0);
-    assert_int_equal(behavior.read(behavior.state, 0, 0x6c, &value, 4), 4);
-    assert_int_equal(value, 0x3010);
+    assert_int_equal(behavior.reset(behavior.state), 0);
+    assert_int_equal(behavior.read(behavior.state, 0, 0x08, &value, 4), 4);
+    assert_int_equal(value, 0x80080783);
     command = (1u << 26) | (1u << 21);
     assert_int_equal(behavior.write(behavior.state, 0, 0x20, &command, 4), 4);
     assert_int_equal(behavior.read(behavior.state, 0, 0x20, &value, 4), 4);
     assert_true((value & 0x10000000u) != 0);
-    command = 0x10000000;
-    assert_int_equal(behavior.write(behavior.state, 0, 0x34, &command, 4), 4);
-    assert_int_equal(behavior.read(behavior.state, 0, 0x34, &value, 4), 4);
-    assert_int_equal(value, 0x0c000000);
+    command = 1u << 7;
+    assert_int_equal(behavior.write(behavior.state, 0, 0x00d0, &command, 4), 4);
+    assert_int_equal(behavior.write(behavior.state, 0, 0x00c8, &command, 4), 4);
+    assert_int_equal(behavior.reset(behavior.state), 0);
+    assert_int_equal(behavior.read(behavior.state, 0, 0x00c0, &value, 4), 4);
+    assert_int_equal(value, 0);
+    assert_int_equal(behavior.read(behavior.state, 0, 0x00d0, &value, 4), 4);
+    assert_int_equal(value, 0);
     behavior.destroy(behavior.state);
     device_model_free(model);
 }
@@ -136,6 +155,7 @@ static void ethernet_descriptor_loopback(void **state)
     uint32_t value;
     uint8_t tx_desc[16] = {0};
     uint8_t rx_desc[16] = {0};
+    uint16_t received_len;
     uint64_t tx_buffer = 0x3000;
     uint64_t rx_buffer = 0x4000;
     uint16_t packet_len = 4;
@@ -145,15 +165,19 @@ static void ethernet_descriptor_loopback(void **state)
     assert_int_equal(behavior_ethernet_create(model, &behavior, err, sizeof(err)), 0);
     assert_int_equal(behavior.bind_host(behavior.state, &ops), 0);
     base = 0x1000;
-    assert_int_equal(behavior.write(behavior.state, 0, 0x0280, &base, 4), 4);
+    assert_int_equal(behavior.write(behavior.state, 0, 0x2800, &base, 4), 4);
     base = 0x2000;
-    assert_int_equal(behavior.write(behavior.state, 0, 0x0380, &base, 4), 4);
-    value = 16;
-    assert_int_equal(behavior.write(behavior.state, 0, 0x0288, &value, 4), 4);
-    assert_int_equal(behavior.write(behavior.state, 0, 0x0388, &value, 4), 4);
+    assert_int_equal(behavior.write(behavior.state, 0, 0x3800, &base, 4), 4);
+    value = 128;
+    assert_int_equal(behavior.write(behavior.state, 0, 0x2808, &value, 4), 4);
+    assert_int_equal(behavior.write(behavior.state, 0, 0x3808, &value, 4), 4);
     memcpy(tx_desc, &tx_buffer, sizeof(tx_buffer));
     memcpy(tx_desc + 8, &packet_len, sizeof(packet_len));
+    tx_desc[11] = 0x02;
+    tx_desc[13] = 0xa5;
     memcpy(rx_desc, &rx_buffer, sizeof(rx_buffer));
+    rx_desc[10] = 0x5a;
+    rx_desc[13] = 0xa5;
     memcpy(host.memory + 0x2000, tx_desc, sizeof(tx_desc));
     memcpy(host.memory + 0x1000, rx_desc, sizeof(rx_desc));
     memcpy(host.memory + 0x3000, "PING", 4);
@@ -161,10 +185,89 @@ static void ethernet_descriptor_loopback(void **state)
     assert_int_equal(behavior.write(behavior.state, 0, 0x00d0, &value, 4), 4);
     value = 1;
     assert_int_equal(behavior.write(behavior.state, 0, 0x3818, &value, 4), 4);
+    assert_int_equal(behavior.write(behavior.state, 0, 0x2818, &value, 4), 4);
     assert_memory_equal(host.memory + 0x4000, "PING", 4);
+    memcpy(tx_desc, host.memory + 0x2000, sizeof(tx_desc));
+    memcpy(rx_desc, host.memory + 0x1000, sizeof(rx_desc));
+    assert_true((tx_desc[11] & 0x02) != 0);
+    assert_int_equal(tx_desc[12] & 0x01, 1);
+    assert_int_equal(tx_desc[13], 0xa5);
+    assert_int_equal(rx_desc[10], 0x5a);
+    assert_int_equal(rx_desc[13], 0xa5);
+    memcpy(&received_len, rx_desc + 8, sizeof(received_len));
+    assert_int_equal(received_len, packet_len);
+    assert_int_equal(rx_desc[12], 0x03);
     assert_int_equal(host.irqs, 1);
     assert_int_equal(behavior.read(behavior.state, 0, 0x2818, &value, 4), 4);
+    assert_int_equal(value, 1);
+    assert_int_equal(behavior.read(behavior.state, 0, 0x2810, &value, 4), 4);
+    assert_int_equal(value, 1);
+    assert_int_equal(behavior.read(behavior.state, 0, 0x00c0, &value, 4), 4);
+    assert_int_equal(value, 0x81);
+    assert_int_equal(behavior.read(behavior.state, 0, 0x00c0, &value, 4), 4);
     assert_int_equal(value, 0);
+    behavior.destroy(behavior.state);
+    device_model_free(model);
+}
+
+static void ethernet_injects_fake_arp(void **state)
+{
+    struct device_model *model = NULL;
+    struct device_behavior behavior = {0};
+    struct ethernet_host host = {0};
+    struct behavior_host_ops ops = {
+        .opaque = &host, .dma_read = ethernet_dma_read,
+        .dma_write = ethernet_dma_write, .irq = ethernet_irq,
+    };
+    char err[256] = {0};
+    uint32_t value;
+    uint32_t base;
+    uint8_t rx_desc[16] = {0};
+    uint64_t rx_buffer = 0x5000;
+    uint16_t packet_len;
+
+    (void)state;
+    assert_int_equal(device_model_load("../tests/cocotb/out_ethernet", &model,
+                                      err, sizeof(err)), 0);
+    assert_int_equal(behavior_ethernet_create(model, &behavior, err, sizeof(err)), 0);
+    assert_int_equal(behavior.bind_host(behavior.state, &ops), 0);
+    base = 0x1000;
+    assert_int_equal(behavior.write(behavior.state, 0, 0x2800, &base, 4), 4);
+    base = 0x2000;
+    assert_int_equal(behavior.write(behavior.state, 0, 0x3800, &base, 4), 4);
+    value = 128;
+    assert_int_equal(behavior.write(behavior.state, 0, 0x2808, &value, 4), 4);
+    assert_int_equal(behavior.write(behavior.state, 0, 0x3808, &value, 4), 4);
+    memcpy(rx_desc, &rx_buffer, sizeof(rx_buffer));
+    memcpy(host.memory + 0x1000, rx_desc, sizeof(rx_desc));
+    value = 1u << 7;
+    assert_int_equal(behavior.write(behavior.state, 0, 0x00d0, &value, 4), 4);
+    value = 1;
+    assert_int_equal(behavior.write(behavior.state, 0, 0x2818, &value, 4), 4);
+    assert_memory_equal(host.memory + 0x5000,
+                        "\xff\xff\xff\xff\xff\xff\x02\x50\x43\x49\x4c\x45\x08\x06", 14);
+    memcpy(rx_desc, host.memory + 0x1000, sizeof(rx_desc));
+    memcpy(&packet_len, rx_desc + 8, sizeof(packet_len));
+    assert_int_equal(packet_len, 60);
+    assert_int_equal(rx_desc[12], 0x03);
+    assert_int_equal(host.irqs, 1);
+    assert_int_equal(behavior.read(behavior.state, 0, 0x2810, &value, 4), 4);
+    assert_int_equal(value, 1);
+    memcpy(&rx_buffer, &(uint64_t){0x5010}, sizeof(rx_buffer));
+    memcpy(host.memory + 0x1010, &rx_buffer, sizeof(rx_buffer));
+    value = 2;
+    assert_int_equal(behavior.write(behavior.state, 0, 0x2818, &value, 4), 4);
+    assert_memory_equal(host.memory + 0x5010,
+                        "\x02\x50\x43\x49\x4c\x46\x02\x50\x43\x49\x4c\x45\x08\x00", 14);
+    assert_int_equal(ethernet_test_checksum(host.memory + 0x5010 + 14, 20), 0xffff);
+    assert_int_equal(ethernet_test_checksum(host.memory + 0x5010 + 34, 12), 0xffff);
+    memcpy(rx_desc, host.memory + 0x1010, sizeof(rx_desc));
+    memcpy(&packet_len, rx_desc + 8, sizeof(packet_len));
+    assert_int_equal(packet_len, 60);
+    assert_int_equal(rx_desc[12], 0x03);
+    assert_int_equal(host.irqs, 2);
+    assert_int_equal(behavior.read(behavior.state, 0, 0x2810, &value, 4), 4);
+    assert_int_equal(value, 2);
     behavior.destroy(behavior.state);
     device_model_free(model);
 }
@@ -177,6 +280,7 @@ int main(void)
         cmocka_unit_test(xhci_reset_and_run_state),
         cmocka_unit_test(ethernet_link_status_and_reset),
         cmocka_unit_test(ethernet_descriptor_loopback),
+        cmocka_unit_test(ethernet_injects_fake_arp),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
## Summary

This draft adds a family-aware early-access Intel Ethernet DMA path while making donor collection safer and generated capability claims explicit.

- Add an Intel I219/e1000e-compatible RX/TX descriptor engine for the tested `8086:15b7` donor.
- Gate Intel DMA by exact family, BAR placement, and interrupt compatibility; MSI-X donors and incompatible Ethernet devices remain on safe fallback paths.
- Correct Intel ring offsets, alignment, descriptor ownership, 64-bit bases, DMA error handling, and ICR/ICS/IMS/IMC behavior.
- Keep Realtek-specific register behavior separate from Intel descriptor semantics.
- Add matching generated HDL, cocotb coverage, and vfio-user C behavior.
- Add `emulation_report.json` with explicit `identity`, `registers`, `behavior`, and `dma` support levels plus limitations.
- Require exact NVMe (`01:08:02`) and xHCI (`0c:03:30`) programming interfaces before selecting specialized models.
- Make live donor collection read-only by default. Driver binding, PM/command changes, resets, and destructive BAR profiling require explicit opt-in.
- Strictly bound and validate donor JSON, BAR/profile topology, MSI-X metadata, and raw Identify payloads.

## Scope and support level

This does **not** claim universal or complete donor emulation.

- Intel Ethernet descriptor DMA is currently limited to the tested `8086:15b7` family and BAR0 model.
- Ethernet MSI-X is intentionally disabled until vector/PBA delivery is implemented and verified.
- Realtek Ethernet remains register behavior without a Realtek descriptor engine.
- xHCI, HDA, AHCI, Wi-Fi, GPU, and Thunderbolt retain explicitly reported limitations.
- Unknown devices use identity/static fallback rather than guessed protocol behavior.

## Validation

Passed locally under WSL/Linux:

- [x] `go test -race -count=1 ./...`
- [x] `go vet ./...`
- [x] `go build -trimpath ./cmd/pcileechgen`
- [x] Generated all ten donor fixtures and verified every manifest
- [x] Full generated HDL lint: **104 passed, 66 documented skips, 0 failures**
- [x] Full vfio-user C suite with `-Wall -Wextra -Werror -fsanitize=address,undefined`
- [x] `git diff --check`
- [x] Added-line scan for hardcoded secrets, eval/exec, and shell injection

## Known blocker

Ethernet cocotb currently reports **6/7 passed**. Explicit JUnit parsing catches the remaining failure:

```text
test_eth_dma_fake_rx_and_tx_loopback
assert host[0x5000] == 0xffffffff
```

The PR is therefore opened as a **draft** and is not presented as merge-ready.

## Additional audit follow-ups

Independent audits identified further NVMe/xHCI hardening that should be resolved before this leaves draft, including:

- Complete NVMe DMA-read error propagation into the responder.
- Enforce completion-queue ownership before command execution.
- Close PRP crossing-page and PRP-list traversal gaps.
- Correct per-vector MSI-X mask/pending behavior.
- Gate NVMe queues and DMA on a valid enabled controller.
- Align advertised NVMe/xHCI capabilities and reset semantics with implemented behavior.
- Add explicit cocotb JUnit failure enforcement to CI.

## Commits

1. `fix(donor): make live collection safe by default`
2. `feat(ethernet): add gated Intel descriptor DMA emulation`
