### PR TITLE
fix(nvme): validate admin PRP chains

### DIFF
--- a/internal/firmware/svgen/nvme_admin_behavior_test.go
+++ b/internal/firmware/svgen/nvme_admin_behavior_test.go
@@ -292,28 +292,63 @@ initial begin
     if (dbg_state !== 8'd0) $fatal(22, "responder not idle after CC.EN handshake");
     @(negedge clk);
 
-    poke_sqe(16'h400, 8'h0A, 32'h0,
+    // Unsupported log pages retain INVALID_FIELD precedence even when the
+    // unused PRP fields are zero.
+    poke_sqe(16'h400, 8'h02, 32'h0,
              32'h0, 32'h0, 32'h0, 32'h0,
              32'h000000FF, 32'h0, 32'h0);
     ring_sq(16'd0, 16'd1);
     wait_cqe(15'h0002);
 
+    // A 4 KiB Identify buffer with only four bytes left in PRP1 requires PRP2.
+    // Reject a missing PRP2 before it turns the remaining payload into writes
+    // at physical address zero.
+    host_mem[16'h0000] = 32'hDEADBEEF;
+    host_mem[16'h0BFF] = 32'hDEADBEEF;
     poke_sqe(16'h410, 8'h06, 32'h0,
-             32'h00005000, 32'h0, 32'h0, 32'h0,
+             32'h00002FFC, 32'h0, 32'h0, 32'h0,
              32'h00000001, 32'h0, 32'h0);
     ring_sq(16'd0, 16'd2);
-    wait_cqe(15'h0000);
+    wait_cqe(15'h0013);
+    if ((host_mem[16'h0000] !== 32'hDEADBEEF) ||
+        (host_mem[16'h0BFF] !== 32'hDEADBEEF))
+        $fatal(55, "invalid Identify PRPs performed a DMA write");
 
-    poke_sqe(16'h420, 8'h05, 32'h0,
-             32'h00004000, 32'h0, 32'h0, 32'h0,
-             32'h00010001, 32'h00000001, 32'h0);
+    // Model an allocator return near the end of a page and prove the Identify
+    // payload continues at PRP2 rather than linearly corrupting the next page.
+    host_mem[16'h1800] = 32'hDEADBEEF;
+    host_mem[16'h1C00] = 32'hCAFEBABE;
+    poke_sqe(16'h420, 8'h06, 32'h0,
+             32'h00005F00, 32'h0, 32'h00007000, 32'h0,
+             32'h00000001, 32'h0, 32'h0);
     ring_sq(16'd0, 16'd3);
     wait_cqe(15'h0000);
+    if (host_mem[16'h1800] !== 32'hDEADBEEF)
+        $fatal(56, "Identify payload ignored PRP2 at the page boundary");
+    if (host_mem[16'h1C00] !== 32'h07030003)
+        $fatal(57, "Identify payload did not continue at PRP2");
 
-    poke_sqe(16'h430, 8'h01, 32'h0,
+    host_mem[16'h0000] = 32'hDEADBEEF;
+    host_mem[16'h0BFF] = 32'hDEADBEEF;
+    poke_sqe(16'h430, 8'h02, 32'h0,
+             32'h00002FFC, 32'h0, 32'h0, 32'h0,
+             32'h03FF0002, 32'h0, 32'h0);
+    ring_sq(16'd0, 16'd4);
+    wait_cqe(15'h0013);
+    if ((host_mem[16'h0000] !== 32'hDEADBEEF) ||
+        (host_mem[16'h0BFF] !== 32'hDEADBEEF))
+        $fatal(58, "invalid Get Log PRPs performed a DMA write");
+
+    poke_sqe(16'h440, 8'h05, 32'h0,
+             32'h00004000, 32'h0, 32'h0, 32'h0,
+             32'h00010001, 32'h00000001, 32'h0);
+    ring_sq(16'd0, 16'd5);
+    wait_cqe(15'h0000);
+
+    poke_sqe(16'h450, 8'h01, 32'h0,
              32'h00003000, 32'h0, 32'h0, 32'h0,
              32'h00010001, 32'h00010001, 32'h0);
-    ring_sq(16'd0, 16'd4);
+    ring_sq(16'd0, 16'd6);
     wait_cqe(15'h0000);
 
     poke_sqe(16'hC00, 8'h02, 32'h00000001,
@@ -322,10 +357,10 @@ initial begin
     ring_sq(16'd1, 16'd1);
     wait_cqe(15'h0002);
 
-    poke_sqe(16'h440, 8'h02, 32'h0,
+    poke_sqe(16'h460, 8'h02, 32'h0,
              32'h00006000, 32'h0, 32'h0, 32'h0,
              32'h007F0002, 32'h0, 32'h0);
-    ring_sq(16'd0, 16'd5);
+    ring_sq(16'd0, 16'd7);
     wait_cqe(15'h0000);
     #1;
     if (host_mem[16'h1800][31:24] !== 8'h64) $fatal(5, "smart log spare byte");
@@ -333,11 +368,11 @@ initial begin
     if (host_mem[16'h1801] !== 32'h0000000A) $fatal(7, "smart log spare threshold");
     if (host_mem[16'h1824] !== 32'h00000003) $fatal(8, "smart log unsafe shutdowns");
 
-    poke_sqe(16'h450, 8'h0C, 32'h0,
+    poke_sqe(16'h470, 8'h0C, 32'h0,
              32'h0, 32'h0, 32'h0, 32'h0,
              32'h0, 32'h0, 32'h0);
     cqe_snapshot = cqe_count;
-    ring_sq(16'd0, 16'd6);
+    ring_sq(16'd0, 16'd8);
     repeat (2000) @(posedge clk);
     if (cqe_count !== cqe_snapshot) $fatal(8, "AER posted a synchronous CQE");
     #1;
@@ -361,12 +396,12 @@ initial begin
 
     // A normal shutdown requested during an active admin command must drain
     // that command and its CQE, then wait for a real backend flush terminal.
-    poke_sqe(16'h460, 8'h0A, 32'h0,
+    poke_sqe(16'h480, 8'h0A, 32'h0,
              32'h0, 32'h0, 32'h0, 32'h0,
              32'h000000FF, 32'h0, 32'h0);
     cqe_snapshot = cqe_count;
     flush_snapshot = disk_flush_count;
-    ring_sq(16'd0, 16'd7);
+    ring_sq(16'd0, 16'd9);
     wait_cycles = 0;
     while (dbg_state == 8'd0 && wait_cycles < 100) begin
         @(posedge clk);
@@ -377,9 +412,9 @@ initial begin
     cc_shn = 2'b01;
     #1;
     if (shutdown_complete) $fatal(31, "normal shutdown completed before command drain");
-    ring_sq(16'd0, 16'd8);
+    ring_sq(16'd0, 16'd10);
     #1;
-    if (responder.sq_tail !== 16'd7)
+    if (responder.sq_tail !== 16'd9)
         $fatal(46, "normal shutdown accepted a new SQ submission");
     wait_cycles = 0;
     while (cqe_count == cqe_snapshot && wait_cycles < 20000) begin

--- a/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
+++ b/internal/firmware/svgen/templates/nvme_admin_responder.sv.tmpl
@@ -267,6 +267,26 @@ module pcileech_nvme_admin_responder #(
     wire        cmd_mdts_ok = (cmd_total_dw <= MAX_XFER_DW);
     wire [127:0] nvme_disk_bytes = {55'h0, NVME_ADVERTISED_LBAS, 9'h000};
     wire [10:0] cmd_log_last_dw = (cmd_cdw10[31:16] > 16'd1023) ? 11'd1023 : cmd_cdw10[26:16];
+    wire [12:0] cmd_log_bytes = ({2'b00, cmd_log_last_dw} + 13'd1) << 2;
+
+    function admin_prps_valid;
+        input [12:0] transfer_bytes;
+        input [63:0] prp1;
+        input [63:0] prp2;
+        reg [12:0] first_span;
+        begin
+            first_span = 13'd4096 - {1'b0, prp1[11:0]};
+            admin_prps_valid =
+                (prp1 != 64'h0000000000000000) &&
+                (prp1[1:0] == 2'b00) &&
+                ((transfer_bytes <= first_span) ||
+                 ((prp2 != 64'h0000000000000000) &&
+                  (prp2[11:0] == 12'h000)));
+        end
+    endfunction
+
+    wire admin_4k_prps_valid = admin_prps_valid(13'd4096, cmd_prp1, cmd_prp2);
+    wire admin_log_prps_valid = admin_prps_valid(cmd_log_bytes, cmd_prp1, cmd_prp2);
 
     function [63:0] prp_data_addr;
         input [23:0] dw_index;
@@ -367,6 +387,19 @@ module pcileech_nvme_admin_responder #(
     localparam [7:0] LOG_PAGE_SMART     = 8'h02;
     localparam [7:0] LOG_PAGE_FW_SLOT   = 8'h03;
     localparam [7:0] LOG_PAGE_VENDOR    = 8'hC0;
+    wire cmd_log_page_supported =
+        (cmd_cdw10[7:0] == LOG_PAGE_SUPPORTED) ||
+        (cmd_cdw10[7:0] == LOG_PAGE_ERROR) ||
+        (cmd_cdw10[7:0] == LOG_PAGE_SMART) ||
+        (cmd_cdw10[7:0] == LOG_PAGE_FW_SLOT) ||
+        (cmd_cdw10[7:0] == LOG_PAGE_VENDOR);
+    wire identify_cns_supported =
+        (identify_cns == 8'h00) || (identify_cns == 8'h11) ||
+        (identify_cns == 8'h01) || (identify_cns == 8'h02) ||
+        (identify_cns == 8'h10) || (identify_cns == 8'h03);
+    wire identify_nsid_valid_for_cns =
+        ((identify_cns == 8'h00) || (identify_cns == 8'h11) ||
+         (identify_cns == 8'h03)) ? cmd_nsid_selects_ns1 : 1'b1;
 
     reg [63:0] stat_data_units_read;
     reg [63:0] stat_data_units_written;
@@ -1318,20 +1351,25 @@ module pcileech_nvme_admin_responder #(
 
 	                                8'h02: begin
                                     timing_class <= TIMING_GET_LOG;
+                                    if (cmd_log_page_supported && !admin_log_prps_valid) begin
+                                        cqe_status <= NVME_SC_PRP_OFFSET_INVALID;
+                                        state <= S_BUILD_CQE;
+                                    end else begin
 	                                    case (cmd_cdw10[7:0])
-                                        LOG_PAGE_SUPPORTED,
-                                        LOG_PAGE_ERROR,
-                                        LOG_PAGE_SMART,
-                                        LOG_PAGE_FW_SLOT,
-                                        LOG_PAGE_VENDOR: begin
-                                            data_dw_cnt <= 11'h0;
-                                            state <= S_EXEC_LOGPAGE;
-                                        end
-                                        default: begin
-                                            cqe_status <= NVME_SC_INVALID_FIELD;
-                                            state <= S_BUILD_CQE;
-                                        end
-                                    endcase
+                                            LOG_PAGE_SUPPORTED,
+                                            LOG_PAGE_ERROR,
+                                            LOG_PAGE_SMART,
+                                            LOG_PAGE_FW_SLOT,
+                                            LOG_PAGE_VENDOR: begin
+                                                data_dw_cnt <= 11'h0;
+                                                state <= S_EXEC_LOGPAGE;
+                                            end
+                                            default: begin
+                                                cqe_status <= NVME_SC_INVALID_FIELD;
+                                                state <= S_BUILD_CQE;
+                                            end
+                                        endcase
+                                    end
                                 end
 
                                 8'h04: begin
@@ -1365,7 +1403,12 @@ module pcileech_nvme_admin_responder #(
 
 	                                8'h06: begin
                                     timing_class <= TIMING_IDENTIFY;
-		                                    case (identify_cns)
+                                    if (identify_cns_supported && identify_nsid_valid_for_cns &&
+                                        !admin_4k_prps_valid) begin
+                                        cqe_status <= NVME_SC_PRP_OFFSET_INVALID;
+                                        state <= S_BUILD_CQE;
+                                    end else begin
+		                                case (identify_cns)
 	                                        8'h00,
 	                                        8'h11: begin
 	                                            if (cmd_nsid_selects_ns1) begin
@@ -1403,6 +1446,7 @@ module pcileech_nvme_admin_responder #(
 	                                            state <= S_BUILD_CQE;
 	                                        end
 	                                    endcase
+                                    end
                                 end
 
                                 8'h08: begin


### PR DESCRIPTION
## Summary
- validate PRP chains before Identify and Get Log DMA
- reject missing or misaligned page-crossing PRP2 with `NVME_SC_PRP_OFFSET_INVALID`
- preserve existing INVALID_FIELD and INVALID_NS precedence for malformed commands
- add behavioral coverage for allocator returns near a page boundary, valid PRP1-to-PRP2 continuation, and zero-write rejection

## Test plan
- `go test ./internal/firmware/svgen -run "TestNVMeAdminBehaviorScenarios|TestGenerateNVMeResponderSV" -count=1`
- `go test ./... -skip "^TestGenerateBarControllerSV_NVMeMSIWithoutMSIX$" -count=1`
- independent diff review: no blockers

## Baseline note
The excluded `TestGenerateBarControllerSV_NVMeMSIWithoutMSIX` failure is already present on upstream `main`; it reports a missing generated-text end marker and is unrelated to this PR.