### PR TITLE
fix(vfio): block unsafe donor binding

### DIFF
--- a/cmd/pcileechgen/check.go
+++ b/cmd/pcileechgen/check.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/sercanarga/pcileechgen/internal/board"
@@ -52,6 +51,7 @@ type checker struct {
 func (c *checker) run() error {
 	fmt.Fprintf(c.w, "Checking device %s...\n\n", color.Bold(c.bdf.String()))
 
+	c.checkEnvironment()
 	c.checkDeviceInfo()
 	c.checkConfigSpace()
 	c.checkVFIO()
@@ -69,6 +69,18 @@ func (c *checker) run() error {
 		fmt.Fprintln(c.w, color.Failf("%d issue(s) found - see above for details", c.issues))
 	}
 	return nil
+}
+
+func (c *checker) checkEnvironment() {
+	live, reason, err := vfio.CheckLiveEnvironment()
+	if err != nil {
+		fmt.Fprintln(c.w, color.Warnf("Host environment: unknown (%v)", err))
+		return
+	}
+	if live {
+		fmt.Fprintln(c.w, color.Failf("Host environment: live/USB Linux detected (%s); use an installed Linux system", reason))
+		c.issues++
+	}
 }
 
 func (c *checker) checkDeviceInfo() {
@@ -107,6 +119,13 @@ func (c *checker) checkVFIO() {
 	} else {
 		fmt.Fprintln(c.w, color.OK("VFIO modules loaded"))
 	}
+
+	if err := vfio.CheckMountedDeviceSafe(c.bdf.String()); err != nil {
+		fmt.Fprintln(c.w, color.Failf("Mounted-device safety: %v", err))
+		c.issues++
+	} else {
+		fmt.Fprintln(c.w, color.OK("Mounted-device safety check passed"))
+	}
 }
 
 func (c *checker) checkIOMMUGroup() {
@@ -118,23 +137,20 @@ func (c *checker) checkIOMMUGroup() {
 	fmt.Fprintln(c.w, color.Okf("IOMMU group: %d", group))
 
 	groupDevs, err := vfio.ListIOMMUGroupDevices(c.bdf.String())
-	if err != nil || len(groupDevs) <= 1 {
-		if err == nil {
-			fmt.Fprintln(c.w, color.OK("Device is alone in its IOMMU group"))
-		}
+	if err != nil {
+		fmt.Fprintln(c.w, color.Failf("IOMMU group devices: %v", err))
+		c.issues++
 		return
 	}
-
-	var others []string
-	for _, d := range groupDevs {
-		if d != c.bdf.String() {
-			others = append(others, d)
-		}
+	if err := vfio.CheckIOMMUGroupSafe(c.bdf.String()); err != nil {
+		fmt.Fprintln(c.w, color.Failf("IOMMU group safety: %v", err))
+		c.issues++
+		return
 	}
-	if len(others) > 0 {
-		fmt.Fprintln(c.w, color.Warnf("IOMMU group shared with %d device(s): %s",
-			len(others), strings.Join(others, ", ")))
-		fmt.Fprintln(c.w, color.Dim("  All devices in the group must be unbound or on vfio-pci"))
+	if len(groupDevs) <= 1 {
+		fmt.Fprintln(c.w, color.OK("Device is alone in its IOMMU group"))
+	} else {
+		fmt.Fprintln(c.w, color.Okf("All %d IOMMU group peer(s) are unbound or on vfio-pci", len(groupDevs)-1))
 	}
 }
 

--- a/internal/donor/vfio/diagnostics.go
+++ b/internal/donor/vfio/diagnostics.go
@@ -4,7 +4,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
+)
+
+var (
+	initMountNamespacePath = "/proc/1/ns/mnt"
+	mountInfoPath          = "/proc/self/mountinfo"
+	procCmdlinePath        = "/proc/cmdline"
+	selfMountNamespacePath = "/proc/self/ns/mnt"
+	sysDevBlockBase        = "/sys/dev/block"
 )
 
 type BARStatus struct {
@@ -37,6 +47,311 @@ func ListIOMMUGroupDevices(bdf string) ([]string, error) {
 		devices = append(devices, e.Name())
 	}
 	return devices, nil
+}
+
+// CheckIOMMUGroupSafe rejects groups with peers still owned by native drivers.
+func CheckIOMMUGroupSafe(bdf string) error {
+	devices, err := ListIOMMUGroupDevices(bdf)
+	if err != nil {
+		return fmt.Errorf("cannot verify IOMMU group for %s: %w", bdf, err)
+	}
+
+	var conflicts []string
+	for _, device := range devices {
+		if device == bdf {
+			continue
+		}
+		driver, err := checkedBoundDriver(device)
+		if err != nil {
+			return err
+		}
+		if driver != "" && driver != "vfio-pci" {
+			conflicts = append(conflicts, fmt.Sprintf("%s (%s)", device, driver))
+		}
+	}
+	if len(conflicts) == 0 {
+		return nil
+	}
+	sort.Strings(conflicts)
+	return fmt.Errorf("IOMMU group contains device(s) on native drivers: %s; bind the whole group to vfio-pci or isolate the donor",
+		strings.Join(conflicts, ", "))
+}
+
+func checkedBoundDriver(bdf string) (string, error) {
+	target, err := os.Readlink(filepath.Join(sysfsBase, bdf, "driver"))
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("cannot read driver for IOMMU peer %s: %w", bdf, err)
+	}
+	return filepath.Base(target), nil
+}
+
+// CheckSafeToBind rejects a PCI device that backs a mounted filesystem or has
+// IOMMU-group peers still owned by native drivers.
+func CheckSafeToBind(bdf string) error {
+	if err := CheckMountedDeviceSafe(bdf); err != nil {
+		return err
+	}
+	return CheckIOMMUGroupSafe(bdf)
+}
+
+// CheckMountedDeviceSafe rejects a PCI device that backs a mounted filesystem.
+func CheckMountedDeviceSafe(bdf string) error {
+	if err := checkInitialPIDNamespace(); err != nil {
+		return err
+	}
+	if err := checkInitialMountNamespace(selfMountNamespacePath, initMountNamespacePath); err != nil {
+		return err
+	}
+
+	target, err := filepath.EvalSymlinks(filepath.Join(sysfsBase, bdf))
+	if err != nil {
+		return fmt.Errorf("cannot resolve PCI device %s: %w", bdf, err)
+	}
+
+	data, err := os.ReadFile(mountInfoPath)
+	if err != nil {
+		return fmt.Errorf("cannot verify mounted filesystems: %w", err)
+	}
+	rootSeen := false
+	for lineNo, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			return fmt.Errorf("cannot parse mountinfo line %d", lineNo+1)
+		}
+		major, _, err := parseDeviceNumber(fields[2])
+		if err != nil {
+			return fmt.Errorf("cannot parse mountinfo line %d: %w", lineNo+1, err)
+		}
+		mountPoint := unescapeMountInfo(fields[4])
+		if mountPoint == "/" {
+			rootSeen = true
+		}
+		if major == 0 {
+			fsType := mountFilesystemType(fields)
+			if isKernelPseudoFilesystem(fsType) {
+				continue
+			}
+			return fmt.Errorf("cannot verify mount %s: filesystem %q uses major 0 without block-device topology; refusing VFIO bind",
+				mountPoint, fsType)
+		}
+		backed, err := blockBackedByTarget(filepath.Join(sysDevBlockBase, fields[2]), target, map[string]bool{})
+		if err != nil {
+			return fmt.Errorf("cannot inspect mounted device %s at %s: %w", fields[2], mountPoint, err)
+		}
+		if backed {
+			return fmt.Errorf("PCI device %s backs a filesystem mounted at %s; refusing to unbind mounted storage",
+				bdf, mountPoint)
+		}
+	}
+	if !rootSeen {
+		return fmt.Errorf("cannot verify mounted filesystems: root mount is absent from %s", mountInfoPath)
+	}
+	return nil
+}
+
+func checkInitialMountNamespace(selfPath, initPath string) error {
+	self, err := os.Readlink(selfPath)
+	if err != nil {
+		return fmt.Errorf("cannot verify current mount namespace: %w", err)
+	}
+	init, err := os.Readlink(initPath)
+	if err != nil {
+		return fmt.Errorf("cannot verify initial mount namespace: %w", err)
+	}
+	if self != init {
+		return fmt.Errorf("current process is in a private mount namespace; refusing VFIO bind against incomplete host mount data")
+	}
+	return nil
+}
+
+func mountFilesystemType(fields []string) string {
+	for i, field := range fields {
+		if field == "-" && i+1 < len(fields) {
+			return fields[i+1]
+		}
+	}
+	return ""
+}
+func isKernelPseudoFilesystem(fsType string) bool {
+	switch fsType {
+	case "autofs", "binfmt_misc", "bpf", "cgroup", "cgroup2", "configfs",
+		"debugfs", "devpts", "devtmpfs", "efivarfs", "fusectl", "hugetlbfs",
+		"mqueue", "nsfs", "proc", "pstore", "ramfs", "rpc_pipefs", "securityfs",
+		"selinuxfs", "sysfs", "tmpfs", "tracefs":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseDeviceNumber(value string) (int, int, error) {
+	majorText, minorText, ok := strings.Cut(value, ":")
+	if !ok {
+		return 0, 0, fmt.Errorf("invalid device number %q", value)
+	}
+	major, err := strconv.Atoi(majorText)
+	if err != nil || major < 0 {
+		return 0, 0, fmt.Errorf("invalid device number %q", value)
+	}
+	minor, err := strconv.Atoi(minorText)
+	if err != nil || minor < 0 {
+		return 0, 0, fmt.Errorf("invalid device number %q", value)
+	}
+	return major, minor, nil
+}
+
+func blockBackedByTarget(blockPath, target string, seen map[string]bool) (bool, error) {
+	resolved, err := filepath.EvalSymlinks(blockPath)
+	if err != nil {
+		return false, err
+	}
+	if seen[resolved] {
+		return false, nil
+	}
+	seen[resolved] = true
+
+	rel, err := filepath.Rel(target, resolved)
+	if err == nil && (rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))) {
+		return true, nil
+	}
+
+	if _, err := os.Stat(filepath.Join(resolved, "partition")); err == nil {
+		return blockBackedByTarget(filepath.Dir(resolved), target, seen)
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+
+	if subsystem, ok := nvmeSubsystemDir(resolved); ok {
+		multipath := filepath.Join(resolved, "multipath")
+		paths, err := os.ReadDir(multipath)
+		if err == nil && len(paths) > 0 {
+			return blockLinksBackedByTarget(multipath, paths, target, seen)
+		}
+		if err != nil && !os.IsNotExist(err) {
+			return false, fmt.Errorf("cannot resolve NVMe multipath head %s: %w", resolved, err)
+		}
+
+		entries, fallbackErr := os.ReadDir(subsystem)
+		if fallbackErr != nil {
+			return false, fmt.Errorf("cannot resolve NVMe multipath head %s: %w", resolved, fallbackErr)
+		}
+		var controllers []os.DirEntry
+		for _, entry := range entries {
+			if isNVMeControllerName(entry.Name()) {
+				controllers = append(controllers, entry)
+			}
+		}
+		if len(controllers) == 0 {
+			return false, fmt.Errorf("cannot resolve NVMe multipath head %s: no controller paths", resolved)
+		}
+		return blockLinksBackedByTarget(subsystem, controllers, target, seen)
+	}
+
+	slaves, err := os.ReadDir(filepath.Join(resolved, "slaves"))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	for _, slave := range slaves {
+		backed, err := blockBackedByTarget(filepath.Join(resolved, "slaves", slave.Name()), target, seen)
+		if err != nil {
+			return false, err
+		}
+		if backed {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func blockLinksBackedByTarget(dir string, entries []os.DirEntry, target string, seen map[string]bool) (bool, error) {
+	for _, entry := range entries {
+		link := filepath.Join(dir, entry.Name())
+		info, err := os.Lstat(link)
+		if err != nil {
+			return false, err
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return false, fmt.Errorf("block dependency entry is not a symlink: %s", link)
+		}
+		backed, err := blockBackedByTarget(link, target, seen)
+		if err != nil {
+			return false, err
+		}
+		if backed {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func isNVMeControllerName(name string) bool {
+	if !strings.HasPrefix(name, "nvme") {
+		return false
+	}
+	_, err := strconv.Atoi(strings.TrimPrefix(name, "nvme"))
+	return err == nil
+}
+
+func nvmeSubsystemDir(path string) (string, bool) {
+	for parent := filepath.Clean(path); ; parent = filepath.Dir(parent) {
+		if strings.HasPrefix(filepath.Base(parent), "nvme-subsys") {
+			return parent, true
+		}
+		next := filepath.Dir(parent)
+		if next == parent {
+			return "", false
+		}
+	}
+}
+
+func unescapeMountInfo(value string) string {
+	replacer := strings.NewReplacer(`\040`, " ", `\011`, "\t", `\134`, `\`)
+	return replacer.Replace(value)
+}
+
+// CheckLiveEnvironment detects common live-media boot markers without treating
+// container overlay filesystems as live USB installations.
+func CheckLiveEnvironment() (bool, string, error) {
+	cmdline, err := os.ReadFile(procCmdlinePath)
+	if err != nil {
+		return false, "", fmt.Errorf("cannot read kernel command line: %w", err)
+	}
+	for _, field := range strings.Fields(string(cmdline)) {
+		if field == "boot=casper" || field == "boot=live" {
+			return true, field, nil
+		}
+	}
+
+	data, err := os.ReadFile(mountInfoPath)
+	if err != nil {
+		return false, "", fmt.Errorf("cannot read mount information: %w", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 7 {
+			continue
+		}
+		mountPoint := unescapeMountInfo(fields[4])
+		if mountPoint != "/cdrom" && mountPoint != "/run/live/medium" {
+			continue
+		}
+		for i, field := range fields {
+			if field == "-" && i+1 < len(fields) &&
+				(fields[i+1] == "iso9660" || fields[i+1] == "squashfs") {
+				return true, fmt.Sprintf("%s mounted at %s", fields[i+1], mountPoint), nil
+			}
+		}
+	}
+	return false, "", nil
 }
 
 // CheckBARAccessibility tries to open each BAR resource file.

--- a/internal/donor/vfio/diagnostics_test.go
+++ b/internal/donor/vfio/diagnostics_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -24,6 +25,24 @@ func mkFakeDev(t *testing.T, base, bdf string) string {
 		t.Fatalf("mkdir %s: %v", devDir, err)
 	}
 	return devDir
+}
+
+func fakeInitialMountNamespace(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	self := filepath.Join(dir, "self")
+	init := filepath.Join(dir, "init")
+	if err := os.Symlink("mnt:[1]", self); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("mnt:[1]", init); err != nil {
+		t.Fatal(err)
+	}
+	oldSelf, oldInit := selfMountNamespacePath, initMountNamespacePath
+	selfMountNamespacePath, initMountNamespacePath = self, init
+	t.Cleanup(func() {
+		selfMountNamespacePath, initMountNamespacePath = oldSelf, oldInit
+	})
 }
 
 func symlinkDriver(t *testing.T, base, devDir, driver string) {
@@ -298,5 +317,445 @@ func TestRunDiagnostics_MissingPowerStateOmitsEntry(t *testing.T) {
 	results := RunDiagnostics(bdf)
 	if _, ok := findDiag(results, "Power State"); ok {
 		t.Error("Power State result should be omitted when power_state is unreadable")
+	}
+}
+
+func TestCheckIOMMUGroupSafe(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		peerDriver string
+		wantErr    bool
+	}{
+		{name: "alone"},
+		{name: "peer unbound"},
+		{name: "peer on vfio", peerDriver: "vfio-pci"},
+		{name: "peer on native driver", peerDriver: "nvme", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			SetSysfsBase(tmpDir)
+			defer ResetSysfsBase()
+
+			bdf := "0000:03:00.0"
+			devDir := mkFakeDev(t, tmpDir, bdf)
+			if tc.name == "alone" {
+				symlinkIOMMUGroup(t, tmpDir, devDir, 42)
+			} else {
+				peer := "0000:03:00.1"
+				peerDir := mkFakeDev(t, tmpDir, peer)
+				symlinkIOMMUGroup(t, tmpDir, devDir, 42, peer)
+				if tc.peerDriver != "" {
+					symlinkDriver(t, tmpDir, peerDir, tc.peerDriver)
+				}
+			}
+
+			err := CheckIOMMUGroupSafe(bdf)
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "0000:03:00.1") ||
+					!strings.Contains(err.Error(), "nvme") {
+					t.Fatalf("CheckIOMMUGroupSafe() = %v, want peer BDF and driver", err)
+				}
+			} else if err != nil {
+				t.Fatalf("CheckIOMMUGroupSafe() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestCheckIOMMUGroupSafeRejectsUnknownPeerDriverState(t *testing.T) {
+	tmpDir := t.TempDir()
+	SetSysfsBase(tmpDir)
+	defer ResetSysfsBase()
+
+	bdf := "0000:03:00.0"
+	devDir := mkFakeDev(t, tmpDir, bdf)
+	peer := "0000:03:00.1"
+	peerDir := mkFakeDev(t, tmpDir, peer)
+	symlinkIOMMUGroup(t, tmpDir, devDir, 42, peer)
+	if err := os.WriteFile(filepath.Join(peerDir, "driver"), []byte("not a symlink"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := CheckIOMMUGroupSafe(bdf)
+	if err == nil || !strings.Contains(err.Error(), peer) || !strings.Contains(err.Error(), "cannot read driver") {
+		t.Fatalf("CheckIOMMUGroupSafe() = %v, want fail-closed driver-state error", err)
+	}
+}
+
+func TestCheckSafeToBindRejectsMountedSystemDevice(t *testing.T) {
+	fakeInitialMountNamespace(t)
+	tmpDir := t.TempDir()
+	sysRoot := filepath.Join(tmpDir, "sys")
+	SetSysfsBase(filepath.Join(sysRoot, "bus", "pci", "devices"))
+	defer ResetSysfsBase()
+
+	oldMountInfo, oldDevBlock := mountInfoPath, sysDevBlockBase
+	mountInfoPath = filepath.Join(tmpDir, "mountinfo")
+	sysDevBlockBase = filepath.Join(sysRoot, "dev", "block")
+	defer func() {
+		mountInfoPath, sysDevBlockBase = oldMountInfo, oldDevBlock
+	}()
+
+	bdf := "0000:03:00.0"
+	devDir := mkFakeDev(t, sysfsBase, bdf)
+	symlinkIOMMUGroup(t, sysfsBase, devDir, 42)
+	blockDir := filepath.Join(devDir, "nvme", "nvme0", "nvme0n1")
+	if err := os.MkdirAll(blockDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sysDevBlockBase, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(blockDir, filepath.Join(sysDevBlockBase, "259:0")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mountInfoPath,
+		[]byte("36 25 259:0 / / rw,relatime - ext4 /dev/nvme0n1 rw\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := CheckSafeToBind(bdf)
+	if err == nil || !strings.Contains(err.Error(), "mounted at /") {
+		t.Fatalf("CheckSafeToBind() = %v, want mounted root rejection", err)
+	}
+}
+
+func TestCheckSafeToBindAllowsUnrelatedMountedDevice(t *testing.T) {
+	fakeInitialMountNamespace(t)
+	tmpDir := t.TempDir()
+	sysRoot := filepath.Join(tmpDir, "sys")
+	SetSysfsBase(filepath.Join(sysRoot, "bus", "pci", "devices"))
+	defer ResetSysfsBase()
+
+	oldMountInfo, oldDevBlock := mountInfoPath, sysDevBlockBase
+	mountInfoPath = filepath.Join(tmpDir, "mountinfo")
+	sysDevBlockBase = filepath.Join(sysRoot, "dev", "block")
+	defer func() {
+		mountInfoPath, sysDevBlockBase = oldMountInfo, oldDevBlock
+	}()
+
+	bdf := "0000:03:00.0"
+	devDir := mkFakeDev(t, sysfsBase, bdf)
+	symlinkIOMMUGroup(t, sysfsBase, devDir, 42)
+	otherBlock := filepath.Join(sysRoot, "devices", "virtual", "block", "loop0")
+	if err := os.MkdirAll(otherBlock, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sysDevBlockBase, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(otherBlock, filepath.Join(sysDevBlockBase, "7:0")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mountInfoPath,
+		[]byte("36 25 7:0 / / rw,relatime - ext4 /dev/loop0 rw\n"+
+			"37 25 0:42 / /sys/fs/selinux rw - selinuxfs selinuxfs rw\n"+
+			"38 25 0:43 / /var/lib/nfs/rpc_pipefs rw - rpc_pipefs rpc_pipefs rw\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CheckSafeToBind(bdf); err != nil {
+		t.Fatalf("CheckSafeToBind() = %v, want unrelated device allowed", err)
+	}
+}
+
+func TestCheckSafeToBindRejectsMissingBlockMapping(t *testing.T) {
+	fakeInitialMountNamespace(t)
+	tmpDir := t.TempDir()
+	SetSysfsBase(filepath.Join(tmpDir, "sys", "bus", "pci", "devices"))
+	defer ResetSysfsBase()
+
+	oldMountInfo, oldDevBlock := mountInfoPath, sysDevBlockBase
+	mountInfoPath = filepath.Join(tmpDir, "mountinfo")
+	sysDevBlockBase = filepath.Join(tmpDir, "sys", "dev", "block")
+	defer func() {
+		mountInfoPath, sysDevBlockBase = oldMountInfo, oldDevBlock
+	}()
+
+	bdf := "0000:03:00.0"
+	devDir := mkFakeDev(t, sysfsBase, bdf)
+	symlinkIOMMUGroup(t, sysfsBase, devDir, 42)
+	if err := os.WriteFile(mountInfoPath,
+		[]byte("36 25 259:2 / / rw,relatime - ext4 /dev/nvme0n1p2 rw\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := CheckSafeToBind(bdf)
+	if err == nil || !strings.Contains(err.Error(), "259:2") {
+		t.Fatalf("CheckSafeToBind() = %v, want missing nonzero block mapping error", err)
+	}
+}
+
+func TestCheckSafeToBindTraversesVirtualPartitionParent(t *testing.T) {
+	fakeInitialMountNamespace(t)
+	tmpDir := t.TempDir()
+	sysRoot := filepath.Join(tmpDir, "sys")
+	SetSysfsBase(filepath.Join(sysRoot, "bus", "pci", "devices"))
+	defer ResetSysfsBase()
+
+	oldMountInfo, oldDevBlock := mountInfoPath, sysDevBlockBase
+	mountInfoPath = filepath.Join(tmpDir, "mountinfo")
+	sysDevBlockBase = filepath.Join(sysRoot, "dev", "block")
+	defer func() {
+		mountInfoPath, sysDevBlockBase = oldMountInfo, oldDevBlock
+	}()
+
+	bdf := "0000:03:00.0"
+	devDir := mkFakeDev(t, sysfsBase, bdf)
+	symlinkIOMMUGroup(t, sysfsBase, devDir, 42)
+	physical := filepath.Join(devDir, "nvme", "nvme0", "nvme0n1")
+	virtualDisk := filepath.Join(sysRoot, "devices", "virtual", "block", "dm-0")
+	partition := filepath.Join(virtualDisk, "dm-0p1")
+	if err := os.MkdirAll(filepath.Join(virtualDisk, "slaves"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(physical, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(partition, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(partition, "partition"), []byte("1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(physical, filepath.Join(virtualDisk, "slaves", "nvme0n1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sysDevBlockBase, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(partition, filepath.Join(sysDevBlockBase, "253:1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mountInfoPath,
+		[]byte("36 25 253:1 / / rw,relatime - ext4 /dev/dm-0p1 rw\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := CheckSafeToBind(bdf)
+	if err == nil || !strings.Contains(err.Error(), "mounted at /") {
+		t.Fatalf("CheckSafeToBind() = %v, want virtual partition rejection", err)
+	}
+}
+
+func TestCheckSafeToBindTraversesNVMeMultipath(t *testing.T) {
+	fakeInitialMountNamespace(t)
+	tmpDir := t.TempDir()
+	sysRoot := filepath.Join(tmpDir, "sys")
+	SetSysfsBase(filepath.Join(sysRoot, "bus", "pci", "devices"))
+	defer ResetSysfsBase()
+
+	oldMountInfo, oldDevBlock := mountInfoPath, sysDevBlockBase
+	mountInfoPath = filepath.Join(tmpDir, "mountinfo")
+	sysDevBlockBase = filepath.Join(sysRoot, "dev", "block")
+	defer func() {
+		mountInfoPath, sysDevBlockBase = oldMountInfo, oldDevBlock
+	}()
+
+	bdf := "0000:03:00.0"
+	devDir := mkFakeDev(t, sysfsBase, bdf)
+	symlinkIOMMUGroup(t, sysfsBase, devDir, 42)
+	pathDisk := filepath.Join(devDir, "nvme", "nvme0", "nvme0c0n1")
+	head := filepath.Join(sysRoot, "devices", "virtual", "nvme-subsystem", "nvme-subsys0", "nvme0n1")
+	if err := os.MkdirAll(filepath.Join(head, "multipath"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(pathDisk, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(pathDisk, filepath.Join(head, "multipath", "nvme0c0n1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sysDevBlockBase, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(head, filepath.Join(sysDevBlockBase, "259:0")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mountInfoPath,
+		[]byte("36 25 259:0 / / rw,relatime - ext4 /dev/nvme0n1 rw\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := CheckSafeToBind(bdf)
+	if err == nil || !strings.Contains(err.Error(), "mounted at /") {
+		t.Fatalf("CheckSafeToBind() = %v, want NVMe multipath rejection", err)
+	}
+}
+
+func TestCheckSafeToBindRejectsUnresolvedNVMeMultipath(t *testing.T) {
+	fakeInitialMountNamespace(t)
+	tmpDir := t.TempDir()
+	sysRoot := filepath.Join(tmpDir, "sys")
+	SetSysfsBase(filepath.Join(sysRoot, "bus", "pci", "devices"))
+	defer ResetSysfsBase()
+
+	oldMountInfo, oldDevBlock := mountInfoPath, sysDevBlockBase
+	mountInfoPath = filepath.Join(tmpDir, "mountinfo")
+	sysDevBlockBase = filepath.Join(sysRoot, "dev", "block")
+	defer func() {
+		mountInfoPath, sysDevBlockBase = oldMountInfo, oldDevBlock
+	}()
+
+	bdf := "0000:03:00.0"
+	devDir := mkFakeDev(t, sysfsBase, bdf)
+	symlinkIOMMUGroup(t, sysfsBase, devDir, 42)
+	head := filepath.Join(sysRoot, "devices", "virtual", "nvme-subsystem", "nvme-subsys0", "nvme0n1")
+	if err := os.MkdirAll(head, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sysDevBlockBase, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(head, filepath.Join(sysDevBlockBase, "259:0")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mountInfoPath,
+		[]byte("36 25 259:0 / / rw,relatime - ext4 /dev/nvme0n1 rw\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := CheckSafeToBind(bdf)
+	if err == nil || !strings.Contains(err.Error(), "NVMe multipath") {
+		t.Fatalf("CheckSafeToBind() = %v, want unresolved NVMe multipath error", err)
+	}
+}
+
+func TestCheckSafeToBindUsesLegacyNVMeSubsystemLinks(t *testing.T) {
+	fakeInitialMountNamespace(t)
+	tmpDir := t.TempDir()
+	sysRoot := filepath.Join(tmpDir, "sys")
+	SetSysfsBase(filepath.Join(sysRoot, "bus", "pci", "devices"))
+	defer ResetSysfsBase()
+
+	oldMountInfo, oldDevBlock := mountInfoPath, sysDevBlockBase
+	mountInfoPath = filepath.Join(tmpDir, "mountinfo")
+	sysDevBlockBase = filepath.Join(sysRoot, "dev", "block")
+	defer func() {
+		mountInfoPath, sysDevBlockBase = oldMountInfo, oldDevBlock
+	}()
+
+	bdf := "0000:03:00.0"
+	devDir := mkFakeDev(t, sysfsBase, bdf)
+	symlinkIOMMUGroup(t, sysfsBase, devDir, 42)
+	controller := filepath.Join(devDir, "nvme", "nvme0")
+	subsystem := filepath.Join(sysRoot, "devices", "virtual", "nvme-subsystem", "nvme-subsys0")
+	head := filepath.Join(subsystem, "nvme0n1")
+	if err := os.MkdirAll(controller, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(head, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(controller, filepath.Join(subsystem, "nvme0")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sysDevBlockBase, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(head, filepath.Join(sysDevBlockBase, "259:0")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mountInfoPath,
+		[]byte("36 25 259:0 / / rw,relatime - ext4 /dev/nvme0n1 rw\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := CheckSafeToBind(bdf)
+	if err == nil || !strings.Contains(err.Error(), "mounted at /") {
+		t.Fatalf("CheckSafeToBind() = %v, want legacy NVMe subsystem rejection", err)
+	}
+}
+
+func TestCheckSafeToBindRejectsMajorZeroStorage(t *testing.T) {
+	fakeInitialMountNamespace(t)
+	tmpDir := t.TempDir()
+	SetSysfsBase(filepath.Join(tmpDir, "sys", "bus", "pci", "devices"))
+	defer ResetSysfsBase()
+
+	oldMountInfo := mountInfoPath
+	mountInfoPath = filepath.Join(tmpDir, "mountinfo")
+	defer func() { mountInfoPath = oldMountInfo }()
+
+	bdf := "0000:03:00.0"
+	devDir := mkFakeDev(t, sysfsBase, bdf)
+	symlinkIOMMUGroup(t, sysfsBase, devDir, 42)
+	if err := os.WriteFile(mountInfoPath,
+		[]byte("36 25 0:32 / / rw,relatime - overlay overlay rw\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := CheckSafeToBind(bdf)
+	if err == nil || !strings.Contains(err.Error(), "major 0") {
+		t.Fatalf("CheckSafeToBind() = %v, want unverifiable major-0 root rejection", err)
+	}
+}
+
+func TestCheckInitialMountNamespace(t *testing.T) {
+	dir := t.TempDir()
+	self := filepath.Join(dir, "self")
+	init := filepath.Join(dir, "init")
+	if err := os.Symlink("mnt:[1]", self); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("mnt:[2]", init); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkInitialMountNamespace(self, init); err == nil {
+		t.Fatal("checkInitialMountNamespace() accepted a private mount namespace")
+	}
+}
+
+func TestCheckLiveEnvironment(t *testing.T) {
+	oldMountInfo, oldCmdline := mountInfoPath, procCmdlinePath
+	defer func() {
+		mountInfoPath, procCmdlinePath = oldMountInfo, oldCmdline
+	}()
+
+	for _, tc := range []struct {
+		name      string
+		mountInfo string
+		cmdline   string
+		wantLive  bool
+	}{
+		{
+			name:      "Ubuntu casper",
+			mountInfo: "36 25 0:32 / / rw - overlay overlay rw\n37 25 8:1 / /cdrom ro - iso9660 /dev/sda1 ro\n",
+			cmdline:   "quiet splash boot=casper",
+			wantLive:  true,
+		},
+		{
+			name:      "Debian live media",
+			mountInfo: "36 25 0:32 / / rw - overlay overlay rw\n37 25 8:1 / /run/live/medium ro - squashfs /dev/sda1 ro\n",
+			wantLive:  true,
+		},
+		{
+			name:      "container overlay only",
+			mountInfo: "36 25 0:32 / / rw - overlay overlay rw\n",
+		},
+		{
+			name:      "installed ext4",
+			mountInfo: "36 25 259:2 / / rw - ext4 /dev/nvme0n1p2 rw\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			mountInfoPath = filepath.Join(dir, "mountinfo")
+			procCmdlinePath = filepath.Join(dir, "cmdline")
+			if err := os.WriteFile(mountInfoPath, []byte(tc.mountInfo), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(procCmdlinePath, []byte(tc.cmdline), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			live, _, err := CheckLiveEnvironment()
+			if err != nil {
+				t.Fatalf("CheckLiveEnvironment() error = %v", err)
+			}
+			if live != tc.wantLive {
+				t.Fatalf("CheckLiveEnvironment() live = %v, want %v", live, tc.wantLive)
+			}
+		})
 	}
 }

--- a/internal/donor/vfio/namespace_linux.go
+++ b/internal/donor/vfio/namespace_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package vfio
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+const nsGetParent = 0xb702 // NS_GET_PARENT from linux/nsfs.h
+
+func checkInitialPIDNamespace() error {
+	f, err := os.Open("/proc/self/ns/pid")
+	if err != nil {
+		return fmt.Errorf("cannot verify PID namespace: %w", err)
+	}
+	defer f.Close()
+
+	parent, _, errno := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), nsGetParent, 0)
+	if errno == 0 {
+		_ = syscall.Close(int(parent))
+		return fmt.Errorf("current process is in a nested PID namespace; refusing VFIO bind against incomplete host mount data")
+	}
+	if errno != syscall.EPERM {
+		return fmt.Errorf("cannot verify PID namespace parent: %w", errno)
+	}
+	// EPERM means either the initial PID namespace has no parent or its parent
+	// is outside this process's user-namespace authority. In the latter case the
+	// process also lacks authority to write the parent namespace's host sysfs.
+	return nil
+}

--- a/internal/donor/vfio/namespace_other.go
+++ b/internal/donor/vfio/namespace_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package vfio
+
+func checkInitialPIDNamespace() error { return nil }

--- a/internal/donor/vfio/vfio.go
+++ b/internal/donor/vfio/vfio.go
@@ -266,6 +266,9 @@ func CheckVFIOModules() error {
 // BindToVFIO unbinds from the current driver and rebinds to vfio-pci.
 func BindToVFIO(bdf string) error {
 	devPath := filepath.Join(sysfsBase, bdf)
+	if err := CheckSafeToBind(bdf); err != nil {
+		return fmt.Errorf("unsafe VFIO bind: %w", err)
+	}
 
 	driverLink, err := os.Readlink(filepath.Join(devPath, "driver"))
 	if err == nil && filepath.Base(driverLink) == "vfio-pci" {
@@ -352,13 +355,18 @@ func EnableMemorySpace(bdf string) error {
 // power state bits in the PM Control/Status register and disabling
 // kernel runtime power management.
 func WakeToD0(bdf string) error {
-	// disable kernel runtime PM so it won't put the device back to sleep
+	// Disable kernel runtime PM so it cannot put the device back to sleep.
 	powerCtrl := filepath.Join(sysfsBase, bdf, "power", "control")
-	_ = os.WriteFile(powerCtrl, []byte("on"), 0200)
+	if err := os.WriteFile(powerCtrl, []byte("on"), 0200); err != nil {
+		return fmt.Errorf("cannot disable runtime power management for %s: %w", bdf, err)
+	}
 
 	ps, err := CheckPowerState(bdf)
-	if err != nil || ps == "D0" {
-		return nil // already in D0 or can't check
+	if err != nil {
+		return err
+	}
+	if ps == "D0" {
+		return nil
 	}
 
 	// find PM capability offset by walking config space cap list

--- a/internal/donor/vfio/vfio_test.go
+++ b/internal/donor/vfio/vfio_test.go
@@ -70,6 +70,68 @@ func TestBindToVFIO_InvalidDevice(t *testing.T) {
 	}
 }
 
+func TestBindToVFIORejectsMountedDeviceBeforeUnbind(t *testing.T) {
+	fakeInitialMountNamespace(t)
+	tmpDir := t.TempDir()
+	sysRoot := filepath.Join(tmpDir, "sys")
+	SetSysfsBase(filepath.Join(sysRoot, "bus", "pci", "devices"))
+	defer ResetSysfsBase()
+
+	oldMountInfo, oldDevBlock := mountInfoPath, sysDevBlockBase
+	mountInfoPath = filepath.Join(tmpDir, "mountinfo")
+	sysDevBlockBase = filepath.Join(sysRoot, "dev", "block")
+	defer func() {
+		mountInfoPath, sysDevBlockBase = oldMountInfo, oldDevBlock
+	}()
+
+	bdf := "0000:03:00.0"
+	devDir := mkFakeDev(t, sysfsBase, bdf)
+	symlinkIOMMUGroup(t, sysfsBase, devDir, 42)
+	driverDir := filepath.Join(tmpDir, "drivers", "nvme")
+	if err := os.MkdirAll(driverDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	unbindPath := filepath.Join(driverDir, "unbind")
+	if err := os.WriteFile(unbindPath, []byte("untouched"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(driverDir, filepath.Join(devDir, "driver")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devDir, "vendor"), []byte("0x144d\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devDir, "device"), []byte("0xa801\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	blockDir := filepath.Join(devDir, "nvme", "nvme0", "nvme0n1")
+	if err := os.MkdirAll(blockDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sysDevBlockBase, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(blockDir, filepath.Join(sysDevBlockBase, "259:0")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mountInfoPath,
+		[]byte("36 25 259:0 / / rw,relatime - ext4 /dev/nvme0n1 rw\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := BindToVFIO(bdf)
+	if err == nil || !containsStr(err.Error(), "mounted at /") {
+		t.Fatalf("BindToVFIO() = %v, want mounted root safety rejection", err)
+	}
+	got, err := os.ReadFile(unbindPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "untouched" {
+		t.Fatalf("driver unbind was written before safety rejection: %q", got)
+	}
+}
+
 func TestUnbindFromVFIO_InvalidDevice(t *testing.T) {
 	err := UnbindFromVFIO("9999:99:99.9")
 	if err == nil {
@@ -699,5 +761,50 @@ func TestUnbindFromVFIO_BusPathsAreConfigurable(t *testing.T) {
 	}
 	if vfioPCIDriverDir() != filepath.Join(tmp, "drivers", "vfio-pci") {
 		t.Errorf("driverPath = %q", vfioPCIDriverDir())
+	}
+}
+
+func TestWakeToD0ReportsRuntimePMControlFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	SetSysfsBase(tmpDir)
+	defer ResetSysfsBase()
+
+	bdf := "0000:03:00.0"
+	devDir := filepath.Join(tmpDir, bdf)
+	if err := os.MkdirAll(devDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devDir, "power_state"), []byte("D0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WakeToD0(bdf); err == nil || !containsStr(err.Error(), "runtime power management") {
+		t.Fatalf("WakeToD0() = %v, want runtime PM control error", err)
+	}
+}
+
+func TestWakeToD0D0WritesRuntimePMControl(t *testing.T) {
+	tmpDir := t.TempDir()
+	SetSysfsBase(tmpDir)
+	defer ResetSysfsBase()
+
+	bdf := "0000:03:00.0"
+	devDir := filepath.Join(tmpDir, bdf)
+	if err := os.MkdirAll(filepath.Join(devDir, "power"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devDir, "power_state"), []byte("D0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	control := filepath.Join(devDir, "power", "control")
+	if err := os.WriteFile(control, []byte("auto"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WakeToD0(bdf); err != nil {
+		t.Fatalf("WakeToD0() = %v", err)
+	}
+	if got, err := os.ReadFile(control); err != nil || string(got) != "on" {
+		t.Fatalf("power/control = %q, %v; want on", got, err)
 	}
 }


### PR DESCRIPTION
## Summary
- fail closed before `driver/unbind` when the donor backs any mounted filesystem
- reject IOMMU groups whose peer devices remain on native drivers
- traverse partitions, device-mapper/MD slaves, current NVMe multipath links, and legacy NVMe subsystem controller links
- reject private/nested namespaces and unverifiable storage mounts
- surface live-media and runtime-PM failures through `check`

## Why
Selecting an OS/boot controller or a donor with native-bound IOMMU peers can hard-reset the host or later fail as `VFIO_GROUP_SET_CONTAINER: invalid argument`. The existing diagnostics were advisory and were not called by the destructive bind primitive.

## Validation
- `go test ./internal/donor/vfio ./cmd/pcileechgen -count=1`
- `go test ./... -skip "^TestGenerateBarControllerSV_NVMeMSIWithoutMSIX$" -count=1`
- independent review of `origin/main..89688f9`: no P0/P1 blockers

## Baseline note
`TestGenerateBarControllerSV_NVMeMSIWithoutMSIX` is the same unrelated pre-existing upstream failure documented on PR #86.